### PR TITLE
Phase 6 — quality-of-life across UX, safety, agent loop, reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Sync (locked)
         run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
       - name: Lint
-        run: uv run ruff check riftor dev
-      - name: Tests (headless TUI + units)
+        run: uv run ruff check riftor dev tests
+      - name: Type check
+        run: uv run pyright riftor
+      - name: Unit tests (pytest)
+        run: uv run pytest
+      - name: Smoke (headless TUI integration)
         run: uv run python dev/smoke.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# riftor pre-commit hooks — run the same gates CI runs, locally on commit.
+# Install:  uv run pre-commit install   (add `pre-commit` to your env first)
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff (lint + format check)
+        entry: uv run ruff check riftor dev tests
+        language: system
+        pass_filenames: false
+        types: [python]
+      - id: pyright
+        name: pyright (type check)
+        entry: uv run pyright riftor
+        language: system
+        pass_filenames: false
+        types: [python]
+      - id: pytest
+        name: pytest (unit tests)
+        entry: uv run pytest
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,15 +19,19 @@ uv run riftor            # launch the TUI (needs an API key, e.g. ANTHROPIC_API_
 ```
 
 ## Before you open a PR
-Run the same checks CI runs:
+Run the same checks CI runs (or just `make check`):
 
 ```bash
-uv run ruff check riftor dev      # lint
-uv run python dev/smoke.py        # headless TUI + unit suites (must print all *_OK)
+uv run ruff check riftor dev tests   # lint
+uv run pyright riftor                # type check
+uv run pytest                        # unit suite (tests/)
+uv run python dev/smoke.py           # headless TUI integration (prints all *_OK)
 ```
 
-`dev/smoke.py` runs offline (no model/API key needed) — it exercises the TUI,
-tools, scope engine, engagement store, CVSS, reports, sessions, and themes.
+Everything runs **offline** — no model/API key needed. `tests/` holds focused
+unit tests (engagement, reports, permissions, config, agent, parsers, tools,
+sessions); `dev/smoke.py` drives the real TUI headlessly end-to-end. Install the
+pre-commit hooks to run these automatically: `make install-hooks`.
 
 ## Project layout
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # riftor — offensive-security AI agent TUI
-# Build:  docker build -t riftor .
-# Run:    docker run -it --rm -e ANTHROPIC_API_KEY -v "$PWD:/work" riftor
+# Build (minimal):  docker build -t riftor .
+# Build (+ tools):  docker build --build-arg INSTALL_TOOLS=1 -t riftor:full .
+# Run:              docker run -it --rm -e ANTHROPIC_API_KEY -v "$PWD:/work" riftor
 #
-# Note: this is a minimal image (no nmap/httpx/etc.). For full recon tooling,
-# run riftor on a host that has the tools, or extend this image.
+# The minimal image has no recon binaries. Pass INSTALL_TOOLS=1 (or use the
+# `full` service in docker-compose.yml) to bundle nmap/curl/dnsutils/etc.
 
 FROM python:3.12-slim AS build
 WORKDIR /src
@@ -14,6 +15,16 @@ FROM python:3.12-slim
 LABEL org.opencontainers.image.title="riftor" \
       org.opencontainers.image.source="https://github.com/Estudely/riftor" \
       org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+# Optional recon tooling. apt packages that exist in Debian slim; heavier tools
+# (httpx/nuclei/ffuf) are best layered on top or run from the host.
+ARG INSTALL_TOOLS=0
+RUN if [ "$INSTALL_TOOLS" = "1" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            nmap curl dnsutils whatweb nikto ncat ripgrep && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
 
 RUN useradd --create-home riftor
 COPY --from=build /dist/*.whl /tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# riftor — common dev tasks. Requires uv (https://docs.astral.sh/uv/).
+.PHONY: help dev run lint typecheck test smoke check build clean install-hooks
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+dev: ## Sync deps (incl. dev extras)
+	uv sync --extra dev
+
+run: ## Launch the TUI
+	uv run riftor
+
+lint: ## Lint with ruff
+	uv run ruff check riftor dev tests
+
+typecheck: ## Type-check with pyright
+	uv run pyright riftor
+
+test: ## Run the pytest suite
+	uv run pytest
+
+smoke: ## Run the headless TUI smoke suite
+	uv run python dev/smoke.py
+
+check: lint typecheck test smoke ## Run every CI gate locally
+
+build: ## Build wheel + sdist
+	uv build
+
+clean: ## Remove build/test artifacts
+	rm -rf dist build .pytest_cache .ruff_cache **/__pycache__
+
+install-hooks: ## Install pre-commit hooks
+	uv run pre-commit install

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ interface backed by [litellm](https://docs.litellm.ai/), organised around the
 It's **cloud-first** (Anthropic, OpenAI, OpenRouter, …) for the strongest agent
 behaviour, with local [Ollama](https://ollama.com/) supported as an option.
 
-> **Status:** fully featured (Phase 4–5). Streaming agent, tool use + permissions,
-> **scope guardrail**, RIFT stage tracking, per-engagement findings store, CVSS
-> reports, session resume, live themes, `import_scan`, Docker, and CI.
-> See [`todo.md`](./todo.md) for the roadmap.
+> **Status:** fully featured (Phase 4–6). Streaming agent with retry/backoff +
+> token/cost metering, **persistent granular permissions** (allow/deny rules,
+> diff preview before write/edit), **scope guardrail** (enforce / dry-run /
+> import-export), RIFT stage tracking, per-engagement findings store (edit/tag/
+> dedup), CVSS reports in **md/html/json/sarif**, crash-safe sessions, input
+> history + command palette, headless one-shot mode, Docker, pytest + types in CI.
+> See [`todo.md`](./todo.md) for the roadmap and [`docs/`](./docs) for configuration.
 
 ## Install
 ```bash
@@ -33,6 +36,10 @@ export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, etc.
 riftor                                 # launch the TUI
 riftor --config                        # show the config file path
 riftor --version
+riftor --model openai/gpt-4o           # override the model for this run
+riftor --workdir ./engagement          # set the engagement directory
+riftor --scope-file scope.txt          # preload scope targets
+riftor -p "enumerate 10.0.0.5"         # headless one-shot (also reads stdin)
 ```
 
 On first launch riftor writes a config file and picks a default model from your
@@ -86,18 +93,25 @@ lives in `.riftor/` per working directory; sessions auto-save and resume.
 |---|---|
 | `/help` | show commands |
 | `/clear` | clear the conversation (`Ctrl+L`) |
-| `/model [name]` | show or switch the model |
+| `/retry` · `/continue [N]` · `/compact` | re-run last turn · extend steps · free context |
+| `/copy` · `/show <id>` · `/cost` | copy last output · expand a result · token/cost total |
+| `/model [name]` · `/theme [name]` | switch model / theme |
 | `/stage [R\|I\|F\|T]` | show or set the RIFT stage |
-| `/scope [add\|out\|rm <t>\|clear\|on\|off]` | manage in/out-of-scope targets |
-| `/findings` | list recorded findings |
-| `/report [md\|html\|both]` | write a pentest report to `.riftor/reports/` |
+| `/scope [add\|out\|rm <t>\|clear\|on\|off\|dry\|import <f>\|export [f]]` | manage scope |
+| `/findings` · `/finding <id>` | list (severity-sorted) / show one |
+| `/edit-finding <id> sev=high tags=…` · `/delete-finding <id>` | triage findings |
+| `/hosts` · `/services` | discovered infrastructure |
+| `/report [md\|html\|json\|sarif\|both\|all]` | write a report to `.riftor/reports/` |
+| `/timeline` · `/export` | engagement activity log · archive the engagement |
+| `/permissions` · `/audit` | review allow/deny rules · recent tool-call log |
 | `/sessions` · `/resume <id>` · `/new` | manage saved sessions |
-| `/tools` | list available tools |
-| `/lore` | toggle the rift persona |
-| `/exit` | quit (`Ctrl+C`) |
+| `/config` · `/tools` · `/lore` · `/exit` | settings · tools · persona · quit |
 
+`↑/↓` recall previous prompts · `PgUp/PgDn` scroll · `Ctrl+P` command palette ·
 `Esc` cancels a running response. Dangerous tools (bash/write/edit) prompt for
-approval; every tool call is written to an audit log.
+approval (with a **diff preview**); `rm -rf`/`dd` and friends are denied by
+default; every tool call is written to an audit log. See
+[`docs/configuration.md`](./docs/configuration.md) for all settings.
 
 ## Use responsibly
 riftor is for **authorized** security testing only. You are responsible for

--- a/completions/_riftor
+++ b/completions/_riftor
@@ -1,0 +1,19 @@
+#compdef riftor
+# zsh completion for riftor
+# Install: place this file in a directory on your $fpath (e.g. ~/.zfunc) and
+# ensure `autoload -U compinit && compinit` runs in your ~/.zshrc.
+
+_riftor() {
+  _arguments \
+    '--version[print version and exit]' \
+    '--config[print the config file path and exit]' \
+    '--model[override the model for this run]:model:(anthropic/claude-sonnet-4-6 openai/gpt-4o openrouter/auto ollama_chat/llama3.1)' \
+    '--api-key[override the API key for this run]:key:' \
+    '--workdir[engagement working directory]:dir:_files -/' \
+    '--scope-file[load scope targets from a file]:file:_files' \
+    '(-p --prompt)'{-p,--prompt}'[run one task non-interactively]:prompt:' \
+    '--headless[non-interactive mode]' \
+    '(-h --help)'{-h,--help}'[show help]'
+}
+
+_riftor "$@"

--- a/completions/riftor.bash
+++ b/completions/riftor.bash
@@ -1,0 +1,22 @@
+# bash completion for riftor
+# Install: source this file, or copy to /etc/bash_completion.d/riftor
+_riftor() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="--version --config --model --api-key --workdir --scope-file --prompt --headless --help"
+
+    case "$prev" in
+        --workdir|--scope-file)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            return 0
+            ;;
+        --model)
+            COMPREPLY=( $(compgen -W "anthropic/claude-sonnet-4-6 openai/gpt-4o openrouter/auto ollama_chat/llama3.1" -- "$cur") )
+            return 0
+            ;;
+    esac
+    COMPREPLY=( $(compgen -W "${opts}" -- "$cur") )
+}
+complete -F _riftor riftor

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -119,6 +119,38 @@ async def main() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
+        # new QoL commands don't crash and do the right thing
+        app.engagement.add_finding(title="Test finding", severity="high", host="10.0.0.1")
+        for cmd in (
+            "/findings", "/hosts", "/services", "/timeline", "/permissions",
+            "/cost", "/audit", "/scope dry", "/scope on",
+        ):
+            inp.value = cmd
+            await pilot.press("enter")
+            await pilot.pause()
+
+        # fuzzy "did you mean" on a typo
+        inp.value = "/findngs"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # input history recall via ↑
+        inp.value = "first task"
+        await pilot.press("enter")
+        await pilot.pause()
+        app.action_cancel()
+        app.query_one("#prompt", Input).focus()
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.query_one("#prompt", Input).value == "first task", app.query_one("#prompt", Input).value
+        app.query_one("#prompt", Input).clear()
+
+        # /export writes an archive
+        inp.value = "/export"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert list((Path(workdir) / ".riftor" / "exports").glob("*.zip")), "export not written"
+
         # /clear empties the chat
         inp.value = "/clear"
         await pilot.press("enter")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+# riftor — two flavors:
+#   docker compose run --rm riftor        # minimal image (no recon tools)
+#   docker compose run --rm full          # batteries-included (nmap/curl/…)
+#
+# Mounts the current directory at /work so engagement state (.riftor/) persists
+# on the host. Pass your provider key through the environment.
+services:
+  riftor:
+    build:
+      context: .
+    image: riftor
+    stdin_open: true
+    tty: true
+    environment:
+      - ANTHROPIC_API_KEY
+      - OPENAI_API_KEY
+      - OPENROUTER_API_KEY
+    volumes:
+      - ./:/work
+
+  full:
+    build:
+      context: .
+      args:
+        INSTALL_TOOLS: "1"
+    image: riftor:full
+    stdin_open: true
+    tty: true
+    environment:
+      - ANTHROPIC_API_KEY
+      - OPENAI_API_KEY
+      - OPENROUTER_API_KEY
+    volumes:
+      - ./:/work

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,90 @@
+# Configuring riftor
+
+riftor reads `~/.config/riftor/config.toml` (or `$XDG_CONFIG_HOME/riftor/`). The
+file is created on first run and written with `0600` perms (it may hold an API
+key). Edit it directly, or use the in-app `/config` panel and `/model` / `/theme`
+commands — those persist your changes back to the file.
+
+## `[riftor]` fields
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `model` | string | `anthropic/claude-sonnet-4-6` | Any [litellm](https://docs.litellm.ai/) model id (`provider/name`). |
+| `api_base` | string | — | Override the API endpoint (e.g. Ollama: `http://localhost:11434`). |
+| `api_key` | string | — | Prefer the provider's env var; only set this if you must. |
+| `temperature` | float | `0.3` | Sampling temperature, `0.0`–`2.0`. Lower = more deterministic. |
+| `max_tokens` | int | `2048` | Max tokens per model response. |
+| `theme` | string | `rift` | One of `rift`, `void`, `fracture`, `singularity`. |
+| `lore` | bool | `true` | The subtle rift persona; off = strictly professional voice. |
+| `max_steps` | int | `16` | Tool-call steps per task before pausing (extend live with `/continue`). |
+| `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |
+| `result_preview_lines` | int | `25` | Lines of a tool result shown before `…/show <id>`. |
+| `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |
+
+### Example
+```toml
+[riftor]
+model = "anthropic/claude-sonnet-4-6"
+temperature = 0.3
+max_tokens = 2048
+theme = "rift"
+lore = true
+max_steps = 16
+rate_limit_per_min = 0
+
+# Local Ollama instead:
+# model = "ollama_chat/llama3.1"
+# api_base = "http://localhost:11434"
+```
+
+## API keys
+
+riftor is cloud-first. Set one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
+`OPENROUTER_API_KEY` in your shell — the first one found picks the default model
+on first launch. If none is set and an Ollama server is running, riftor uses
+that. With no key at all, riftor still launches and tells you what to set; add a
+key with `/config` or `export …` and switch with `/model`.
+
+## Permissions — `~/.config/riftor/permissions.toml`
+
+Trust choices persist here. `allow` rules auto-approve a tool (optionally only
+when the call matches a regex `pattern`); `deny` rules hard-block it without ever
+prompting. Destructive `bash` patterns (`rm -rf`, `dd of=/dev/…`, `mkfs`, fork
+bombs) are denied by default.
+
+```toml
+[permissions]
+allow = [
+  { tool = "read" },
+  { tool = "bash", pattern = '^nmap\b' },   # auto-approve nmap, prompt for the rest
+]
+deny = [
+  { tool = "bash", pattern = 'shutdown|reboot' },
+]
+```
+
+Manage rules live with `/permissions allow <tool> [pattern]` and
+`/permissions deny <tool> [pattern]`, or pick **Always (w)** / **Never (d)** in
+an approval prompt. In headless mode (`--prompt`), approval-gated tools only run
+if a standing `allow` rule exists.
+
+## Keybindings — `~/.config/riftor/keybindings.toml`
+
+Override the built-in hotkeys (`action = key`):
+
+```toml
+[keybindings]
+clear = "ctrl+k"      # rebind the clear action
+quit  = "ctrl+q"
+```
+
+## Troubleshooting
+
+- **`authentication failed`** — the key for your model's provider is missing or
+  wrong. Check the right env var (e.g. `ANTHROPIC_API_KEY`) or set `api_key`.
+- **`context ~NN% of window`** — the conversation is large. Run `/compact` to
+  shrink old tool output, or `/clear` to start fresh.
+- **`model '…' has no known provider prefix`** — the id is likely a typo; use a
+  `provider/name` form litellm recognises.
+- **A scan is blocked as out-of-scope** — add the target with `/scope add`, or
+  preview without blocking via `/scope dry`.

--- a/docs/riftor.1
+++ b/docs/riftor.1
@@ -1,0 +1,62 @@
+.TH RIFTOR 1 "2026" "riftor" "User Commands"
+.SH NAME
+riftor \- offensive-security AI agent that lives in your terminal
+.SH SYNOPSIS
+.B riftor
+[\fIOPTIONS\fR]
+.SH DESCRIPTION
+.B riftor
+is a full-screen terminal (TUI) penetration-testing assistant organised around
+the RIFT methodology: Recon, Intrusion, Foothold, Takeover. The agent runs
+recon/scanning tools through a permission-gated shell, enforces an engagement
+scope, records services and findings, and writes CVSS-scored reports.
+.SH OPTIONS
+.TP
+.B \-\-version
+Print the version and exit.
+.TP
+.B \-\-config
+Print the path of the config file and exit.
+.TP
+.B \-\-model \fIMODEL\fR
+Override the model for this run (any litellm id, e.g. anthropic/claude-sonnet-4-6).
+.TP
+.B \-\-api\-key \fIKEY\fR
+Override the API key for this run (prefer the provider's environment variable).
+.TP
+.B \-\-workdir \fIDIR\fR
+Engagement working directory; state lives in \fIDIR\fR/.riftor/ (default: cwd).
+.TP
+.B \-\-scope\-file \fIFILE\fR
+Preload scope targets from a file (one per line; \fBout:\fR prefix for out-of-scope).
+.TP
+.B \-p, \-\-prompt \fITEXT\fR
+Run a single task non-interactively and exit (headless one-shot).
+.TP
+.B \-\-headless
+Non-interactive mode; reads the prompt from \fB\-\-prompt\fR or stdin.
+.SH IN-APP COMMANDS
+Type \fB/help\fR inside riftor for the full list, including \fB/scope\fR,
+\fB/stage\fR, \fB/findings\fR, \fB/report\fR, \fB/permissions\fR, \fB/cost\fR,
+\fB/retry\fR, \fB/continue\fR, \fB/compact\fR, \fB/timeline\fR and \fB/export\fR.
+.SH FILES
+.TP
+.I ~/.config/riftor/config.toml
+Runtime configuration (model, theme, limits). Written 0600.
+.TP
+.I ~/.config/riftor/permissions.toml
+Persistent tool allow/deny rules.
+.TP
+.I ./.riftor/
+Per-engagement state: sqlite store, sessions, reports, exports.
+.SH ENVIRONMENT
+.TP
+.B ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY
+Provider keys; the first one found selects the default model on first run.
+.SH AUTHORIZATION
+riftor is for authorized security testing only. You are responsible for having
+explicit, written permission for any system you assess.
+.SH SEE ALSO
+Project: https://github.com/Estudely/riftor
+.SH LICENSE
+GPL-3.0-or-later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.0.4"
+version = "0.0.5"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -26,6 +26,9 @@ dependencies = [
 dev = [
     "textual-dev>=1.5",
     "ruff>=0.6",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pyright>=1.1.380",
 ]
 
 [project.urls]
@@ -45,3 +48,19 @@ packages = ["riftor"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-q"
+
+[tool.pyright]
+include = ["riftor"]
+exclude = ["**/__pycache__", "dist", ".venv"]
+pythonVersion = "3.11"
+# Pragmatic: report obvious errors without drowning in strict-mode noise.
+typeCheckingMode = "basic"
+reportMissingImports = true
+reportAttributeAccessIssue = "warning"
+reportOptionalMemberAccess = "warning"
+reportArgumentType = "warning"

--- a/riftor/__init__.py
+++ b/riftor/__init__.py
@@ -3,4 +3,4 @@
 Find the rift. Open it. Cross through.
 """
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/riftor/__main__.py
+++ b/riftor/__main__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
 
 from riftor import __version__
 
@@ -16,6 +18,18 @@ def main() -> None:
     parser.add_argument(
         "--config", action="store_true", help="print the config file path and exit"
     )
+    parser.add_argument("--model", help="override the model for this run")
+    parser.add_argument("--api-key", dest="api_key", help="override the API key for this run")
+    parser.add_argument("--workdir", help="engagement working directory (default: cwd)")
+    parser.add_argument("--scope-file", dest="scope_file", help="load scope targets from a file")
+    parser.add_argument(
+        "-p", "--prompt",
+        help="run a single task non-interactively and exit (headless one-shot)",
+    )
+    parser.add_argument(
+        "--headless", action="store_true",
+        help="non-interactive mode; implied by --prompt. Prints the result and exits.",
+    )
     args = parser.parse_args()
 
     from riftor.config import CONFIG_PATH, Config
@@ -25,10 +39,52 @@ def main() -> None:
         return
 
     cfg = Config.load()
+    if args.model:
+        cfg.model = args.model
+    if args.api_key:
+        cfg.api_key = args.api_key
+
+    workdir = Path(args.workdir).expanduser() if args.workdir else Path.cwd()
+
+    if args.prompt or args.headless:
+        from riftor.headless import run_headless
+
+        code = run_headless(cfg, workdir, prompt=args.prompt, scope_file=args.scope_file)
+        sys.exit(code)
+
+    # Graceful first-run: if no credentials are configured, guide the operator.
+    if not cfg.has_credentials() and not cfg.onboarded:
+        _print_onboarding(cfg)
 
     from riftor.tui.app import RiftorApp
 
-    RiftorApp(cfg).run()
+    app = RiftorApp(cfg, workdir=workdir)
+    if args.scope_file:
+        _preload_scope(app, args.scope_file)
+    app.run()
+
+
+def _print_onboarding(cfg) -> None:
+    env = cfg.provider_env() or "ANTHROPIC_API_KEY"
+    print("riftor: no API key detected for the configured model.")
+    print(f"  model:    {cfg.model}")
+    print(f"  set one:  export {env}=...   (or run a local Ollama server)")
+    print("  then:     riftor   ·   change the model with /model or /config")
+    print("Launching anyway — set a key, or use /config inside the app.\n")
+    cfg.onboarded = True
+    try:
+        cfg.save()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _preload_scope(app, scope_file: str) -> None:
+    try:
+        text = Path(scope_file).expanduser().read_text(encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        print(f"riftor: could not read scope file {scope_file}: {exc}", file=sys.stderr)
+        return
+    app.engagement.import_scope(text)
 
 
 if __name__ == "__main__":

--- a/riftor/agent/context.py
+++ b/riftor/agent/context.py
@@ -1,7 +1,9 @@
-"""Conversation context: system prompt + message history.
+"""Conversation context: system prompt + message history + compaction.
 
-Phase 1 keeps the whole history in memory. Compaction / persistence arrive in
-later phases.
+History is kept in memory and persisted by the session layer. When it grows
+large we can compact it: tool results are the bulk of the tokens, so the cheap,
+lossless-enough strategy is to shrink old tool results while keeping the recent
+turns intact.
 """
 
 from __future__ import annotations
@@ -15,11 +17,22 @@ LORE_PREAMBLE = (
     "accurate, actionable work."
 )
 
+# Rough chars-per-token; good enough for a status-bar gauge without tiktoken.
+_CHARS_PER_TOKEN = 4
+
 
 def _load_system_prompt() -> str:
     return (
         resources.files("riftor.agent").joinpath("prompts/system.md").read_text(encoding="utf-8")
     )
+
+
+def _content_len(msg: dict) -> int:
+    content = msg.get("content")
+    total = len(content) if isinstance(content, str) else 0
+    for call in msg.get("tool_calls") or []:
+        total += len(str(call.get("function", {}).get("arguments", "")))
+    return total
 
 
 class Context:
@@ -50,6 +63,39 @@ class Context:
         self._messages.append(
             {"role": "tool", "tool_call_id": tool_call_id, "content": content}
         )
+
+    # -- token accounting -------------------------------------------------------
+    def estimated_tokens(self) -> int:
+        chars = len(self.system_prompt)
+        for msg in self._messages:
+            chars += _content_len(msg)
+        return chars // _CHARS_PER_TOKEN
+
+    def pop_last_user_turn(self) -> str | None:
+        """Remove everything back through (and including) the last user message.
+
+        Returns that user message's text, so the caller can resend/edit it.
+        """
+        for i in range(len(self._messages) - 1, -1, -1):
+            if self._messages[i].get("role") == "user":
+                text = self._messages[i].get("content")
+                del self._messages[i:]
+                return text if isinstance(text, str) else ""
+        return None
+
+    def compact(self, keep_recent: int = 8, clip: int = 400) -> int:
+        """Shrink old tool results to ``clip`` chars, keeping the last ``keep_recent``
+        messages untouched. Returns the number of messages compacted."""
+        cutoff = max(0, len(self._messages) - keep_recent)
+        changed = 0
+        for msg in self._messages[:cutoff]:
+            if msg.get("role") == "tool":
+                content = msg.get("content")
+                if isinstance(content, str) and len(content) > clip:
+                    dropped = len(content) - clip
+                    msg["content"] = content[:clip] + f"\n…[compacted {dropped} chars]"
+                    changed += 1
+        return changed
 
     def repair(self) -> int:
         """Ensure every assistant tool_call has a following tool result.

--- a/riftor/agent/prompts/system.md
+++ b/riftor/agent/prompts/system.md
@@ -34,10 +34,17 @@ Act through tools — don't just describe, do it. Shell tools run real binaries
 - `write`, `edit` — create/modify files (scripts, PoCs, notes). Approval-gated.
 - `set_stage` — set the current RIFT stage.
 - `import_scan` — parse raw `nmap`/`httpx`/`nuclei` output and bulk-record the
-  services/findings. Prefer this over recording each result by hand.
+  services/findings. Prefer this over recording each result by hand. Duplicates
+  are skipped automatically; re-importing the same scan is safe.
 - `record_service` — log a single discovered host/port/service.
+- `list_hosts` — review hosts/services already discovered.
 - `record_finding` — log a vulnerability (title, severity, host, evidence,
   remediation). Pass a `cvss_vector` when you can — severity is derived from it.
+  Optional `tags` (e.g. `false-positive`, `needs-validation`) and `notes`.
+  Duplicate findings (same title/host/severity/evidence) are skipped.
+- `edit_finding` / `delete_finding` — correct a finding (wrong severity, add
+  tags/notes) or remove a duplicate/false positive, by its id.
+- `generate_report` — write the report (md/html/json/sarif/all).
 
 ## How you work
 - Start with `scope_list`. Operate **only** on in-scope targets. If something you

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -2,11 +2,14 @@
 
 ``stream`` is plain text streaming. ``stream_turn`` is the tool-aware agent
 turn: it streams text deltas *and* accumulates any tool calls, yielding a final
-assembled :class:`Turn`.
+assembled :class:`Turn`. Transient provider errors (rate limit, network, 5xx)
+are retried with exponential backoff; the final error is classified into an
+actionable message.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from dataclasses import dataclass, field
@@ -33,23 +36,98 @@ class ToolCall:
 
 
 @dataclass
+class Usage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    def add(self, other: "Usage") -> None:
+        self.prompt_tokens += other.prompt_tokens
+        self.completion_tokens += other.completion_tokens
+        self.cost += other.cost
+
+
+@dataclass
 class Turn:
     """The result of one assistant turn."""
 
     text: str
     tool_calls: list[ToolCall] = field(default_factory=list)
     assistant_message: dict = field(default_factory=dict)
+    usage: Usage = field(default_factory=Usage)
+
+
+class ProviderError(Exception):
+    """A classified, operator-facing provider failure."""
+
+    def __init__(self, kind: str, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.retryable = retryable
+
+
+def classify_error(exc: Exception) -> ProviderError:
+    """Map a raw litellm/network exception to an actionable ProviderError."""
+    name = type(exc).__name__
+    text = str(exc)
+    low = text.lower()
+    if "authentication" in name.lower() or "auth" in low or "api key" in low or "401" in text:
+        return ProviderError(
+            "auth",
+            "authentication failed — check your API key (env var or /config). " + text[:200],
+            retryable=False,
+        )
+    if "ratelimit" in name.lower() or "rate limit" in low or "429" in text:
+        return ProviderError("rate_limit", "rate limited by the provider — backing off. " + text[:160],
+                             retryable=True)
+    if "timeout" in name.lower() or "timed out" in low:
+        return ProviderError("timeout", "request timed out. " + text[:160], retryable=True)
+    if any(code in text for code in ("500", "502", "503", "504", "529")) or "overloaded" in low:
+        return ProviderError("server", "provider server error — retrying. " + text[:160], retryable=True)
+    if "connection" in low or "network" in low or "getaddrinfo" in low:
+        return ProviderError("network", "network error reaching the provider. " + text[:160],
+                             retryable=True)
+    if "context" in low and ("length" in low or "window" in low or "maximum" in low or "token" in low):
+        return ProviderError(
+            "context",
+            "context window exceeded — clear/compact the conversation (/clear or /compact). " + text[:160],
+            retryable=False,
+        )
+    if "badrequest" in name.lower() or "invalid" in low or "400" in text:
+        return ProviderError("validation", "request rejected by the provider. " + text[:200],
+                             retryable=False)
+    return ProviderError("unknown", text[:240] or name, retryable=False)
+
+
+def _extract_usage(chunk) -> Usage | None:
+    raw = getattr(chunk, "usage", None)
+    if raw is None:
+        return None
+    u = Usage(
+        prompt_tokens=int(getattr(raw, "prompt_tokens", 0) or 0),
+        completion_tokens=int(getattr(raw, "completion_tokens", 0) or 0),
+    )
+    cost = getattr(raw, "cost", None)
+    if cost:
+        u.cost = float(cost)
+    return u
 
 
 class Provider:
     def __init__(self, config: "Config") -> None:
         self.config = config
+        self.max_retries = 4
 
     def _kwargs(self, messages: list[dict], tools: list[dict] | None = None) -> dict:
         kwargs: dict = {
             "model": self.config.model,
             "messages": messages,
             "stream": True,
+            "stream_options": {"include_usage": True},
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
         }
@@ -62,10 +140,26 @@ class Provider:
             kwargs["api_key"] = self.config.api_key
         return kwargs
 
+    async def _acompletion(self, **kwargs):
+        """litellm.acompletion with classified retry/backoff for transient errors."""
+        last: ProviderError | None = None
+        for attempt in range(self.max_retries):
+            try:
+                return await litellm.acompletion(**kwargs)
+            except Exception as exc:  # noqa: BLE001
+                err = classify_error(exc)
+                last = err
+                if not err.retryable or attempt == self.max_retries - 1:
+                    raise err from exc
+                # exponential backoff with deterministic jitter (no RNG dependency)
+                delay = min(2.0 ** attempt, 8.0) + (attempt * 0.13)
+                await asyncio.sleep(delay)
+        raise last or ProviderError("unknown", "completion failed")
+
     async def stream(self, messages: list[dict]) -> AsyncIterator[str]:
         """Yield content deltas from the model as they arrive (no tools)."""
-        response = await litellm.acompletion(**self._kwargs(messages))
-        async for chunk in response:
+        response = await self._acompletion(**self._kwargs(messages))
+        async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
             try:
                 content = chunk.choices[0].delta.content
             except (IndexError, AttributeError):
@@ -77,11 +171,15 @@ class Provider:
         self, messages: list[dict], tools: list[dict] | None = None
     ) -> AsyncIterator[tuple[str, object]]:
         """Yield ``("text", str)`` deltas, then a final ``("done", Turn)``."""
-        response = await litellm.acompletion(**self._kwargs(messages, tools))
+        response = await self._acompletion(**self._kwargs(messages, tools))
         text_parts: list[str] = []
         acc: dict[int, dict] = {}
+        usage = Usage()
 
-        async for chunk in response:
+        async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
+            seen = _extract_usage(chunk)
+            if seen is not None:
+                usage = seen
             try:
                 delta = chunk.choices[0].delta
             except (IndexError, AttributeError):
@@ -132,4 +230,12 @@ class Provider:
         if raw_tool_calls:
             assistant_message["tool_calls"] = raw_tool_calls
 
-        yield ("done", Turn(text=text, tool_calls=tool_calls, assistant_message=assistant_message))
+        yield (
+            "done",
+            Turn(
+                text=text,
+                tool_calls=tool_calls,
+                assistant_message=assistant_message,
+                usage=usage,
+            ),
+        )

--- a/riftor/agent/session.py
+++ b/riftor/agent/session.py
@@ -31,7 +31,16 @@ def new_id() -> str:
     return time.strftime("%Y%m%d-%H%M%S")
 
 
-def save(workdir: Path, session_id: str, messages: list[dict], model: str) -> Path:
+def save(
+    workdir: Path,
+    session_id: str,
+    messages: list[dict],
+    model: str,
+    *,
+    complete: bool = True,
+) -> Path:
+    """Persist a session atomically. ``complete=False`` marks a mid-run checkpoint
+    so a crash mid-turn can be detected and offered for resume on next launch."""
     path = sessions_dir(workdir) / f"{session_id}.json"
     created = time.time()
     if path.exists():
@@ -44,10 +53,14 @@ def save(workdir: Path, session_id: str, messages: list[dict], model: str) -> Pa
         "created": created,
         "updated": time.time(),
         "model": model,
+        "complete": complete,
         "title": _title(messages),
         "messages": messages,
     }
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    # atomic write: tmp + replace, so a crash never leaves a half-written file
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(path)
     return path
 
 
@@ -75,6 +88,7 @@ def list_sessions(workdir: Path) -> list[dict]:
                 "title": data.get("title", ""),
                 "updated": data.get("updated", 0),
                 "model": data.get("model", ""),
+                "complete": data.get("complete", True),
                 "messages": len(data.get("messages", [])),
             }
         )

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -14,7 +14,7 @@ import tomllib
 import urllib.request
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 def _config_dir() -> Path:
@@ -25,7 +25,28 @@ def _config_dir() -> Path:
 
 CONFIG_DIR = _config_dir()
 CONFIG_PATH = CONFIG_DIR / "config.toml"
+PERMISSIONS_PATH = CONFIG_DIR / "permissions.toml"
+KEYBINDINGS_PATH = CONFIG_DIR / "keybindings.toml"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
+
+# Provider prefixes litellm understands; used for a soft model-id sanity check.
+_KNOWN_PROVIDERS = (
+    "anthropic/", "openai/", "openrouter/", "ollama/", "ollama_chat/", "gemini/",
+    "groq/", "mistral/", "cohere/", "azure/", "bedrock/", "vertex_ai/", "together_ai/",
+    "deepseek/", "xai/", "perplexity/", "fireworks_ai/", "huggingface/", "replicate/",
+)
+
+# Env var per provider, for first-run key detection / graceful onboarding.
+_PROVIDER_ENV = {
+    "anthropic/": "ANTHROPIC_API_KEY",
+    "openai/": "OPENAI_API_KEY",
+    "openrouter/": "OPENROUTER_API_KEY",
+    "gemini/": "GEMINI_API_KEY",
+    "groq/": "GROQ_API_KEY",
+    "mistral/": "MISTRAL_API_KEY",
+    "deepseek/": "DEEPSEEK_API_KEY",
+    "xai/": "XAI_API_KEY",
+}
 
 
 class Config(BaseModel):
@@ -38,6 +59,51 @@ class Config(BaseModel):
     max_tokens: int = 2048
     theme: str = "rift"
     lore: bool = True
+    # Agent-loop tuning
+    max_steps: int = 16
+    max_result_chars: int = 30_000
+    result_preview_lines: int = 25
+    # Politeness / safety toward targets and APIs
+    rate_limit_per_min: int = 0  # 0 = unlimited
+    # Tracks whether we've shown the first-run onboarding.
+    onboarded: bool = False
+
+    @field_validator("model")
+    @classmethod
+    def _check_model(cls, value: str) -> str:
+        value = (value or "").strip()
+        if value and "/" not in value:
+            # Bare ids (e.g. "gpt-4o") still work for some providers; just warn-shape.
+            return value
+        return value
+
+    def model_warning(self) -> str | None:
+        """A human hint if the model id looks unusual (not a hard error)."""
+        if self.model and not any(self.model.startswith(p) for p in _KNOWN_PROVIDERS):
+            return (
+                f"model '{self.model}' has no known provider prefix; "
+                f"expected e.g. {', '.join(p.rstrip('/') for p in _KNOWN_PROVIDERS[:4])}…"
+            )
+        return None
+
+    def provider_env(self) -> str | None:
+        """The env var name expected for this model's provider, if known."""
+        for prefix, env in _PROVIDER_ENV.items():
+            if self.model.startswith(prefix):
+                return env
+        return None
+
+    def has_credentials(self) -> bool:
+        """True if a key is configured (explicit, env, or local Ollama)."""
+        if self.api_key:
+            return True
+        if self.model.startswith(("ollama/", "ollama_chat/")):
+            return True
+        env = self.provider_env()
+        if env and os.environ.get(env):
+            return True
+        # Unknown provider: don't block; litellm may resolve it from its own env.
+        return self.provider_env() is None
 
     @classmethod
     def load(cls) -> "Config":
@@ -67,7 +133,16 @@ class Config(BaseModel):
 
     def save(self) -> None:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        CONFIG_PATH.write_text(self._to_toml(), encoding="utf-8")
+        # Write with owner-only perms — the file may hold an API key.
+        fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, self._to_toml().encode("utf-8"))
+        finally:
+            os.close(fd)
+        try:
+            os.chmod(CONFIG_PATH, 0o600)
+        except OSError:
+            pass
 
     def _to_toml(self) -> str:
         lines = [
@@ -90,8 +165,29 @@ class Config(BaseModel):
             f"max_tokens = {self.max_tokens}",
             f'theme = "{self.theme}"',
             f"lore = {str(self.lore).lower()}",
+            f"max_steps = {self.max_steps}",
+            f"max_result_chars = {self.max_result_chars}",
+            f"result_preview_lines = {self.result_preview_lines}",
+            f"rate_limit_per_min = {self.rate_limit_per_min}",
+            f"onboarded = {str(self.onboarded).lower()}",
         ]
         return "\n".join(lines) + "\n"
+
+
+def load_keybindings() -> dict[str, str]:
+    """Operator key overrides from ``keybindings.toml`` ([keybindings] action=key).
+
+    Returns ``{action: key}``; empty if the file is missing or malformed.
+    """
+    if not KEYBINDINGS_PATH.exists():
+        return {}
+    try:
+        with KEYBINDINGS_PATH.open("rb") as fh:
+            data = tomllib.load(fh)
+    except Exception:  # noqa: BLE001 — bad config must never crash the app
+        return {}
+    section = data.get("keybindings", data)
+    return {str(k): str(v) for k, v in section.items() if isinstance(v, str)}
 
 
 def _ollama_models() -> list[str]:

--- a/riftor/engagement/__init__.py
+++ b/riftor/engagement/__init__.py
@@ -8,6 +8,7 @@ from riftor.engagement.scope import Scope, Target
 from riftor.engagement.state import Store
 
 VALID_STAGES = ("R", "I", "F", "T")
+STAGE_LABELS = {"R": "Recon", "I": "Intrusion", "F": "Foothold", "T": "Takeover"}
 
 
 class Engagement:
@@ -19,6 +20,8 @@ class Engagement:
         self.store = Store(self.dir / "engagement.db")
         self.scope = Scope()
         self.enforce = self.store.get_meta("enforce", "1") == "1"
+        # dry-run: warn on violations but don't block. Off by default.
+        self.dry_run = self.store.get_meta("scope_dry_run", "0") == "1"
         self.stage = self.store.get_meta("stage", "R") or "R"
         for target, mode in self.store.list_scope():
             self.scope.add(target, mode)
@@ -27,20 +30,29 @@ class Engagement:
     def add_scope(self, raw: str, mode: str = "in") -> Target:
         target = self.scope.add(raw, mode)
         self.store.add_scope(target.raw, mode)
+        self.store.log_activity("scope_add", f"{mode}: {target.raw}")
         return target
 
     def remove_scope(self, raw: str) -> bool:
         ok = self.scope.remove(raw)
         self.store.remove_scope(Target.parse(raw).raw)
+        self.store.log_activity("scope_remove", raw)
         return ok
 
     def clear_scope(self) -> None:
         self.scope.clear()
         self.store.clear_scope()
+        self.store.log_activity("scope_clear", "")
 
     def set_enforce(self, on: bool) -> None:
         self.enforce = on
         self.store.set_meta("enforce", "1" if on else "0")
+        self.store.log_activity("scope_enforce", "on" if on else "off")
+
+    def set_dry_run(self, on: bool) -> None:
+        self.dry_run = on
+        self.store.set_meta("scope_dry_run", "1" if on else "0")
+        self.store.log_activity("scope_dry_run", "on" if on else "off")
 
     def violations(self, text: str) -> list[str]:
         if not self.enforce:
@@ -50,25 +62,96 @@ class Engagement:
     def scope_count(self) -> int:
         return len(self.scope.in_scope)
 
+    def export_scope(self) -> str:
+        """One target per line, ``out:`` prefix for out-of-scope entries."""
+        lines = [t.raw for t in self.scope.in_scope]
+        lines += [f"out:{t.raw}" for t in self.scope.out_of_scope]
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def import_scope(self, text: str) -> tuple[int, int]:
+        """Load targets from text (one per line; ``#`` comments; ``out:`` prefix).
+
+        Returns (in_count, out_count) added.
+        """
+        added_in = added_out = 0
+        for raw in (text or "").splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            mode = "in"
+            if line.lower().startswith("out:"):
+                mode, line = "out", line[4:].strip()
+            elif line.lower().startswith("in:"):
+                line = line[3:].strip()
+            if not line:
+                continue
+            self.add_scope(line, mode)
+            if mode == "in":
+                added_in += 1
+            else:
+                added_out += 1
+        return added_in, added_out
+
     # -- stage ------------------------------------------------------------------
     def set_stage(self, letter: str) -> bool:
         letter = (letter or "").strip().upper()[:1]
         if letter in VALID_STAGES:
+            prev = self.stage
             self.stage = letter
             self.store.set_meta("stage", letter)
+            if prev != letter:
+                self.store.log_activity("stage", f"{prev}->{letter}")
             return True
         return False
 
     # -- findings / services ----------------------------------------------------
     def add_finding(self, **kwargs) -> int:
         kwargs.setdefault("stage", self.stage)
-        return self.store.add_finding(**kwargs)
+        fid = self.store.add_finding(**kwargs)
+        self.store.log_activity(
+            "finding_add", f"#{fid} [{kwargs.get('severity', '?')}] {kwargs.get('title', '')}"
+        )
+        return fid
+
+    def add_finding_dedup(self, *, dedup: str = "skip", **kwargs) -> tuple[int, str]:
+        """Add a finding honoring a dedup policy. Returns (id, action).
+
+        ``dedup``: ``skip`` (default, ignore duplicates), ``merge`` (update the
+        existing row's evidence/recommendation), or ``allow-all`` (always insert).
+        ``action`` is one of "added", "skipped", "merged".
+        """
+        if dedup == "allow-all":
+            return self.add_finding(**kwargs), "added"
+        existing = self.store.find_finding_id(
+            kwargs.get("title", ""),
+            kwargs.get("host", ""),
+            kwargs.get("severity", ""),
+            kwargs.get("evidence", ""),
+        )
+        if existing is None:
+            return self.add_finding(**kwargs), "added"
+        if dedup == "merge":
+            self.store.update_finding(
+                existing,
+                evidence=kwargs.get("evidence") or None,
+                recommendation=kwargs.get("recommendation") or None,
+            )
+            self.store.log_activity("finding_merge", f"#{existing}")
+            return existing, "merged"
+        return existing, "skipped"
 
     def add_service(self, **kwargs) -> int:
         return self.store.add_service(**kwargs)
+
+    def add_service_dedup(self, *, dedup: str = "skip", **kwargs) -> tuple[int | None, str]:
+        if dedup != "allow-all" and self.store.service_exists(
+            kwargs.get("host", ""), kwargs.get("port"), kwargs.get("proto", "tcp")
+        ):
+            return None, "skipped"
+        return self.store.add_service(**kwargs), "added"
 
     def findings_count(self) -> int:
         return self.store.count_findings()
 
 
-__all__ = ["Engagement", "Scope", "Target", "Store", "VALID_STAGES"]
+__all__ = ["Engagement", "Scope", "Target", "Store", "VALID_STAGES", "STAGE_LABELS"]

--- a/riftor/engagement/parsers.py
+++ b/riftor/engagement/parsers.py
@@ -24,6 +24,10 @@ _SEVERITIES = {"info", "low", "medium", "high", "critical"}
 class ParsedScan:
     services: list[dict] = field(default_factory=list)
     findings: list[dict] = field(default_factory=list)
+    #: non-empty lines the parser could not turn into a service/finding
+    skipped: int = 0
+    #: lines that looked like JSON but failed to decode
+    json_errors: int = 0
 
 
 def _sev(value: str) -> str:
@@ -108,10 +112,13 @@ def parse_httpx(text: str) -> ParsedScan:
             try:
                 data = json.loads(line)
             except json.JSONDecodeError:
+                scan.json_errors += 1
+                scan.skipped += 1
                 continue
             url = data.get("url") or data.get("input") or ""
             host, port = _host_port(url)
             if not host:
+                scan.skipped += 1
                 continue
             tech = data.get("webserver") or data.get("tech") or ""
             if isinstance(tech, list):
@@ -132,10 +139,12 @@ def parse_httpx(text: str) -> ParsedScan:
 
         parts = line.split()
         if not parts or "://" not in parts[0]:
+            scan.skipped += 1
             continue
         url = parts[0]
         host, port = _host_port(url)
         if not host:
+            scan.skipped += 1
             continue
         brackets = re.findall(r"\[([^\]]*)\]", line)
         status = brackets[0] if brackets else ""
@@ -165,6 +174,8 @@ def parse_nuclei(text: str) -> ParsedScan:
             try:
                 data = json.loads(line)
             except json.JSONDecodeError:
+                scan.json_errors += 1
+                scan.skipped += 1
                 continue
             info = data.get("info", {}) if isinstance(data.get("info"), dict) else {}
             template = data.get("template-id") or data.get("templateID") or info.get("name", "finding")
@@ -181,6 +192,7 @@ def parse_nuclei(text: str) -> ParsedScan:
 
         brackets = re.findall(r"\[([^\]]*)\]", line)
         if len(brackets) < 3:
+            scan.skipped += 1
             continue
         template = brackets[0]
         severity = brackets[2]

--- a/riftor/engagement/report.py
+++ b/riftor/engagement/report.py
@@ -1,8 +1,9 @@
-"""Render the engagement into a pentest report (markdown + self-contained HTML)."""
+"""Render the engagement into a pentest report (markdown, HTML, JSON, SARIF)."""
 
 from __future__ import annotations
 
 import html
+import json
 import time
 from pathlib import Path
 
@@ -11,6 +12,12 @@ from riftor.engagement.cvss import base_score
 _SEV_RANK = {"critical": 5, "high": 4, "medium": 3, "low": 2, "info": 1}
 _SEV_ORDER = ["critical", "high", "medium", "low", "info"]
 _STAGE_NAMES = {"R": "Recon", "I": "Intrusion", "F": "Foothold", "T": "Takeover"}
+# SARIF maps severity onto its small enum; "warning" covers the middle band.
+_SARIF_LEVEL = {
+    "critical": "error", "high": "error", "medium": "warning",
+    "low": "note", "info": "note",
+}
+_FORMATS = ("md", "html", "json", "sarif", "both", "all")
 
 
 def report_data(engagement) -> dict:
@@ -39,10 +46,47 @@ def report_data(engagement) -> dict:
         "scope_in": [t.raw for t in engagement.scope.in_scope],
         "scope_out": [t.raw for t in engagement.scope.out_of_scope],
         "counts": counts,
+        "exec_summary": _exec_summary(counts, findings),
         "findings": findings,
         "services": store.list_services(),
         "hosts": store.list_hosts(),
     }
+
+
+def _exec_summary(counts: dict, findings: list[dict]) -> str:
+    """A short, auto-generated business-impact paragraph for stakeholders."""
+    total = len(findings)
+    if not total:
+        return "No findings were recorded during this engagement."
+    crit, high = counts.get("critical", 0), counts.get("high", 0)
+    med, low = counts.get("medium", 0), counts.get("low", 0)
+    if crit:
+        risk = "critical"
+        lede = (
+            f"This engagement uncovered {crit} critical "
+            f"{'issue' if crit == 1 else 'issues'} requiring immediate remediation."
+        )
+    elif high:
+        risk = "high"
+        lede = f"This engagement uncovered {high} high-severity {'issue' if high == 1 else 'issues'}."
+    elif med:
+        risk = "medium"
+        lede = "This engagement surfaced moderate-risk issues worth scheduled remediation."
+    else:
+        risk = "low"
+        lede = "This engagement surfaced only low-risk or informational items."
+    top = findings[0]["title"] if findings else ""
+    parts = [
+        lede,
+        f"Overall risk is assessed as **{risk}** across {total} "
+        f"total {'finding' if total == 1 else 'findings'} "
+        f"({crit} critical, {high} high, {med} medium, {low} low).",
+    ]
+    if crit or high:
+        parts.append(
+            f"Prioritise the highest-severity items first — beginning with “{top}”."
+        )
+    return " ".join(parts)
 
 
 def _cvss_label(finding: dict) -> str:
@@ -57,6 +101,11 @@ def build_markdown(data: dict) -> str:
     out.append(f"# {data['title']} — riftor report")
     out.append("")
     out.append(f"_Generated {data['generated']} · stage reached: {data['stage_name']}_")
+    out.append("")
+
+    out.append("## Executive summary")
+    out.append("")
+    out.append(data.get("exec_summary", ""))
     out.append("")
 
     out.append("## Scope")
@@ -86,12 +135,16 @@ def build_markdown(data: dict) -> str:
         out.append(f"### {idx}. [{tag}] {f['title']}")
         if f.get("host"):
             out.append(f"- **Host:** {f['host']}")
+        if f.get("tags"):
+            out.append(f"- **Tags:** {f['tags']}")
         if f.get("cvss"):
             out.append(f"- **CVSS:** {cvss} (`{f['cvss']}`)")
         if f.get("evidence"):
             out.append(f"- **Evidence:**\n\n```\n{f['evidence']}\n```")
         if f.get("recommendation"):
             out.append(f"- **Recommendation:** {f['recommendation']}")
+        if f.get("notes"):
+            out.append(f"- **Notes:** {f['notes']}")
         out.append("")
 
     if data["services"]:
@@ -150,6 +203,9 @@ def build_html(data: dict) -> str:
         f"{esc(data['stage_name'])}</p>"
     )
 
+    parts.append("<h2>Executive summary</h2>")
+    parts.append(f"<p>{esc(data.get('exec_summary', '')).replace('**', '')}</p>")
+
     parts.append("<h2>Scope</h2><ul>")
     parts.append(f"<li><b>In scope:</b> {esc(', '.join(data['scope_in']) or '(none)')}</li>")
     if data["scope_out"]:
@@ -173,12 +229,16 @@ def build_html(data: dict) -> str:
         parts.append(f"<h3>{idx}. <span class=badge>[{esc(tag)}]</span> {esc(f['title'])}</h3>")
         if f.get("host"):
             parts.append(f"<p><b>Host:</b> {esc(f['host'])}</p>")
+        if f.get("tags"):
+            parts.append(f"<p><b>Tags:</b> {esc(f['tags'])}</p>")
         if f.get("cvss"):
             parts.append(f"<p><b>CVSS:</b> {esc(cvss)} (<code>{esc(f['cvss'])}</code>)</p>")
         if f.get("evidence"):
             parts.append(f"<p><b>Evidence:</b></p><pre>{esc(f['evidence'])}</pre>")
         if f.get("recommendation"):
             parts.append(f"<p><b>Recommendation:</b> {esc(f['recommendation'])}</p>")
+        if f.get("notes"):
+            parts.append(f"<p><b>Notes:</b> {esc(f['notes'])}</p>")
         parts.append("</div>")
 
     if data["services"]:
@@ -197,20 +257,119 @@ def build_html(data: dict) -> str:
     return "".join(parts)
 
 
+def build_json(data: dict) -> str:
+    """Machine-readable report: the full structured engagement data."""
+    payload = {
+        "tool": "riftor",
+        "title": data["title"],
+        "generated": data["generated"],
+        "stage": data["stage"],
+        "scope": {"in": data["scope_in"], "out": data["scope_out"]},
+        "summary": {"counts": data["counts"], "total": len(data["findings"])},
+        "executive_summary": data.get("exec_summary", ""),
+        "findings": [
+            {
+                "id": f.get("id"),
+                "title": f.get("title"),
+                "severity": f.get("severity"),
+                "cvss_vector": f.get("cvss") or None,
+                "cvss_score": f.get("cvss_score"),
+                "host": f.get("host") or None,
+                "evidence": f.get("evidence") or None,
+                "recommendation": f.get("recommendation") or None,
+                "tags": f.get("tags") or None,
+                "notes": f.get("notes") or None,
+                "stage": f.get("stage") or None,
+            }
+            for f in data["findings"]
+        ],
+        "services": data["services"],
+        "hosts": data["hosts"],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def build_sarif(data: dict) -> str:
+    """SARIF v2.1.0 — for GitHub Advanced Security, defect trackers, etc."""
+    rules: dict[str, dict] = {}
+    results: list[dict] = []
+    for f in data["findings"]:
+        rule_id = (f.get("title") or "finding").strip() or "finding"
+        rules.setdefault(
+            rule_id,
+            {
+                "id": rule_id,
+                "name": rule_id,
+                "shortDescription": {"text": rule_id},
+                "properties": {"security-severity": f"{f.get('cvss_score') or 0.0:.1f}"},
+            },
+        )
+        message = f.get("evidence") or f.get("recommendation") or rule_id
+        result = {
+            "ruleId": rule_id,
+            "level": _SARIF_LEVEL.get(f.get("severity", "info"), "note"),
+            "message": {"text": str(message)},
+            "properties": {
+                "severity": f.get("severity"),
+                "host": f.get("host") or "",
+                "tags": f.get("tags") or "",
+            },
+        }
+        if f.get("host"):
+            result["locations"] = [
+                {"physicalLocation": {"artifactLocation": {"uri": str(f["host"])}}}
+            ]
+        results.append(result)
+
+    sarif = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "riftor",
+                        "informationUri": "https://github.com/Estudely/riftor",
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(sarif, indent=2)
+
+
+_BUILDERS = {
+    "md": ("md", build_markdown),
+    "html": ("html", build_html),
+    "json": ("json", build_json),
+    "sarif": ("sarif", build_sarif),
+}
+
+
+def _formats_for(fmt: str) -> list[str]:
+    fmt = (fmt or "both").lower()
+    if fmt == "both":
+        return ["md", "html"]
+    if fmt == "all":
+        return ["md", "html", "json", "sarif"]
+    return [fmt] if fmt in _BUILDERS else []
+
+
 def write_reports(engagement, fmt: str = "both") -> list[Path]:
-    """Render and write report file(s). fmt in {md, html, both}. Returns paths."""
+    """Render and write report file(s). fmt in {md, html, json, sarif, both, all}."""
+    formats = _formats_for(fmt)
+    if not formats:
+        raise ValueError(f"unknown report format: {fmt}")
     data = report_data(engagement)
     out_dir = engagement.dir / "reports"
     out_dir.mkdir(parents=True, exist_ok=True)
     stamp = time.strftime("%Y%m%d-%H%M%S")
     written: list[Path] = []
-
-    if fmt in ("md", "both"):
-        path = out_dir / f"report-{stamp}.md"
-        path.write_text(build_markdown(data), encoding="utf-8")
-        written.append(path)
-    if fmt in ("html", "both"):
-        path = out_dir / f"report-{stamp}.html"
-        path.write_text(build_html(data), encoding="utf-8")
+    for key in formats:
+        ext, builder = _BUILDERS[key]
+        path = out_dir / f"report-{stamp}.{ext}"
+        path.write_text(builder(data), encoding="utf-8")
         written.append(path)
     return written

--- a/riftor/engagement/state.py
+++ b/riftor/engagement/state.py
@@ -1,7 +1,8 @@
-"""SQLite-backed engagement state: scope, hosts, services, findings, meta."""
+"""SQLite-backed engagement state: scope, hosts, services, findings, meta, activity."""
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import time
 from pathlib import Path
@@ -18,7 +19,18 @@ CREATE TABLE IF NOT EXISTS findings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT, severity TEXT, host TEXT, evidence TEXT, recommendation TEXT, stage TEXT, ts REAL
 );
+CREATE TABLE IF NOT EXISTS activity (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event TEXT, detail TEXT, ts REAL
+);
 """
+
+# Columns added after the original schema shipped; (table, column, type).
+_LATE_COLUMNS = (
+    ("findings", "cvss", "TEXT"),
+    ("findings", "tags", "TEXT"),
+    ("findings", "notes", "TEXT"),
+)
 
 
 class Store:
@@ -31,9 +43,15 @@ class Store:
         self._conn.commit()
 
     def _migrate(self) -> None:
-        cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(findings)")}
-        if "cvss" not in cols:
-            self._conn.execute("ALTER TABLE findings ADD COLUMN cvss TEXT")
+        for table, column, ctype in _LATE_COLUMNS:
+            cols = {r["name"] for r in self._conn.execute(f"PRAGMA table_info({table})")}
+            if column not in cols:
+                self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ctype}")
+        # activity table is created in the base schema for new DBs; ensure for old ones.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS activity "
+            "(id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT, detail TEXT, ts REAL)"
+        )
 
     # -- meta -------------------------------------------------------------------
     def set_meta(self, key: str, value: str) -> None:
@@ -91,6 +109,13 @@ class Store:
         self._conn.commit()
         return int(cur.lastrowid)
 
+    def service_exists(self, host: str, port: int | None, proto: str = "tcp") -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM services WHERE host=? AND IFNULL(port,-1)=IFNULL(?,-1) AND proto=? LIMIT 1",
+            (host, port, proto),
+        ).fetchone()
+        return row is not None
+
     def list_services(self) -> list[dict]:
         return [dict(r) for r in self._conn.execute("SELECT * FROM services ORDER BY host, port")]
 
@@ -107,20 +132,89 @@ class Store:
         recommendation: str = "",
         stage: str = "",
         cvss: str = "",
+        tags: str = "",
+        notes: str = "",
     ) -> int:
         cur = self._conn.execute(
-            "INSERT INTO findings(title, severity, host, evidence, recommendation, stage, cvss, ts) "
-            "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-            (title, severity, host, evidence, recommendation, stage, cvss, time.time()),
+            "INSERT INTO findings"
+            "(title, severity, host, evidence, recommendation, stage, cvss, tags, notes, ts) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (title, severity, host, evidence, recommendation, stage, cvss, tags, notes, time.time()),
         )
         self._conn.commit()
         return int(cur.lastrowid)
+
+    def find_finding_id(self, title: str, host: str, severity: str, evidence: str = "") -> int | None:
+        """Return the id of an existing finding matching the natural key, else None."""
+        row = self._conn.execute(
+            "SELECT id FROM findings WHERE "
+            "LOWER(TRIM(title))=LOWER(TRIM(?)) AND LOWER(TRIM(IFNULL(host,'')))=LOWER(TRIM(?)) "
+            "AND LOWER(TRIM(severity))=LOWER(TRIM(?)) AND IFNULL(evidence,'')=? LIMIT 1",
+            (title, host, severity, evidence),
+        ).fetchone()
+        return int(row["id"]) if row else None
+
+    def get_finding(self, finding_id: int) -> dict | None:
+        row = self._conn.execute("SELECT * FROM findings WHERE id=?", (finding_id,)).fetchone()
+        return dict(row) if row else None
+
+    def update_finding(self, finding_id: int, **fields) -> bool:
+        """Update allowed fields of a finding. Returns True if the row existed."""
+        allowed = {
+            "title", "severity", "host", "evidence", "recommendation",
+            "stage", "cvss", "tags", "notes",
+        }
+        sets = {k: v for k, v in fields.items() if k in allowed and v is not None}
+        if not sets:
+            return self.get_finding(finding_id) is not None
+        cols = ", ".join(f"{k}=?" for k in sets)
+        cur = self._conn.execute(
+            f"UPDATE findings SET {cols} WHERE id=?", (*sets.values(), finding_id)
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def delete_finding(self, finding_id: int) -> bool:
+        cur = self._conn.execute("DELETE FROM findings WHERE id=?", (finding_id,))
+        self._conn.commit()
+        return cur.rowcount > 0
 
     def list_findings(self) -> list[dict]:
         return [dict(r) for r in self._conn.execute("SELECT * FROM findings ORDER BY id")]
 
     def count_findings(self) -> int:
         return int(self._conn.execute("SELECT COUNT(*) AS c FROM findings").fetchone()["c"])
+
+    # -- activity log -----------------------------------------------------------
+    def log_activity(self, event: str, detail: str = "") -> None:
+        self._conn.execute(
+            "INSERT INTO activity(event, detail, ts) VALUES(?, ?, ?)",
+            (event, detail, time.time()),
+        )
+        self._conn.commit()
+
+    def list_activity(self, limit: int = 200) -> list[dict]:
+        return [
+            dict(r)
+            for r in self._conn.execute(
+                "SELECT * FROM activity ORDER BY id DESC LIMIT ?", (limit,)
+            )
+        ][::-1]
+
+    # -- export -----------------------------------------------------------------
+    def export_dict(self) -> dict:
+        """A JSON-serializable snapshot of the whole engagement state."""
+        return {
+            "meta": {r["key"]: r["value"] for r in self._conn.execute("SELECT key, value FROM meta")},
+            "scope": [{"target": t, "mode": m} for t, m in self.list_scope()],
+            "hosts": self.list_hosts(),
+            "services": self.list_services(),
+            "findings": self.list_findings(),
+            "activity": self.list_activity(limit=10_000),
+        }
+
+    def dump_json(self) -> str:
+        return json.dumps(self.export_dict(), indent=2)
 
     def close(self) -> None:
         self._conn.close()

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -1,0 +1,137 @@
+"""Headless / one-shot mode: run a single task without the TUI.
+
+Useful for scripting and CI. The agent streams to stdout. For safety, dangerous
+tools (bash/write/edit) only run if an explicit allow rule exists in
+``permissions.toml`` — otherwise they are auto-denied (no interactive operator to
+approve). Out-of-scope, scope-sensitive calls are always blocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from riftor import tools
+from riftor.agent.context import Context
+from riftor.agent.provider import Provider, ProviderError, ToolCall
+from riftor.config import PERMISSIONS_PATH, Config
+from riftor.engagement import Engagement
+from riftor.safety.audit import AuditLog
+from riftor.safety.permissions import Permissions
+from riftor.tools import ToolContext, ToolResult
+
+
+def run_headless(
+    cfg: Config,
+    workdir: Path,
+    *,
+    prompt: str | None,
+    scope_file: str | None = None,
+) -> int:
+    if not prompt:
+        if not sys.stdin.isatty():
+            prompt = sys.stdin.read().strip()
+        if not prompt:
+            print("riftor --headless: no prompt (use --prompt or pipe stdin)", file=sys.stderr)
+            return 2
+    if not cfg.has_credentials():
+        env = cfg.provider_env() or "ANTHROPIC_API_KEY"
+        print(f"riftor: no API key for {cfg.model}; set {env}", file=sys.stderr)
+        return 3
+    try:
+        return asyncio.run(_run(cfg, workdir, prompt, scope_file))
+    except KeyboardInterrupt:
+        return 130
+
+
+async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None) -> int:
+    context = Context(lore=cfg.lore)
+    provider = Provider(cfg)
+    engagement = Engagement(workdir)
+    if scope_file:
+        try:
+            engagement.import_scope(Path(scope_file).expanduser().read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            print(f"riftor: scope file error: {exc}", file=sys.stderr)
+    toolctx = ToolContext(
+        workdir=workdir, engagement=engagement, max_result_chars=cfg.max_result_chars
+    )
+    permissions = Permissions.load(PERMISSIONS_PATH)
+    audit = AuditLog()
+    schemas = tools.schemas()
+
+    context.add_user(prompt)
+    for _ in range(cfg.max_steps):
+        context.repair()
+        text_parts: list[str] = []
+        turn = None
+        try:
+            async for event, payload in provider.stream_turn(context.messages, schemas):
+                if event == "text":
+                    sys.stdout.write(str(payload))
+                    sys.stdout.flush()
+                    text_parts.append(str(payload))
+                elif event == "done":
+                    turn = payload  # type: ignore[assignment]  # ("done", Turn)
+        except ProviderError as exc:
+            print(f"\nriftor: provider error [{exc.kind}] — {exc}", file=sys.stderr)
+            return 1
+        if turn is None:
+            break
+        context.add_message(turn.assistant_message)
+        if not turn.tool_calls:
+            break
+        for call in turn.tool_calls:
+            await _run_tool_headless(call, engagement, permissions, audit, toolctx, context)
+    print()  # trailing newline
+    return 0
+
+
+async def _run_tool_headless(
+    call: ToolCall,
+    engagement: Engagement,
+    permissions: Permissions,
+    audit: AuditLog,
+    toolctx: ToolContext,
+    context: Context,
+) -> None:
+    tool = tools.get(call.name)
+    if tool is None:
+        context.add_tool_result(call.id, f"error: unknown tool '{call.name}'")
+        return
+    preview = tool.preview(call.arguments)
+    print(f"\n  ⛏ {tool.name}  {preview}", file=sys.stderr)
+
+    if getattr(tool, "scope_sensitive", False):
+        violations = engagement.violations(" ".join(str(v) for v in call.arguments.values()))
+        if violations:
+            context.add_tool_result(
+                call.id,
+                f"[blocked: out of scope] {', '.join(violations)} not in scope.",
+            )
+            audit.record(tool.name, preview, allowed=False)
+            return
+
+    if permissions.is_denied(tool.name, preview):
+        context.add_tool_result(call.id, "[blocked by policy] denied by a deny rule.")
+        audit.record(tool.name, preview, allowed=False)
+        return
+
+    # No operator present: dangerous tools require a standing allow rule.
+    if tool.requires_permission and not permissions.is_allowed(tool.name, preview):
+        context.add_tool_result(
+            call.id,
+            "[denied: headless] This tool needs approval and no allow rule exists. "
+            "Add one to permissions.toml to enable it in headless mode.",
+        )
+        audit.record(tool.name, preview, allowed=False)
+        return
+
+    try:
+        result = await tool.execute(call.arguments, toolctx)
+    except Exception as exc:  # noqa: BLE001
+        result = ToolResult(f"error: {exc}", is_error=True)
+    result = result.truncated(toolctx.max_result_chars)
+    audit.record(tool.name, preview, allowed=True, is_error=result.is_error)
+    context.add_tool_result(call.id, result.content)

--- a/riftor/safety/audit.py
+++ b/riftor/safety/audit.py
@@ -1,11 +1,14 @@
 """Append-only JSONL audit log: every tool invocation riftor attempts.
 
 Lives under ``$XDG_STATE_HOME/riftor/audit.jsonl`` (falls back to
-``~/.local/state/riftor/audit.jsonl``). This is the engagement record.
+``~/.local/state/riftor/audit.jsonl``). This is the engagement record. When the
+file grows past ``max_bytes`` it is rotated to ``audit.jsonl.1`` (gzip-compressed)
+so the active log stays small and readable.
 """
 
 from __future__ import annotations
 
+import gzip
 import json
 import os
 import time
@@ -19,12 +22,24 @@ def _state_dir() -> Path:
 
 
 class AuditLog:
-    def __init__(self, path: Path | None = None) -> None:
+    def __init__(self, path: Path | None = None, max_bytes: int = 5_000_000) -> None:
         if path is None:
             d = _state_dir()
             d.mkdir(parents=True, exist_ok=True)
             path = d / "audit.jsonl"
         self.path = path
+        self.max_bytes = max_bytes
+
+    def _maybe_rotate(self) -> None:
+        try:
+            if not self.path.exists() or self.path.stat().st_size < self.max_bytes:
+                return
+            archive = self.path.with_suffix(self.path.suffix + ".1.gz")
+            with self.path.open("rb") as src, gzip.open(archive, "wb") as dst:
+                dst.writelines(src)
+            self.path.write_text("", encoding="utf-8")
+        except Exception:  # noqa: BLE001 — rotation must never crash the agent
+            pass
 
     def record(
         self,
@@ -46,7 +61,22 @@ class AuditLog:
             "result_len": result_len,
         }
         try:
+            self._maybe_rotate()
             with self.path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(record) + "\n")
         except Exception:  # noqa: BLE001 — auditing must never crash the agent
             pass
+
+    def tail(self, limit: int = 30) -> list[dict]:
+        """Most recent audit entries (oldest-first), for the in-app /audit view."""
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except Exception:  # noqa: BLE001
+            return []
+        out: list[dict] = []
+        for line in lines[-limit:]:
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return out

--- a/riftor/safety/permissions.py
+++ b/riftor/safety/permissions.py
@@ -1,6 +1,23 @@
-"""Permission state + the confirmation modal for dangerous tool calls."""
+"""Permission state + the confirmation modal for dangerous tool calls.
+
+Permissions are layered, in priority order:
+
+1. **deny rules** — hard block (e.g. ``bash rm -rf``); never even prompts.
+2. **allow rules** — auto-approve a tool, or a tool whose preview matches a pattern.
+3. **session grants** — "allow for session" choices made this run.
+4. otherwise → prompt the operator (once / session / always-allow / deny / always-deny).
+
+Persistent rules live in ``~/.config/riftor/permissions.toml`` so an operator's
+trust choices survive across runs. "Allow once" approves exactly this call
+without remembering anything.
+"""
 
 from __future__ import annotations
+
+import os
+import re
+import tomllib
+from pathlib import Path
 
 from rich.text import Text
 from textual.app import ComposeResult
@@ -9,33 +26,168 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
 
+def _default_deny() -> list[dict]:
+    """Sensible destructive-command guards, on by default for the bash tool."""
+    return [
+        {"tool": "bash", "pattern": r"\brm\s+-[a-z]*r[a-z]*f|\brm\s+-[a-z]*f[a-z]*r"},
+        {"tool": "bash", "pattern": r"\bdd\s+.*of=/dev/"},
+        {"tool": "bash", "pattern": r"\bmkfs(\.\w+)?\b"},
+        {"tool": "bash", "pattern": r":\(\)\s*\{\s*:\|:&\s*\}"},  # fork bomb
+        {"tool": "bash", "pattern": r">\s*/dev/sd[a-z]"},
+    ]
+
+
+class Rule:
+    """A tool/pattern matcher. ``pattern`` matches against the call preview."""
+
+    def __init__(self, tool: str = "*", pattern: str | None = None) -> None:
+        self.tool = tool or "*"
+        self.pattern = pattern
+        self._rx = re.compile(pattern, re.IGNORECASE) if pattern else None
+
+    def matches(self, tool_name: str, preview: str) -> bool:
+        if self.tool not in ("*", tool_name):
+            return False
+        if self._rx is None:
+            return True
+        return bool(self._rx.search(preview or ""))
+
+
 class Permissions:
-    """Tracks which tools the operator has allowed for the rest of the session."""
+    """Layered permission engine: persistent rules + per-session grants."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        allow: list[dict] | None = None,
+        deny: list[dict] | None = None,
+    ) -> None:
+        self.allow_rules = [Rule(**r) for r in (allow or [])]
+        self.deny_rules = [Rule(**r) for r in (deny if deny is not None else _default_deny())]
         self.session_allowed: set[str] = set()
+        self.session_denied: set[str] = set()
+        self._path: Path | None = None
 
-    def needs_prompt(self, tool_name: str, requires_permission: bool) -> bool:
-        return requires_permission and tool_name not in self.session_allowed
+    # -- persistence ------------------------------------------------------------
+    @classmethod
+    def load(cls, path: Path) -> "Permissions":
+        perms = cls()
+        perms._path = path
+        if not path.exists():
+            return perms
+        try:
+            with path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except Exception:  # noqa: BLE001 — bad config must never crash the app
+            return perms
+        section = data.get("permissions", data)
+        allow = section.get("allow") or []
+        deny = section.get("deny")
+        perms.allow_rules = [Rule(**r) for r in allow]
+        perms.deny_rules = [Rule(**r) for r in (deny if deny is not None else [])]
+        if deny is None:  # no deny key at all → keep the safe defaults
+            perms.deny_rules = [Rule(**r) for r in _default_deny()]
+        return perms
+
+    def save(self) -> None:
+        if self._path is None:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        def rule_line(r: Rule) -> str:
+            # TOML *literal* strings (single quotes) so regex backslashes survive
+            # without escaping. Single quotes inside a pattern are rare; strip if any.
+            if r.pattern:
+                pat = f", pattern = '{r.pattern.replace(chr(39), '')}'"
+            else:
+                pat = ""
+            return f'  {{ tool = "{r.tool}"{pat} }},'
+
+        lines = ["# riftor permissions", "", "[permissions]", ""]
+        lines.append("# allow = auto-approve; deny = hard-block (never prompts).")
+        lines.append("allow = [")
+        lines += [rule_line(r) for r in self.allow_rules]
+        lines.append("]")
+        lines.append("deny = [")
+        lines += [rule_line(r) for r in self.deny_rules]
+        lines.append("]")
+        fd = os.open(str(self._path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, ("\n".join(lines) + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+
+    # -- decisions --------------------------------------------------------------
+    def is_denied(self, tool_name: str, preview: str = "") -> bool:
+        if tool_name in self.session_denied:
+            return True
+        return any(r.matches(tool_name, preview) for r in self.deny_rules)
+
+    def is_allowed(self, tool_name: str, preview: str = "") -> bool:
+        if tool_name in self.session_allowed:
+            return True
+        return any(r.matches(tool_name, preview) for r in self.allow_rules)
+
+    def needs_prompt(self, tool_name: str, requires_permission: bool, preview: str = "") -> bool:
+        if not requires_permission:
+            return False
+        if self.is_allowed(tool_name, preview):
+            return False
+        return True
 
     def allow_for_session(self, tool_name: str) -> None:
         self.session_allowed.add(tool_name)
 
+    def deny_for_session(self, tool_name: str) -> None:
+        self.session_denied.add(tool_name)
+
+    def add_allow_rule(self, tool: str, pattern: str | None = None) -> None:
+        self.allow_rules.append(Rule(tool, pattern))
+        self.save()
+
+    def add_deny_rule(self, tool: str, pattern: str | None = None) -> None:
+        self.deny_rules.append(Rule(tool, pattern))
+        self.save()
+
+    def describe(self) -> str:
+        def fmt(rules: list[Rule]) -> str:
+            if not rules:
+                return "(none)"
+            return ", ".join(f"{r.tool}{':' + r.pattern if r.pattern else ''}" for r in rules)
+
+        return (
+            f"allow: {fmt(self.allow_rules)}\n"
+            f"deny: {fmt(self.deny_rules)}\n"
+            f"session-allow: {', '.join(sorted(self.session_allowed)) or '(none)'}"
+        )
+
 
 class ConfirmScreen(ModalScreen[str]):
-    """Asks the operator to approve a tool call. Dismisses with once/session/deny."""
+    """Asks the operator to approve a tool call.
+
+    Dismisses with one of: ``once`` (this call only), ``session`` (rest of run),
+    ``always`` (persist an allow rule), ``deny`` (refuse), ``always_deny``
+    (persist a deny rule). ``detail`` is an optional multi-line preview (e.g. a diff).
+    """
 
     BINDINGS = [
         ("escape", "decide('deny')", "Deny"),
         ("a", "decide('once')", "Allow once"),
         ("s", "decide('session')", "Allow session"),
+        ("w", "decide('always')", "Always allow"),
+        ("d", "decide('always_deny')", "Always deny"),
     ]
 
-    def __init__(self, tool_name: str, preview: str, scope_warning: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        tool_name: str,
+        preview: str,
+        scope_warning: list[str] | None = None,
+        detail: str | None = None,
+    ) -> None:
         super().__init__()
         self.tool_name = tool_name
         self.preview = preview
         self.scope_warning = scope_warning or []
+        self.detail = detail
 
     def compose(self) -> ComposeResult:
         with Vertical(id="confirm-box"):
@@ -52,10 +204,28 @@ class ConfirmScreen(ModalScreen[str]):
                     id="confirm-scope",
                 )
             yield Static(Text(self.preview or "(no detail)", style="#e9e9f2"), id="confirm-detail")
+            if self.detail:
+                yield Static(self._render_detail(), id="confirm-diff")
             with Horizontal(id="confirm-buttons"):
-                yield Button("Allow once (a)", id="once", variant="success")
-                yield Button("Allow session (s)", id="session", variant="primary")
+                yield Button("Once (a)", id="once", variant="success")
+                yield Button("Session (s)", id="session", variant="primary")
+                yield Button("Always (w)", id="always", variant="primary")
                 yield Button("Deny (esc)", id="deny", variant="error")
+                yield Button("Never (d)", id="always_deny", variant="error")
+
+    def _render_detail(self) -> Text:
+        """Color a unified diff (or show plain preview text)."""
+        text = Text()
+        for line in (self.detail or "").splitlines()[:200]:
+            if line.startswith("+") and not line.startswith("+++"):
+                text.append(line + "\n", style="#86efac")
+            elif line.startswith("-") and not line.startswith("---"):
+                text.append(line + "\n", style="#fca5a5")
+            elif line.startswith("@@"):
+                text.append(line + "\n", style="#22d3ee")
+            else:
+                text.append(line + "\n", style="#8b8ba7")
+        return text
 
     def on_mount(self) -> None:
         self.query_one("#once", Button).focus()

--- a/riftor/tools/__init__.py
+++ b/riftor/tools/__init__.py
@@ -13,8 +13,11 @@ from riftor.tools.core import (
     WriteTool,
 )
 from riftor.tools.engagement import (
+    DeleteFindingTool,
+    EditFindingTool,
     GenerateReportTool,
     ImportScanTool,
+    ListHostsTool,
     RecordFindingTool,
     RecordServiceTool,
     ScopeListTool,
@@ -24,6 +27,7 @@ from riftor.tools.engagement import (
 # Order is roughly safe -> mutating; it's also the order shown to the model.
 ALL_TOOLS: list[Tool] = [
     ScopeListTool(),
+    ListHostsTool(),
     ReadTool(),
     GlobTool(),
     GrepTool(),
@@ -32,6 +36,8 @@ ALL_TOOLS: list[Tool] = [
     ImportScanTool(),
     RecordServiceTool(),
     RecordFindingTool(),
+    EditFindingTool(),
+    DeleteFindingTool(),
     GenerateReportTool(),
     WriteTool(),
     EditTool(),

--- a/riftor/tools/base.py
+++ b/riftor/tools/base.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from riftor.engagement import Engagement
 
 MAX_RESULT_CHARS = 30_000
 
@@ -29,7 +33,9 @@ class ToolContext:
     """Shared execution context handed to every tool."""
 
     workdir: Path = field(default_factory=Path.cwd)
-    engagement: object | None = None
+    engagement: "Engagement | None" = None
+    #: per-result truncation cap fed back into the model (configurable via Config)
+    max_result_chars: int = MAX_RESULT_CHARS
 
 
 def resolve_path(ctx: ToolContext, raw: str) -> Path:
@@ -50,6 +56,13 @@ class Tool(ABC):
     def preview(self, args: dict) -> str:
         """One-line human summary for permission prompts and the audit log."""
         return ", ".join(f"{k}={v!r}" for k, v in args.items())[:300]
+
+    def confirm_detail(self, args: dict, ctx: ToolContext) -> str | None:
+        """Optional multi-line detail (e.g. a diff) shown in the approval modal.
+
+        Returning ``None`` means "no extra detail" — the default for most tools.
+        """
+        return None
 
     @abstractmethod
     async def execute(self, args: dict, ctx: ToolContext) -> ToolResult: ...

--- a/riftor/tools/core.py
+++ b/riftor/tools/core.py
@@ -7,12 +7,26 @@ Read-only tools (read/grep/glob/webfetch) run without a prompt. Mutating tools
 from __future__ import annotations
 
 import asyncio
+import difflib
 import re
 import shutil
 import urllib.request
 from pathlib import Path
 
 from riftor.tools.base import Tool, ToolContext, ToolResult, resolve_path
+
+
+def _unified_diff(old: str, new: str, path: str, max_lines: int = 200) -> str:
+    diff = difflib.unified_diff(
+        old.splitlines(), new.splitlines(),
+        fromfile=f"a/{path}", tofile=f"b/{path}", lineterm="",
+    )
+    lines = list(diff)
+    if not lines:
+        return "(no changes)"
+    if len(lines) > max_lines:
+        lines = lines[:max_lines] + [f"… (+{len(lines) - max_lines} more diff lines)"]
+    return "\n".join(lines)
 
 
 class BashTool(Tool):
@@ -57,7 +71,7 @@ class BashTool(Tool):
             return ToolResult(f"error: timed out after {timeout}s", is_error=True)
         text = out.decode("utf-8", errors="replace")
         rc = proc.returncode
-        return ToolResult(f"[exit {rc}]\n{text}", is_error=(rc != 0)).truncated()
+        return ToolResult(f"[exit {rc}]\n{text}", is_error=(rc != 0)).truncated(ctx.max_result_chars)
 
 
 class ReadTool(Tool):
@@ -113,6 +127,21 @@ class WriteTool(Tool):
         content = args.get("content", "")
         return f"{args.get('path', '')}  ({len(content)} bytes)"
 
+    def confirm_detail(self, args: dict, ctx: ToolContext) -> str | None:
+        path = resolve_path(ctx, str(args.get("path", "")))
+        new = str(args.get("content", ""))
+        old = ""
+        if path.exists() and path.is_file():
+            try:
+                old = path.read_text(encoding="utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                old = ""
+        if not old:
+            preview = "\n".join(f"+{line}" for line in new.splitlines()[:120])
+            extra = "" if new.count("\n") <= 120 else f"\n… (+{new.count(chr(10)) - 120} more lines)"
+            return f"new file {path.name}:\n{preview}{extra}"
+        return _unified_diff(old, new, path.name)
+
     async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
         path = resolve_path(ctx, args["path"])
         try:
@@ -144,6 +173,21 @@ class EditTool(Tool):
 
     def preview(self, args: dict) -> str:
         return str(args.get("path", ""))
+
+    def confirm_detail(self, args: dict, ctx: ToolContext) -> str | None:
+        path = resolve_path(ctx, str(args.get("path", "")))
+        if not path.exists() or not path.is_file():
+            return None
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            return None
+        old = str(args.get("old_string", ""))
+        new = str(args.get("new_string", ""))
+        if old not in text:
+            return f"⚠ old_string not found in {path.name} — edit will fail"
+        updated = text.replace(old, new) if args.get("replace_all") else text.replace(old, new, 1)
+        return _unified_diff(text, updated, path.name)
 
     async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
         path = resolve_path(ctx, args["path"])

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -97,6 +97,12 @@ class RecordFindingTool(Tool):
             "host": {"type": "string"},
             "evidence": {"type": "string"},
             "recommendation": {"type": "string"},
+            "tags": {
+                "type": "string",
+                "description": "Optional comma-separated tags, e.g. "
+                "'requires-client-approval, pending-validation'.",
+            },
+            "notes": {"type": "string", "description": "Optional free-form markdown notes."},
             "cvss_vector": {
                 "type": "string",
                 "description": "Optional CVSS v3.1 vector, e.g. "
@@ -122,16 +128,109 @@ class RecordFindingTool(Tool):
         else:
             vector = ""  # don't store an invalid vector
 
-        fid = eng.add_finding(
+        fid, action = eng.add_finding_dedup(
+            dedup="skip",
             title=str(args["title"]),
             severity=severity,
             host=str(args.get("host") or ""),
             evidence=str(args.get("evidence") or ""),
             recommendation=str(args.get("recommendation") or ""),
+            tags=str(args.get("tags") or ""),
+            notes=str(args.get("notes") or ""),
             cvss=vector,
         )
+        if action == "skipped":
+            return ToolResult(f"finding already recorded (#{fid}) — skipped duplicate")
         tag = severity + (f" · CVSS {score:.1f}" if score is not None else "")
         return ToolResult(f"recorded finding #{fid} [{tag}] {args['title']}")
+
+
+class EditFindingTool(Tool):
+    name = "edit_finding"
+    description = (
+        "Update an existing finding by id (from /findings). Pass only the fields to "
+        "change: title, severity, host, evidence, recommendation, tags, notes."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer", "description": "Finding id to edit."},
+            "title": {"type": "string"},
+            "severity": {"type": "string", "enum": _SEVERITIES},
+            "host": {"type": "string"},
+            "evidence": {"type": "string"},
+            "recommendation": {"type": "string"},
+            "tags": {"type": "string"},
+            "notes": {"type": "string"},
+        },
+        "required": ["id"],
+    }
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        eng = ctx.engagement
+        if eng is None:
+            return ToolResult("error: no active engagement", is_error=True)
+        try:
+            fid = int(args["id"])
+        except (KeyError, TypeError, ValueError):
+            return ToolResult("error: id must be an integer", is_error=True)
+        fields = {
+            k: str(args[k])
+            for k in ("title", "severity", "host", "evidence", "recommendation", "tags", "notes")
+            if k in args and args[k] is not None
+        }
+        if "severity" in fields and fields["severity"].lower() not in _SEVERITIES:
+            return ToolResult(f"error: severity must be one of {', '.join(_SEVERITIES)}", is_error=True)
+        if not eng.store.update_finding(fid, **fields):
+            return ToolResult(f"error: no finding #{fid}", is_error=True)
+        eng.store.log_activity("finding_edit", f"#{fid} {', '.join(fields)}")
+        return ToolResult(f"updated finding #{fid} ({', '.join(fields) or 'no changes'})")
+
+
+class DeleteFindingTool(Tool):
+    name = "delete_finding"
+    description = "Delete a finding by id (from /findings). Use to remove duplicates or false positives."
+    parameters = {
+        "type": "object",
+        "properties": {"id": {"type": "integer", "description": "Finding id to delete."}},
+        "required": ["id"],
+    }
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        eng = ctx.engagement
+        if eng is None:
+            return ToolResult("error: no active engagement", is_error=True)
+        try:
+            fid = int(args["id"])
+        except (KeyError, TypeError, ValueError):
+            return ToolResult("error: id must be an integer", is_error=True)
+        if not eng.store.delete_finding(fid):
+            return ToolResult(f"error: no finding #{fid}", is_error=True)
+        eng.store.log_activity("finding_delete", f"#{fid}")
+        return ToolResult(f"deleted finding #{fid}")
+
+
+class ListHostsTool(Tool):
+    name = "list_hosts"
+    description = "List discovered hosts and services recorded in the engagement."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        eng = ctx.engagement
+        if eng is None:
+            return ToolResult("error: no active engagement", is_error=True)
+        services = eng.store.list_services()
+        if not services:
+            hosts = eng.store.list_hosts()
+            if not hosts:
+                return ToolResult("no hosts or services recorded yet")
+            return ToolResult("hosts:\n" + "\n".join(h["host"] for h in hosts))
+        lines = [
+            f"{s['host']}:{s.get('port') or ''}/{s.get('proto', 'tcp')} "
+            f"{s.get('service', '')} {s.get('version', '')}".rstrip()
+            for s in services
+        ]
+        return ToolResult("services:\n" + "\n".join(lines)).truncated()
 
 
 class ImportScanTool(Tool):
@@ -147,6 +246,11 @@ class ImportScanTool(Tool):
         "properties": {
             "tool": {"type": "string", "enum": list(SUPPORTED)},
             "output": {"type": "string", "description": "Raw stdout from the tool."},
+            "dedup": {
+                "type": "string",
+                "enum": ["skip", "merge", "allow-all"],
+                "description": "How to handle duplicates (default skip).",
+            },
         },
         "required": ["tool", "output"],
     }
@@ -161,25 +265,52 @@ class ImportScanTool(Tool):
         tool = str(args.get("tool", "")).lower()
         if tool not in SUPPORTED:
             return ToolResult(f"error: tool must be one of {', '.join(SUPPORTED)}", is_error=True)
+        dedup = str(args.get("dedup") or "skip").lower()
+        if dedup not in ("skip", "merge", "allow-all"):
+            dedup = "skip"
         scan = parse(tool, str(args.get("output", "")))
+
+        svc_added = svc_skipped = 0
         for service in scan.services:
-            eng.add_service(**service)
+            _id, action = eng.add_service_dedup(dedup=dedup, **service)
+            svc_added += action == "added"
+            svc_skipped += action == "skipped"
+        fnd_added = fnd_skipped = fnd_merged = 0
         for finding in scan.findings:
-            eng.add_finding(**finding)
+            _id, action = eng.add_finding_dedup(dedup=dedup, **finding)
+            fnd_added += action == "added"
+            fnd_skipped += action == "skipped"
+            fnd_merged += action == "merged"
+
         if not scan.services and not scan.findings:
-            return ToolResult(f"parsed {tool}: nothing recognised (check the output format)")
-        return ToolResult(
-            f"imported {tool}: {len(scan.services)} service(s), {len(scan.findings)} finding(s)"
-        )
+            extra = f" ({scan.skipped} line(s) skipped)" if scan.skipped else ""
+            return ToolResult(f"parsed {tool}: nothing recognised{extra} (check the output format)")
+
+        msg = f"imported {tool}: {svc_added} service(s), {fnd_added} finding(s)"
+        details = []
+        if svc_skipped or fnd_skipped:
+            details.append(f"{svc_skipped + fnd_skipped} duplicate(s) skipped")
+        if fnd_merged:
+            details.append(f"{fnd_merged} merged")
+        if scan.skipped:
+            details.append(f"{scan.skipped} unparsable line(s)")
+        if scan.json_errors:
+            details.append(f"{scan.json_errors} JSON error(s)")
+        if details:
+            msg += " · " + ", ".join(details)
+        return ToolResult(msg)
 
 
 class GenerateReportTool(Tool):
     name = "generate_report"
-    description = "Write a pentest report of the current engagement to disk (markdown + HTML)."
+    description = (
+        "Write a pentest report of the current engagement to disk. Formats: md, html, "
+        "json (machine-readable), sarif (CI/defect-tracker), both (md+html), all."
+    )
     parameters = {
         "type": "object",
         "properties": {
-            "format": {"type": "string", "enum": ["md", "html", "both"]},
+            "format": {"type": "string", "enum": ["md", "html", "json", "sarif", "both", "all"]},
         },
     }
 
@@ -188,7 +319,9 @@ class GenerateReportTool(Tool):
         if eng is None:
             return ToolResult("error: no active engagement", is_error=True)
         fmt = str(args.get("format") or "both").lower()
-        if fmt not in ("md", "html", "both"):
-            fmt = "both"
-        paths = write_reports(eng, fmt)
+        try:
+            paths = write_reports(eng, fmt)
+        except ValueError:
+            paths = write_reports(eng, "both")
+        eng.store.log_activity("report", fmt)
         return ToolResult("wrote report:\n" + "\n".join(str(p) for p in paths))

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -1,14 +1,15 @@
 """The riftor Textual app.
 
-Phase 3: an offensive-security agent. The model calls tools (bash/read/write/
-edit/grep/glob/webfetch + engagement tools); dangerous tools prompt for
-permission; scope-sensitive tools are blocked against out-of-scope targets
-(with an explicit per-call override); RIFT stage, scope and findings live in the
-engagement state and show in the status bar.
+An offensive-security agent. The model calls tools (bash/read/write/edit/grep/
+glob/webfetch + engagement tools); dangerous tools prompt for permission (with a
+diff preview for write/edit); scope-sensitive tools are blocked against
+out-of-scope targets (with an explicit per-call override); RIFT stage, scope and
+findings live in the engagement state and show in the status bar.
 """
 
 from __future__ import annotations
 
+import difflib
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,13 +17,17 @@ from typing import TYPE_CHECKING
 from rich.text import Text
 from textual import work
 from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.command import Hit, Hits
+from textual.command import Provider as CommandProvider
 from textual.containers import VerticalScroll
 from textual.widgets import Input, Markdown, Static
 
 from riftor import tools
 from riftor.agent import session as sessions
 from riftor.agent.context import Context
-from riftor.agent.provider import Provider, ToolCall, Turn
+from riftor.agent.provider import Provider, ProviderError, ToolCall, Turn, Usage
+from riftor.config import PERMISSIONS_PATH
 from riftor.engagement import Engagement
 from riftor.engagement.report import write_reports
 from riftor.safety.audit import AuditLog
@@ -35,35 +40,105 @@ from riftor.tui.widgets import STAGE_NAMES, Banner, StatusBar
 if TYPE_CHECKING:
     from riftor.config import Config
 
+# Model-window estimates (tokens) for the context gauge, by provider prefix.
+_CONTEXT_WINDOWS = {
+    "anthropic/": 200_000, "openai/": 128_000, "openrouter/": 128_000,
+    "gemini/": 1_000_000, "groq/": 128_000, "ollama": 8_192,
+}
+_DEFAULT_WINDOW = 128_000
+
+# Commands offered for fuzzy "did you mean" suggestions.
+_COMMANDS = [
+    "/help", "/clear", "/model", "/stage", "/scope", "/findings", "/finding",
+    "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
+    "/sessions", "/resume", "/new", "/theme", "/config", "/tools", "/permissions",
+    "/lore", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
+    "/timeline", "/audit", "/export", "/exit",
+]
+
 HELP = """\
 **riftor — commands**
 
-- `/help` — show this help
-- `/clear` — clear the conversation (also `Ctrl+L`)
-- `/model [name]` — show or switch the model
-- `/stage [R|I|F|T]` — show or set the RIFT stage (Recon/Intrusion/Foothold/Takeover)
-- `/scope [add|out|rm <t>|clear|on|off]` — manage in/out-of-scope targets
-- `/findings` — list recorded findings
-- `/report [md|html|both]` — write a pentest report to `.riftor/reports/`
-- `/sessions` — list saved sessions · `/resume <id>` · `/new` — start fresh
-- `/theme [name]` — show or switch theme (rift/void/fracture/singularity)
-- `/config` — open the settings panel
-- `/tools` — list available tools
-- `/lore` — toggle the rift persona
-- `/exit` — leave riftor (also `Ctrl+C`)
+_Conversation_
+- `/help` — show this help · `/clear` — clear conversation (`Ctrl+L`)
+- `/retry` — re-run the last turn · `/continue [N]` — extend the step budget
+- `/compact` — shrink old tool output to free context
+- `/copy` — copy the last agent/tool output · `/show <id>` — expand a tool result
+- `/cost` — token + cost for this session
 
-Type anything else to task the agent. `Esc` cancels a running response.
+_Engagement_
+- `/scope` — show scope · `/scope add 10.0.0.0/24 example.com` · `/scope out <t>`
+  · `/scope rm <t>` · `/scope clear` · `/scope on|off|dry` · `/scope import <file>` · `/scope export [file]`
+- `/stage [R|I|F|T]` — show or set the RIFT stage (Recon/Intrusion/Foothold/Takeover)
+- `/findings` — list findings (severity-sorted) · `/finding <id>` — show one
+- `/edit-finding <id> sev=high tags=...` · `/delete-finding <id>`
+- `/hosts` · `/services` — discovered infrastructure
+- `/report [md|html|json|sarif|both|all]` — write a report to `.riftor/reports/`
+- `/timeline` — engagement activity log · `/export` — archive the whole engagement
+
+_Settings & sessions_
+- `/model [name]` — show or switch the model · `/theme [name]` (rift/void/fracture/singularity)
+- `/config` — settings panel · `/permissions` — review allow/deny rules
+- `/lore` — toggle the rift persona · `/audit` — recent tool-call audit log
+- `/sessions` · `/resume <id>` · `/new` — manage saved sessions
+- `/tools` — list tools · `/exit` — quit (`Ctrl+C`)
+
+Type anything else to task the agent. `↑/↓` recall input · `PgUp/PgDn` scroll ·
+`Esc` cancels a running response.
 """
+
+
+# (command, display, help) for the Ctrl+P command palette.
+_PALETTE_COMMANDS = [
+    ("/help", "Help", "Show all commands"),
+    ("/findings", "Findings", "List findings (severity-sorted)"),
+    ("/hosts", "Hosts", "List discovered hosts"),
+    ("/services", "Services", "List discovered services"),
+    ("/report both", "Report", "Write a report (md + html)"),
+    ("/report all", "Report (all formats)", "md + html + json + sarif"),
+    ("/timeline", "Timeline", "Engagement activity log"),
+    ("/export", "Export engagement", "Archive the whole engagement"),
+    ("/permissions", "Permissions", "Review allow/deny rules"),
+    ("/audit", "Audit log", "Recent tool-call audit entries"),
+    ("/cost", "Cost", "Token + cost for this session"),
+    ("/compact", "Compact context", "Shrink old tool output"),
+    ("/retry", "Retry", "Re-run the last turn"),
+    ("/config", "Config", "Open the settings panel"),
+    ("/new", "New session", "Start a fresh conversation"),
+    ("/clear", "Clear", "Clear the conversation"),
+]
+
+
+class RiftorCommands(CommandProvider):
+    """Surfaces riftor's slash commands in the Ctrl+P command palette."""
+
+    async def search(self, query: str) -> Hits:  # type: ignore[override]
+        matcher = self.matcher(query)
+        app = self.app
+        for command, display, help_text in _PALETTE_COMMANDS:
+            score = matcher.match(display)
+            if score > 0:
+                yield Hit(
+                    score,
+                    matcher.highlight(display),
+                    (lambda c=command: app._command(c)),  # type: ignore[attr-defined]
+                    help=help_text,
+                )
 
 
 class RiftorApp(App):
     CSS_PATH = "themes/rift.tcss"
     TITLE = "riftor"
+    COMMANDS = App.COMMANDS | {RiftorCommands}  # type: ignore[arg-type]
 
     BINDINGS = [
         ("ctrl+c", "quit", "Quit"),
         ("ctrl+l", "clear", "Clear"),
         ("escape", "cancel", "Cancel"),
+        Binding("pageup", "scroll_chat('pageup')", "Scroll up", show=False),
+        Binding("pagedown", "scroll_chat('pagedown')", "Scroll down", show=False),
+        Binding("ctrl+home", "scroll_chat('home')", "Top", show=False),
+        Binding("ctrl+end", "scroll_chat('end')", "Bottom", show=False),
     ]
 
     def __init__(self, config: "Config", workdir: Path | None = None) -> None:
@@ -75,11 +150,24 @@ class RiftorApp(App):
         self.tools = tools.all_tools()
         self.tool_schemas = tools.schemas()
         self.engagement = Engagement(self.workdir)
-        self.toolctx = ToolContext(workdir=self.workdir, engagement=self.engagement)
-        self.permissions = Permissions()
+        self.toolctx = ToolContext(
+            workdir=self.workdir,
+            engagement=self.engagement,
+            max_result_chars=config.max_result_chars,
+        )
+        self.permissions = Permissions.load(PERMISSIONS_PATH)
         self.audit = AuditLog()
-        self.max_steps = 16
+        self.max_steps = config.max_steps
         self.session_id = sessions.new_id()
+        # input history + last-output tracking + rate limiting
+        self._history: list[str] = []
+        self._history_idx: int | None = None
+        self._tool_results: dict[int, str] = {}
+        self._last_output: str = ""
+        self._last_user_text: str | None = None
+        self.usage = Usage()
+        self._rate_times: list[float] = []
+        self._autoscroll = True
 
     def compose(self) -> ComposeResult:
         yield Banner(id="banner")
@@ -88,11 +176,20 @@ class RiftorApp(App):
         yield Input(placeholder="task riftor — or /help", id="prompt")
 
     def get_css_variables(self) -> dict[str, str]:
-        # Ensure $violet/$user-bg/etc. always resolve, even on the first paint
-        # before our theme is active (built-in themes lack these variables).
         variables = dict(css_variable_defaults())
         variables.update(super().get_css_variables())
         return variables
+
+    def _apply_keybindings(self) -> None:
+        """Apply operator key overrides from keybindings.toml (action → key)."""
+        from riftor.config import load_keybindings
+
+        overrides = load_keybindings()
+        for action, key in overrides.items():
+            try:
+                self.bind(key, action, description=action.replace("action_", ""))
+            except Exception:  # noqa: BLE001 — a bad override must not crash startup
+                continue
 
     def _apply_theme(self, name: str) -> None:
         if name not in THEMES:
@@ -108,10 +205,14 @@ class RiftorApp(App):
     def on_mount(self) -> None:
         for theme in THEMES.values():
             self.register_theme(theme)
+        self._apply_keybindings()
         self._apply_theme(self.config.theme)
         self.query_one("#prompt", Input).focus()
         self.status.set_stage(self.engagement.stage)
         self._refresh_status()
+        warning = self.config.model_warning()
+        if warning:
+            self._note("⚠ " + warning)
         if not self._resume_latest():
             self._note(
                 "rift online · set scope with /scope add <target> before tasking the agent"
@@ -125,13 +226,29 @@ class RiftorApp(App):
         self.context.load(data["messages"])
         self.context.repair()
         self._replay_transcript(self.context.messages)
-        self._note(f"resumed session {data['id']} ({len(data['messages'])} messages) · /new for fresh")
+        note = f"resumed session {data['id']} ({len(data['messages'])} messages) · /new for fresh"
+        if not data.get("complete", True):
+            note += "  ⚠ previous run ended mid-task — /retry to resume or /continue"
+        self._note(note)
         return True
 
     def _refresh_status(self) -> None:
         self.status.set_stage(self.engagement.stage)
-        self.status.set_scope(self.engagement.scope_count(), self.engagement.enforce)
+        self.status.set_scope(
+            self.engagement.scope_count(), self.engagement.enforce, self.engagement.dry_run
+        )
         self.status.set_findings(self.engagement.findings_count())
+
+    def _context_window(self) -> int:
+        for prefix, window in _CONTEXT_WINDOWS.items():
+            if self.config.model.startswith(prefix):
+                return window
+        return _DEFAULT_WINDOW
+
+    def _refresh_usage(self) -> None:
+        self.status.set_usage(self.usage.total_tokens, self.usage.cost)
+        pct = int(self.context.estimated_tokens() / self._context_window() * 100)
+        self.status.set_context(min(pct, 999))
 
     # ---- accessors -------------------------------------------------------------
     @property
@@ -146,87 +263,160 @@ class RiftorApp(App):
     def _pal(self) -> dict[str, str]:
         return palette(self)
 
+    def _scroll_if_following(self) -> None:
+        if self._autoscroll:
+            self.chat.scroll_end(animate=False)
+
     def _note(self, text: str) -> None:
         self.chat.mount(Static(Text(text, style=f"italic {self._pal()['dim']}"), classes="note"))
-        self.chat.scroll_end(animate=False)
+        self._scroll_if_following()
 
     def _error(self, text: str) -> None:
         self.chat.mount(Static(Text(text, style=f"bold {self._pal()['danger']}"), classes="note"))
-        self.chat.scroll_end(animate=False)
+        self._scroll_if_following()
+
+    def _markdown(self, text: str) -> None:
+        self.chat.mount(Markdown(text, classes="assistant"))
+        self._scroll_if_following()
 
     def _add_user(self, text: str) -> None:
         self.chat.mount(Static(Text(text), classes="user"))
-        self.chat.scroll_end(animate=False)
+        self._scroll_if_following()
 
     async def _mount(self, widget) -> None:
         await self.chat.mount(widget)
-        self.chat.scroll_end(animate=False)
+        self._scroll_if_following()
 
     # ---- events ----------------------------------------------------------------
     def on_input_submitted(self, event: Input.Submitted) -> None:
         text = event.value.strip()
         self.query_one("#prompt", Input).clear()
+        self._history_idx = None
         if not text:
             return
+        if not text.startswith("/"):
+            self._history.append(text)
         if text.startswith("/"):
             self._command(text)
             return
         self._add_user(text)
         self._agent(text)
 
+    def on_key(self, event) -> None:
+        # ↑/↓ recall previous prompts when the input is focused and empty-ish.
+        inp = self.query_one("#prompt", Input)
+        if not inp.has_focus or event.key not in ("up", "down"):
+            return
+        if not self._history:
+            return
+        if event.key == "up":
+            self._history_idx = (
+                len(self._history) - 1 if self._history_idx is None
+                else max(0, self._history_idx - 1)
+            )
+        else:  # down
+            if self._history_idx is None:
+                return
+            self._history_idx += 1
+            if self._history_idx >= len(self._history):
+                self._history_idx = None
+                inp.value = ""
+                event.prevent_default()
+                return
+        inp.value = self._history[self._history_idx]
+        inp.cursor_position = len(inp.value)
+        event.prevent_default()
+
+    def action_scroll_chat(self, where: str) -> None:
+        chat = self.chat
+        if where == "pageup":
+            chat.scroll_page_up()
+            self._autoscroll = False
+        elif where == "pagedown":
+            chat.scroll_page_down()
+            self._autoscroll = chat.scroll_offset.y >= chat.max_scroll_y - 2
+        elif where == "home":
+            chat.scroll_home()
+            self._autoscroll = False
+        elif where == "end":
+            chat.scroll_end()
+            self._autoscroll = True
+
     def _command(self, text: str) -> None:
         parts = text.split(maxsplit=1)
         cmd = parts[0].lower()
         arg = parts[1].strip() if len(parts) > 1 else ""
 
+        handlers = {
+            "/help": lambda: self._markdown(HELP),
+            "/tools": self._tools_cmd,
+            "/clear": self.action_clear,
+            "/lore": self._lore_cmd,
+            "/model": lambda: self._model_cmd(arg),
+            "/stage": lambda: self._set_stage(arg),
+            "/scope": lambda: self._scope_cmd(arg),
+            "/findings": self._show_findings,
+            "/finding": lambda: self._show_finding(arg),
+            "/edit-finding": lambda: self._edit_finding_cmd(arg),
+            "/delete-finding": lambda: self._delete_finding_cmd(arg),
+            "/hosts": self._hosts_cmd,
+            "/services": self._services_cmd,
+            "/report": lambda: self._report_cmd(arg),
+            "/sessions": self._sessions_cmd,
+            "/resume": lambda: self._resume_cmd(arg),
+            "/new": self._new_session,
+            "/theme": lambda: self._theme_cmd(arg),
+            "/config": self._open_config,
+            "/permissions": lambda: self._permissions_cmd(arg),
+            "/cost": self._cost_cmd,
+            "/retry": self._retry_cmd,
+            "/continue": lambda: self._continue_cmd(arg),
+            "/compact": self._compact_cmd,
+            "/copy": self._copy_cmd,
+            "/show": lambda: self._show_result(arg),
+            "/timeline": self._timeline_cmd,
+            "/audit": self._audit_cmd,
+            "/export": self._export_cmd,
+        }
         if cmd in ("/exit", "/quit"):
             self._save_session()
             self.exit()
-        elif cmd == "/help":
-            self.chat.mount(Markdown(HELP, classes="assistant"))
-            self.chat.scroll_end(animate=False)
-        elif cmd == "/tools":
-            listing = "\n".join(
-                f"- `{t.name}`{'  ⚠ needs approval' if t.requires_permission else ''} — {t.description}"
-                for t in self.tools
-            )
-            self.chat.mount(Markdown(f"**tools**\n\n{listing}", classes="assistant"))
-            self.chat.scroll_end(animate=False)
-        elif cmd == "/clear":
-            self.action_clear()
-        elif cmd == "/lore":
-            self.config.lore = not self.config.lore
-            self.context.lore = self.config.lore
-            self.status.set_lore(self.config.lore)
-            self._note(f"lore {'engaged' if self.config.lore else 'disengaged'}")
-        elif cmd == "/model":
-            if arg:
-                self.config.model = arg
-                self.provider = Provider(self.config)
-                self.status.set_model(arg)
-                self._note(f"model → {arg}")
-            else:
-                self._note(f"model: {self.config.model}")
-        elif cmd == "/stage":
-            self._set_stage(arg)
-        elif cmd == "/scope":
-            self._scope_cmd(arg)
-        elif cmd == "/findings":
-            self._show_findings()
-        elif cmd == "/report":
-            self._report_cmd(arg)
-        elif cmd == "/sessions":
-            self._sessions_cmd()
-        elif cmd == "/resume":
-            self._resume_cmd(arg)
-        elif cmd == "/new":
-            self._new_session()
-        elif cmd == "/theme":
-            self._theme_cmd(arg)
-        elif cmd == "/config":
-            self._open_config()
+            return
+        handler = handlers.get(cmd)
+        if handler is not None:
+            handler()
+            return
+        # fuzzy "did you mean"
+        close = difflib.get_close_matches(cmd, _COMMANDS, n=3, cutoff=0.5)
+        if close:
+            self._note(f"unknown command: {cmd} — did you mean {', '.join(close)}?")
         else:
             self._note(f"unknown command: {cmd} — try /help")
+
+    def _tools_cmd(self) -> None:
+        listing = "\n".join(
+            f"- `{t.name}`{'  ⚠ needs approval' if t.requires_permission else ''} — {t.description}"
+            for t in self.tools
+        )
+        self._markdown(f"**tools**\n\n{listing}")
+
+    def _lore_cmd(self) -> None:
+        self.config.lore = not self.config.lore
+        self.context.lore = self.config.lore
+        self.status.set_lore(self.config.lore)
+        self._note(f"lore {'engaged' if self.config.lore else 'disengaged'}")
+
+    def _model_cmd(self, arg: str) -> None:
+        if arg:
+            self.config.model = arg
+            self.provider = Provider(self.config)
+            self.status.set_model(arg)
+            self._note(f"model → {arg}")
+            warning = self.config.model_warning()
+            if warning:
+                self._note("⚠ " + warning)
+        else:
+            self._note(f"model: {self.config.model}")
 
     def _theme_cmd(self, arg: str) -> None:
         name = arg.strip().lower()
@@ -262,6 +452,23 @@ class RiftorApp(App):
         self.config.save()
         self._note("config saved")
 
+    def _permissions_cmd(self, arg: str) -> None:
+        parts = arg.split()
+        if not parts:
+            self._markdown("**permissions**\n\n```\n" + self.permissions.describe() + "\n```")
+            return
+        sub, rest = parts[0].lower(), parts[1:]
+        if sub == "allow" and rest:
+            pattern = " ".join(rest[1:]) if len(rest) > 1 else None
+            self.permissions.add_allow_rule(rest[0], pattern)
+            self._note(f"allow rule added: {rest[0]} {pattern or ''}".strip())
+        elif sub == "deny" and rest:
+            pattern = " ".join(rest[1:]) if len(rest) > 1 else None
+            self.permissions.add_deny_rule(rest[0], pattern)
+            self._note(f"deny rule added: {rest[0]} {pattern or ''}".strip())
+        else:
+            self._note("usage: /permissions [allow <tool> [pattern] | deny <tool> [pattern]]")
+
     def _set_stage(self, arg: str) -> None:
         if not arg:
             cur = self.engagement.stage
@@ -274,16 +481,29 @@ class RiftorApp(App):
         if letter:
             self.engagement.set_stage(letter)
             self._refresh_status()
-            self._note(f"stage → {letter} ({STAGE_NAMES[letter]})")
+            self._stage_divider(letter)
         else:
             self._note(f"unknown stage: {arg} — use R/I/F/T or recon/intrusion/foothold/takeover")
+
+    def _stage_divider(self, letter: str) -> None:
+        """A scannable, color-coded divider marking a RIFT stage transition."""
+        p = self._pal()
+        colors = {"R": p["cyan"], "I": p["magenta"], "F": p["violet"], "T": p["danger"]}
+        color = colors.get(letter, p["cyan"])
+        line = Text()
+        line.append("──◢ ", style=color)
+        line.append(f"{letter} · {STAGE_NAMES[letter]}", style=f"bold {color}")
+        line.append(" ◣" + "─" * 30, style=color)
+        self.chat.mount(Static(line, classes="note"))
+        self._scroll_if_following()
 
     def _scope_cmd(self, arg: str) -> None:
         parts = arg.split()
         if not parts:
             ins = ", ".join(t.raw for t in self.engagement.scope.in_scope) or "(none)"
             outs = self.engagement.scope.out_of_scope
-            line = f"scope · enforce {'on' if self.engagement.enforce else 'off'} · in: {ins}"
+            mode = "dry-run" if self.engagement.dry_run else ("on" if self.engagement.enforce else "off")
+            line = f"scope · enforce {mode} · in: {ins}"
             if outs:
                 line += " · out: " + ", ".join(t.raw for t in outs)
             self._note(line)
@@ -306,42 +526,279 @@ class RiftorApp(App):
             self._note("scope cleared")
         elif sub == "on":
             self.engagement.set_enforce(True)
+            self.engagement.set_dry_run(False)
             self._note("scope enforcement ON")
         elif sub == "off":
             self.engagement.set_enforce(False)
             self._error("scope enforcement OFF — riftor will not block out-of-scope actions")
+        elif sub in ("dry", "dry-run"):
+            self.engagement.set_enforce(True)
+            self.engagement.set_dry_run(True)
+            self._note("scope dry-run ON — violations are warned but not blocked")
+        elif sub == "import" and rest:
+            self._scope_import(rest[0])
+        elif sub == "export":
+            self._scope_export(rest[0] if rest else None)
         else:
-            self._note("usage: /scope [add <t>|out <t>|rm <t>|clear|on|off]")
+            self._note(
+                "usage: /scope [add <t>|out <t>|rm <t>|clear|on|off|dry|import <file>|export [file]]"
+            )
         self._refresh_status()
 
+    def _scope_import(self, path: str) -> None:
+        p = Path(path).expanduser()
+        if not p.is_absolute():
+            p = self.workdir / p
+        try:
+            text = p.read_text(encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            self._error(f"scope import failed — {exc}")
+            return
+        added_in, added_out = self.engagement.import_scope(text)
+        self._note(f"scope imported: +{added_in} in, +{added_out} out (from {p})")
+
+    def _scope_export(self, path: str | None) -> None:
+        out = path or str(self.engagement.dir / "scope.txt")
+        p = Path(out).expanduser()
+        if not p.is_absolute():
+            p = self.workdir / p
+        try:
+            p.write_text(self.engagement.export_scope(), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            self._error(f"scope export failed — {exc}")
+            return
+        self._note(f"scope exported → {p}")
+
+    # ---- findings --------------------------------------------------------------
+    def _sorted_findings(self) -> list[dict]:
+        from riftor.engagement.report import report_data
+
+        return report_data(self.engagement)["findings"]
+
     def _show_findings(self) -> None:
-        findings = self.engagement.store.list_findings()
+        findings = self._sorted_findings()
         if not findings:
             self._note("no findings recorded yet")
             return
         rows = []
-        for i, f in enumerate(findings, 1):
-            host = f" — `{f['host']}`" if f["host"] else ""
-            rows.append(f"{i}. **[{f['severity']}]** {f['title']}{host}")
-        self.chat.mount(Markdown("**findings**\n\n" + "\n".join(rows), classes="assistant"))
-        self.chat.scroll_end(animate=False)
+        for f in findings:
+            host = f" — `{f['host']}`" if f.get("host") else ""
+            cvss = f" · CVSS {f['cvss_score']:.1f}" if f.get("cvss_score") else ""
+            tags = f"  ‹{f['tags']}›" if f.get("tags") else ""
+            rows.append(f"`#{f['id']}` **[{f['severity'].upper()}{cvss}]** {f['title']}{host}{tags}")
+        self._markdown("**findings** (severity-sorted)\n\n" + "\n".join(rows))
+
+    def _show_finding(self, arg: str) -> None:
+        try:
+            fid = int(arg.strip())
+        except ValueError:
+            self._note("usage: /finding <id> — see /findings")
+            return
+        f = self.engagement.store.get_finding(fid)
+        if not f:
+            self._note(f"no finding #{fid}")
+            return
+        lines = [f"**#{fid} · [{f['severity'].upper()}] {f['title']}**", ""]
+        for label, key in (
+            ("Host", "host"), ("CVSS", "cvss"), ("Tags", "tags"),
+            ("Evidence", "evidence"), ("Recommendation", "recommendation"), ("Notes", "notes"),
+        ):
+            if f.get(key):
+                lines.append(f"- **{label}:** {f[key]}")
+        self._markdown("\n".join(lines))
+
+    def _edit_finding_cmd(self, arg: str) -> None:
+        parts = arg.split()
+        if not parts:
+            self._note("usage: /edit-finding <id> field=value … (sev/severity, host, tags, notes, title)")
+            return
+        try:
+            fid = int(parts[0])
+        except ValueError:
+            self._note("usage: /edit-finding <id> field=value …")
+            return
+        alias = {"sev": "severity", "rec": "recommendation"}
+        fields: dict[str, str] = {}
+        for token in arg.split(maxsplit=1)[1].split() if len(arg.split()) > 1 else []:
+            if "=" not in token:
+                continue
+            key, _, value = token.partition("=")
+            key = alias.get(key.lower(), key.lower())
+            if key in ("title", "severity", "host", "evidence", "recommendation", "tags", "notes"):
+                fields[key] = value
+        if not fields:
+            self._note("nothing to change — use field=value (e.g. sev=high tags=fp)")
+            return
+        if self.engagement.store.update_finding(fid, **fields):
+            self.engagement.store.log_activity("finding_edit", f"#{fid} {', '.join(fields)}")
+            self._note(f"updated finding #{fid}: {', '.join(fields)}")
+        else:
+            self._note(f"no finding #{fid}")
+
+    def _delete_finding_cmd(self, arg: str) -> None:
+        try:
+            fid = int(arg.strip())
+        except ValueError:
+            self._note("usage: /delete-finding <id>")
+            return
+        if self.engagement.store.delete_finding(fid):
+            self.engagement.store.log_activity("finding_delete", f"#{fid}")
+            self._refresh_status()
+            self._note(f"deleted finding #{fid}")
+        else:
+            self._note(f"no finding #{fid}")
+
+    def _hosts_cmd(self) -> None:
+        hosts = self.engagement.store.list_hosts()
+        if not hosts:
+            self._note("no hosts recorded yet")
+            return
+        rows = [f"- `{h['host']}`" + (f" — {h['note']}" if h.get("note") else "") for h in hosts]
+        self._markdown("**hosts**\n\n" + "\n".join(rows))
+
+    def _services_cmd(self) -> None:
+        services = self.engagement.store.list_services()
+        if not services:
+            self._note("no services recorded yet")
+            return
+        rows = ["| Host | Port | Proto | Service | Version |", "| --- | --- | --- | --- | --- |"]
+        for s in services:
+            rows.append(
+                f"| {s.get('host', '')} | {s.get('port') or ''} | {s.get('proto', '')} "
+                f"| {s.get('service', '')} | {s.get('version', '')} |"
+            )
+        self._markdown("**services**\n\n" + "\n".join(rows))
 
     def _report_cmd(self, arg: str) -> None:
         fmt = (arg or "both").strip().lower()
-        if fmt not in ("md", "html", "both"):
-            self._note("usage: /report [md|html|both]")
+        if fmt not in ("md", "html", "json", "sarif", "both", "all"):
+            self._note("usage: /report [md|html|json|sarif|both|all]")
             return
         try:
             paths = write_reports(self.engagement, fmt)
         except Exception as exc:  # noqa: BLE001
             self._error(f"report failed — {exc}")
             return
+        self.engagement.store.log_activity("report", fmt)
         self._note("report written: " + ", ".join(str(p) for p in paths))
 
-    # ---- sessions --------------------------------------------------------------
-    def _save_session(self) -> None:
+    def _timeline_cmd(self) -> None:
+        events = self.engagement.store.list_activity(limit=100)
+        if not events:
+            self._note("no activity recorded yet")
+            return
+        rows = []
+        for e in events:
+            when = time.strftime("%H:%M:%S", time.localtime(e.get("ts", 0)))
+            rows.append(f"`{when}` **{e['event']}** {e.get('detail', '')}")
+        self._markdown("**timeline**\n\n" + "\n".join(rows))
+
+    def _audit_cmd(self) -> None:
+        entries = self.audit.tail(30)
+        if not entries:
+            self._note("no audit entries yet")
+            return
+        rows = []
+        for e in entries:
+            when = time.strftime("%H:%M:%S", time.localtime(e.get("ts", 0)))
+            flag = "✓" if e.get("allowed") else "✗"
+            err = " ⚠" if e.get("is_error") else ""
+            rows.append(f"`{when}` {flag} **{e.get('tool', '?')}** {e.get('preview', '')[:80]}{err}")
+        self._markdown("**audit log** (recent)\n\n" + "\n".join(rows))
+
+    def _export_cmd(self) -> None:
+        import json
+        import shutil
+
+        out_dir = self.engagement.dir / "exports"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        stage = out_dir / f"engagement-{stamp}"
+        stage.mkdir(exist_ok=True)
         try:
-            sessions.save(self.workdir, self.session_id, self.context.dump(), self.config.model)
+            (stage / "engagement.json").write_text(self.engagement.store.dump_json(), encoding="utf-8")
+            db = self.engagement.dir / "engagement.db"
+            if db.exists():
+                shutil.copy2(db, stage / "engagement.db")
+            manifest = {
+                "tool": "riftor",
+                "exported": stamp,
+                "stage": self.engagement.stage,
+                "findings": self.engagement.findings_count(),
+                "model": self.config.model,
+            }
+            (stage / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+            archive = shutil.make_archive(str(stage), "zip", root_dir=str(stage))
+            shutil.rmtree(stage, ignore_errors=True)
+        except Exception as exc:  # noqa: BLE001
+            self._error(f"export failed — {exc}")
+            return
+        self.engagement.store.log_activity("export", archive)
+        self._note(f"engagement exported → {archive}")
+
+    # ---- conversation utilities ------------------------------------------------
+    def _cost_cmd(self) -> None:
+        u = self.usage
+        cost = f" · ${u.cost:.4f}" if u.cost else ""
+        pct = int(self.context.estimated_tokens() / self._context_window() * 100)
+        self._note(
+            f"session usage: {u.prompt_tokens} in + {u.completion_tokens} out = "
+            f"{u.total_tokens} tokens{cost} · context ~{pct}% of window"
+        )
+
+    def _retry_cmd(self) -> None:
+        last = self.context.pop_last_user_turn()
+        if last is None:
+            self._note("nothing to retry")
+            return
+        self._note("retrying last turn…")
+        self._add_user(last)
+        self._agent(last)
+
+    def _continue_cmd(self, arg: str) -> None:
+        extra = 16
+        if arg.strip().isdigit():
+            extra = int(arg.strip())
+        self._note(f"continuing — extending the step budget by {extra}")
+        self._agent("Continue from where you left off.", extra_steps=extra)
+
+    def _compact_cmd(self) -> None:
+        changed = self.context.compact()
+        self._refresh_usage()
+        self._note(f"compacted {changed} old tool result(s) to free context")
+
+    def _copy_cmd(self) -> None:
+        if not self._last_output:
+            self._note("nothing to copy yet")
+            return
+        try:
+            self.copy_to_clipboard(self._last_output)
+            self._note(f"copied {len(self._last_output)} chars to clipboard")
+        except Exception as exc:  # noqa: BLE001
+            self._error(f"copy failed — {exc}")
+
+    def _show_result(self, arg: str) -> None:
+        try:
+            rid = int(arg.strip())
+        except ValueError:
+            ids = ", ".join(f"#{i}" for i in sorted(self._tool_results)) or "(none)"
+            self._note(f"usage: /show <id> — available: {ids}")
+            return
+        content = self._tool_results.get(rid)
+        if content is None:
+            self._note(f"no stored result #{rid}")
+            return
+        self.chat.mount(Static(Text(content), classes="tool-result"))
+        self._last_output = content
+        self._scroll_if_following()
+
+    # ---- sessions --------------------------------------------------------------
+    def _save_session(self, complete: bool = True) -> None:
+        try:
+            sessions.save(
+                self.workdir, self.session_id, self.context.dump(), self.config.model,
+                complete=complete,
+            )
         except Exception:  # noqa: BLE001 — persistence must never crash the app
             pass
 
@@ -353,9 +810,9 @@ class RiftorApp(App):
         lines = []
         for s in rows:
             marker = "→ " if s["id"] == self.session_id else "  "
-            lines.append(f"{marker}`{s['id']}` · {s['messages']} msgs · {s['title']}")
-        self.chat.mount(Markdown("**sessions**\n\n" + "\n".join(lines), classes="assistant"))
-        self.chat.scroll_end(animate=False)
+            flag = "" if s.get("complete", True) else " ⚠"
+            lines.append(f"{marker}`{s['id']}`{flag} · {s['messages']} msgs · {s['title']}")
+        self._markdown("**sessions**\n\n" + "\n".join(lines))
 
     def _resume_cmd(self, arg: str) -> None:
         sid = arg.strip()
@@ -377,6 +834,8 @@ class RiftorApp(App):
         self._save_session()
         self.session_id = sessions.new_id()
         self.context.clear()
+        self.usage = Usage()
+        self._refresh_usage()
         self.chat.remove_children()
         self._note(f"new session {self.session_id}")
 
@@ -404,6 +863,8 @@ class RiftorApp(App):
 
     def action_clear(self) -> None:
         self.context.clear()
+        self.usage = Usage()
+        self._refresh_usage()
         self.chat.remove_children()
         self._note("conversation cleared")
 
@@ -422,16 +883,43 @@ class RiftorApp(App):
         while isinstance(self.screen, ConfirmScreen):
             self.pop_screen()
 
+    # ---- rate limiting ---------------------------------------------------------
+    async def _rate_gate(self) -> None:
+        limit = self.config.rate_limit_per_min
+        if limit <= 0:
+            return
+        import asyncio
+
+        now = time.monotonic()
+        self._rate_times = [t for t in self._rate_times if now - t < 60.0]
+        if len(self._rate_times) >= limit:
+            wait = 60.0 - (now - self._rate_times[0])
+            if wait > 0:
+                self._note(f"rate limit ({limit}/min) — waiting {wait:.0f}s")
+                await asyncio.sleep(wait)
+        self._rate_times.append(time.monotonic())
+
     # ---- agent loop ------------------------------------------------------------
     @work(exclusive=True)
-    async def _agent(self, user_text: str) -> None:
+    async def _agent(self, user_text: str, extra_steps: int = 0) -> None:
         self._close_modals()  # a prior run may have been cancelled mid-prompt
-        self.context.add_user(user_text)
+        self._autoscroll = True
+        if user_text != "Continue from where you left off.":
+            self.context.add_user(user_text)
+            self._last_user_text = user_text
         self.status.set_busy(True)
+        budget = self.max_steps + extra_steps
         try:
-            for _ in range(self.max_steps):
+            for step in range(budget):
+                self._save_session(complete=False)  # crash-safe checkpoint
+                await self._rate_gate()
                 turn = await self._assistant_turn()
                 self.context.add_message(turn.assistant_message)
+                self.usage.add(turn.usage)
+                self._refresh_usage()
+                pct = int(self.context.estimated_tokens() / self._context_window() * 100)
+                if pct >= 80:
+                    self._note(f"⚠ context ~{pct}% of window — /compact or /clear soon")
                 if not turn.tool_calls:
                     if not turn.text.strip():
                         self._note("(no output)")
@@ -439,17 +927,19 @@ class RiftorApp(App):
                 for call in turn.tool_calls:
                     await self._run_tool(call)
             else:
-                self._note(f"reached step limit ({self.max_steps}); stopping")
+                self._note(
+                    f"reached step limit ({budget}); stopping — /continue to extend"
+                )
+        except ProviderError as exc:
+            self._error(f"rift collapsed [{exc.kind}] — {exc}")
         except Exception as exc:  # noqa: BLE001
             self._error(f"rift collapsed — {exc}")
         finally:
             self.status.set_busy(False)
             self.chat.scroll_end(animate=False)
-            self._save_session()
+            self._save_session(complete=True)
 
     async def _assistant_turn(self) -> Turn:
-        # Guarantee a valid history: any dangling tool_use (from an interrupted
-        # or cancelled turn) gets a synthetic result before we call the model.
         self.context.repair()
 
         bubble = Markdown("", classes="assistant")
@@ -466,7 +956,7 @@ class RiftorApp(App):
                 now = time.monotonic()
                 if now - last_render > 0.08:
                     await bubble.update("".join(buffer))
-                    self.chat.scroll_end(animate=False)
+                    self._scroll_if_following()
                     last_render = now
             elif event == "done":
                 turn = payload  # type: ignore[assignment]
@@ -474,9 +964,10 @@ class RiftorApp(App):
         text = "".join(buffer).strip()
         if text:
             await bubble.update(text)
+            self._last_output = text
         else:
             await bubble.remove()
-        self.chat.scroll_end(animate=False)
+        self._scroll_if_following()
         return turn or Turn(text=text, assistant_message={"role": "assistant", "content": text})
 
     async def _run_tool(self, call: ToolCall) -> None:
@@ -497,11 +988,33 @@ class RiftorApp(App):
             probe = " ".join(str(v) for v in call.arguments.values())
             scope_warning = self.engagement.violations(probe)
 
-        if scope_warning or self.permissions.needs_prompt(tool.name, tool.requires_permission):
-            decision = await self.push_screen_wait(
-                ConfirmScreen(tool.name, preview, scope_warning=scope_warning)
+        # dry-run: warn but don't block
+        if scope_warning and self.engagement.dry_run:
+            self._note(f"⚠ dry-run: out of scope — {', '.join(scope_warning)} (allowed)")
+            scope_warning = []
+
+        # hard deny rules (e.g. bash rm -rf) — refuse without prompting
+        if self.permissions.is_denied(tool.name, preview):
+            reason = "blocked by a deny rule"
+            await self._show_tool_result(reason, is_error=True)
+            self.context.add_tool_result(
+                call.id,
+                "[blocked by policy] This action matches a deny rule and was refused. "
+                "Do not retry it; propose a safer alternative.",
             )
-            if decision == "deny":
+            self.audit.record(tool.name, preview, allowed=False)
+            return
+
+        if scope_warning or self.permissions.needs_prompt(
+            tool.name, tool.requires_permission, preview
+        ):
+            detail = tool.confirm_detail(call.arguments, self.toolctx)
+            decision = await self.push_screen_wait(
+                ConfirmScreen(tool.name, preview, scope_warning=scope_warning, detail=detail)
+            )
+            if decision in ("deny", "always_deny"):
+                if decision == "always_deny":
+                    self.permissions.add_deny_rule(tool.name)
                 reason = "blocked — out of scope" if scope_warning else "denied by operator"
                 await self._show_tool_result(reason, is_error=True)
                 if scope_warning:
@@ -519,6 +1032,9 @@ class RiftorApp(App):
                 return
             if decision == "session":
                 self.permissions.allow_for_session(tool.name)
+            elif decision == "always":
+                self.permissions.add_allow_rule(tool.name)
+            # "once" → approve this single call, remember nothing
 
         audit_preview = preview + (" [scope-override]" if scope_warning else "")
         start = time.monotonic()
@@ -526,7 +1042,7 @@ class RiftorApp(App):
             result = await tool.execute(call.arguments, self.toolctx)
         except Exception as exc:  # noqa: BLE001
             result = ToolResult(f"error: {exc}", is_error=True)
-        result = result.truncated()
+        result = result.truncated(self.config.max_result_chars)
         duration = time.monotonic() - start
 
         self.audit.record(
@@ -539,6 +1055,7 @@ class RiftorApp(App):
         )
         await self._show_tool_result(result.content, is_error=result.is_error)
         self.context.add_tool_result(call.id, result.content)
+        self._last_output = result.content
         self._refresh_status()
 
     # ---- tool rendering --------------------------------------------------------
@@ -552,10 +1069,13 @@ class RiftorApp(App):
             line.append(preview, style=p["muted"])
         await self._mount(Static(line, classes="tool"))
 
-    async def _show_tool_result(self, content: str, is_error: bool = False, max_lines: int = 25) -> None:
+    async def _show_tool_result(self, content: str, is_error: bool = False) -> None:
+        max_lines = self.config.result_preview_lines
         lines = content.splitlines() or [""]
         shown = "\n".join(lines[:max_lines])
         if len(lines) > max_lines:
-            shown += f"\n…(+{len(lines) - max_lines} more lines)"
+            rid = len(self._tool_results) + 1
+            self._tool_results[rid] = content
+            shown += f"\n…(+{len(lines) - max_lines} more lines · /show {rid})"
         classes = "tool-result error" if is_error else "tool-result"
         await self._mount(Static(Text(shown), classes=classes))

--- a/riftor/tui/widgets.py
+++ b/riftor/tui/widgets.py
@@ -30,7 +30,11 @@ class StatusBar(Static):
         self.busy = False
         self.scope_count = 0
         self.enforce = True
+        self.dry_run = False
         self.findings = 0
+        self.tokens = 0
+        self.cost = 0.0
+        self.ctx_pct = 0
 
     def on_mount(self) -> None:
         self.refresh_bar()
@@ -52,13 +56,23 @@ class StatusBar(Static):
             self.stage = stage
             self.refresh_bar()
 
-    def set_scope(self, count: int, enforce: bool) -> None:
+    def set_scope(self, count: int, enforce: bool, dry_run: bool = False) -> None:
         self.scope_count = count
         self.enforce = enforce
+        self.dry_run = dry_run
         self.refresh_bar()
 
     def set_findings(self, count: int) -> None:
         self.findings = count
+        self.refresh_bar()
+
+    def set_usage(self, tokens: int, cost: float) -> None:
+        self.tokens = tokens
+        self.cost = cost
+        self.refresh_bar()
+
+    def set_context(self, pct: int) -> None:
+        self.ctx_pct = pct
         self.refresh_bar()
 
     def refresh_bar(self) -> None:
@@ -74,11 +88,23 @@ class StatusBar(Static):
         t.append("   scope:", style=p["dim"])
         if self.scope_count:
             t.append(str(self.scope_count), style=p["muted"])
-            t.append("" if self.enforce else " (off)", style=p["danger"])
+            if self.dry_run:
+                t.append(" (dry)", style=p["magenta"])
+            elif not self.enforce:
+                t.append(" (off)", style=p["danger"])
         else:
             t.append("none", style=p["danger"] if self.enforce else p["dim"])
         t.append("   finds:", style=p["dim"])
         t.append(str(self.findings), style=p["magenta"] if self.findings else p["muted"])
+        if self.tokens:
+            t.append("   tok:", style=p["dim"])
+            tok_label = f"{self.tokens / 1000:.1f}k" if self.tokens >= 1000 else str(self.tokens)
+            t.append(tok_label, style=p["muted"])
+            if self.cost:
+                t.append(f" ${self.cost:.3f}", style=p["muted"])
+        if self.ctx_pct >= 60:
+            t.append("   ctx:", style=p["dim"])
+            t.append(f"{self.ctx_pct}%", style=p["danger"] if self.ctx_pct >= 80 else p["magenta"])
         t.append("   model:", style=p["dim"])
         t.append(self.model, style=p["muted"])
         t.append("   lore:", style=p["dim"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared pytest fixtures for riftor's offline test suite."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from riftor.engagement import Engagement
+from riftor.tools import ToolContext
+
+
+@pytest.fixture
+def tmp_workdir():
+    with tempfile.TemporaryDirectory(prefix="riftor-test-") as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def engagement(tmp_workdir):
+    return Engagement(tmp_workdir)
+
+
+@pytest.fixture
+def toolctx(tmp_workdir, engagement):
+    return ToolContext(workdir=tmp_workdir, engagement=engagement)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,60 @@
+"""Agent layer: error classification, usage accounting, context compaction."""
+
+from __future__ import annotations
+
+from riftor.agent.context import Context
+from riftor.agent.provider import Usage, classify_error
+
+
+def test_classify_auth():
+    err = classify_error(Exception("AuthenticationError: invalid x-api-key (401)"))
+    assert err.kind == "auth" and not err.retryable
+
+
+def test_classify_rate_limit():
+    err = classify_error(Exception("RateLimitError: 429 Too Many Requests"))
+    assert err.kind == "rate_limit" and err.retryable
+
+
+def test_classify_server_retryable():
+    err = classify_error(Exception("APIError: 503 overloaded"))
+    assert err.kind == "server" and err.retryable
+
+
+def test_classify_context():
+    err = classify_error(Exception("maximum context length is 200000 tokens"))
+    assert err.kind == "context" and not err.retryable
+
+
+def test_usage_add():
+    u = Usage(prompt_tokens=10, completion_tokens=5, cost=0.01)
+    u.add(Usage(prompt_tokens=3, completion_tokens=2, cost=0.02))
+    assert u.total_tokens == 20
+    assert round(u.cost, 4) == 0.03
+
+
+def test_context_token_estimate_and_compact():
+    ctx = Context(lore=False)
+    ctx.add_user("scan it")
+    ctx.add_message({"role": "assistant", "content": None, "tool_calls": [
+        {"id": "a", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+    ]})
+    ctx.add_tool_result("a", "X" * 5000)
+    ctx.add_user("again")  # recent turns kept
+    before = ctx.estimated_tokens()
+    changed = ctx.compact(keep_recent=1, clip=100)
+    assert changed == 1
+    assert ctx.estimated_tokens() < before
+
+
+def test_pop_last_user_turn():
+    ctx = Context(lore=False)
+    ctx.add_user("first")
+    ctx.add_assistant("reply")
+    ctx.add_user("second")
+    ctx.add_assistant("reply2")
+    text = ctx.pop_last_user_turn()
+    assert text == "second"
+    # only the first exchange remains
+    roles = [m["role"] for m in ctx._messages]
+    assert roles == ["user", "assistant"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,57 @@
+"""Config: secure file perms, model validation, credential detection."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import riftor.config as cfgmod
+from riftor.config import Config
+
+
+def test_save_is_owner_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfgmod, "CONFIG_PATH", tmp_path / "config.toml")
+    cfg = Config(api_key="sk-secret")
+    cfg.save()
+    mode = stat.S_IMODE(os.stat(cfgmod.CONFIG_PATH).st_mode)
+    assert mode == 0o600, oct(mode)
+    assert "sk-secret" in cfgmod.CONFIG_PATH.read_text()
+
+
+def test_model_warning():
+    assert Config(model="anthropic/claude-sonnet-4-6").model_warning() is None
+    assert Config(model="totally/madeup-xyz").model_warning() is not None
+
+
+def test_provider_env():
+    assert Config(model="anthropic/claude-sonnet-4-6").provider_env() == "ANTHROPIC_API_KEY"
+    assert Config(model="openai/gpt-4o").provider_env() == "OPENAI_API_KEY"
+
+
+def test_has_credentials(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert not Config(model="anthropic/claude-sonnet-4-6").has_credentials()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-x")
+    assert Config(model="anthropic/claude-sonnet-4-6").has_credentials()
+    # local ollama always has "credentials"
+    assert Config(model="ollama_chat/llama3").has_credentials()
+    # explicit key
+    assert Config(model="anthropic/claude-sonnet-4-6", api_key="k").has_credentials()
+
+
+def test_roundtrip_new_fields(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfgmod, "CONFIG_PATH", tmp_path / "config.toml")
+    Config(max_steps=24, rate_limit_per_min=10, max_result_chars=5000).save()
+    loaded = Config.load()
+    assert loaded.max_steps == 24
+    assert loaded.rate_limit_per_min == 10
+    assert loaded.max_result_chars == 5000
+
+
+def test_load_keybindings(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfgmod, "KEYBINDINGS_PATH", tmp_path / "keybindings.toml")
+    assert cfgmod.load_keybindings() == {}
+    (tmp_path / "keybindings.toml").write_text('[keybindings]\nclear = "ctrl+k"\n')
+    assert cfgmod.load_keybindings() == {"clear": "ctrl+k"}

--- a/tests/test_engagement.py
+++ b/tests/test_engagement.py
@@ -1,0 +1,75 @@
+"""Engagement store: dedup, edit/delete, tags/notes, activity log, export."""
+
+from __future__ import annotations
+
+
+def test_finding_dedup_skip(engagement):
+    fid1, a1 = engagement.add_finding_dedup(
+        dedup="skip", title="SQLi", severity="high", host="10.0.0.5", evidence="x"
+    )
+    fid2, a2 = engagement.add_finding_dedup(
+        dedup="skip", title="SQLi", severity="high", host="10.0.0.5", evidence="x"
+    )
+    assert a1 == "added" and a2 == "skipped"
+    assert fid1 == fid2
+    assert engagement.findings_count() == 1
+
+
+def test_finding_dedup_allow_all(engagement):
+    engagement.add_finding_dedup(dedup="allow-all", title="X", severity="low", host="h")
+    engagement.add_finding_dedup(dedup="allow-all", title="X", severity="low", host="h")
+    assert engagement.findings_count() == 2
+
+
+def test_finding_dedup_merge(engagement):
+    fid, _ = engagement.add_finding_dedup(
+        dedup="skip", title="X", severity="low", host="h", evidence="e"
+    )
+    fid2, action = engagement.add_finding_dedup(
+        dedup="merge", title="X", severity="low", host="h", evidence="e",
+        recommendation="patch it",
+    )
+    assert action == "merged" and fid2 == fid
+    row = engagement.store.get_finding(fid)
+    assert row["recommendation"] == "patch it"
+
+
+def test_edit_and_delete_finding(engagement):
+    fid = engagement.add_finding(title="Weak TLS", severity="medium", host="h")
+    assert engagement.store.update_finding(fid, severity="high", tags="needs-validation")
+    row = engagement.store.get_finding(fid)
+    assert row["severity"] == "high" and row["tags"] == "needs-validation"
+    assert engagement.store.delete_finding(fid)
+    assert engagement.store.get_finding(fid) is None
+    assert not engagement.store.delete_finding(fid)  # already gone
+
+
+def test_service_dedup(engagement):
+    _id, a1 = engagement.add_service_dedup(dedup="skip", host="h", port=443, proto="tcp")
+    _id2, a2 = engagement.add_service_dedup(dedup="skip", host="h", port=443, proto="tcp")
+    assert a1 == "added" and a2 == "skipped"
+
+
+def test_activity_log(engagement):
+    engagement.add_scope("example.com", "in")
+    engagement.set_stage("I")
+    engagement.add_finding(title="X", severity="low")
+    events = {e["event"] for e in engagement.store.list_activity()}
+    assert {"scope_add", "stage", "finding_add"} <= events
+
+
+def test_scope_import_export(engagement):
+    added_in, added_out = engagement.import_scope(
+        "example.com\n# a comment\n10.0.0.0/24\nout:admin.example.com\n"
+    )
+    assert added_in == 2 and added_out == 1
+    text = engagement.export_scope()
+    assert "example.com" in text and "out:admin.example.com" in text
+
+
+def test_export_dict_roundtrip(engagement):
+    engagement.add_scope("example.com", "in")
+    engagement.add_finding(title="X", severity="high", host="h")
+    snap = engagement.store.export_dict()
+    assert snap["findings"][0]["title"] == "X"
+    assert {"target": "example.com", "mode": "in"} in snap["scope"]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,31 @@
+"""Scan parsers: structured extraction plus the new skip/error diagnostics."""
+
+from __future__ import annotations
+
+from riftor.engagement.parsers import parse
+
+
+def test_nmap_services():
+    s = parse("nmap", (
+        "Nmap scan report for h (10.0.0.5)\n"
+        "PORT STATE SERVICE VERSION\n"
+        "22/tcp open ssh OpenSSH 8.2\n443/tcp closed https\n"
+    ))
+    assert len(s.services) == 1 and s.services[0]["port"] == 22
+
+
+def test_httpx_skip_count():
+    s = parse("httpx", "https://example.com [200]\nnot-a-url line here\n")
+    assert len(s.services) == 1
+    assert s.skipped == 1
+
+
+def test_nuclei_json_error_count():
+    s = parse("nuclei", '{"broken json\n[tpl] [http] [high] https://x\n')
+    assert s.json_errors == 1
+    assert len(s.findings) == 1  # the valid bracket line still parses
+
+
+def test_nuclei_severity():
+    s = parse("nuclei", "[CVE-x] [http] [critical] https://x/y\n")
+    assert s.findings[0]["severity"] == "critical"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,52 @@
+"""Permission engine: deny rules, allow rules, session grants, persistence."""
+
+from __future__ import annotations
+
+from riftor.safety.permissions import Permissions
+
+
+def test_default_deny_blocks_rm_rf():
+    perms = Permissions()
+    assert perms.is_denied("bash", "rm -rf /tmp/x")
+    assert perms.is_denied("bash", "dd if=/dev/zero of=/dev/sda")
+    assert not perms.is_denied("bash", "ls -la")
+
+
+def test_allow_rule_skips_prompt():
+    perms = Permissions(allow=[{"tool": "bash"}])
+    assert not perms.needs_prompt("bash", True, "nmap -sV host")
+    assert perms.is_allowed("bash", "anything")
+
+
+def test_pattern_allow():
+    perms = Permissions(allow=[{"tool": "bash", "pattern": r"^nmap\b"}])
+    assert perms.is_allowed("bash", "nmap -sV host")
+    assert not perms.is_allowed("bash", "curl http://x")
+
+
+def test_session_grant():
+    perms = Permissions()
+    assert perms.needs_prompt("write", True, "a.txt")
+    perms.allow_for_session("write")
+    assert not perms.needs_prompt("write", True, "a.txt")
+
+
+def test_no_prompt_when_not_required():
+    perms = Permissions()
+    assert not perms.needs_prompt("read", False, "a.txt")
+
+
+def test_persistence_roundtrip(tmp_path):
+    path = tmp_path / "permissions.toml"
+    perms = Permissions.load(path)
+    perms._path = path
+    perms.add_allow_rule("bash", r"^nmap\b")
+    perms.add_deny_rule("bash", r"shutdown")
+    reloaded = Permissions.load(path)
+    assert reloaded.is_allowed("bash", "nmap -p- host")
+    assert reloaded.is_denied("bash", "shutdown now")
+
+
+def test_load_missing_keeps_defaults(tmp_path):
+    perms = Permissions.load(tmp_path / "nope.toml")
+    assert perms.is_denied("bash", "rm -rf /")  # safe defaults preserved

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,73 @@
+"""Report rendering: markdown, HTML, JSON, SARIF, and the executive summary."""
+
+from __future__ import annotations
+
+import json
+
+
+def _seed(engagement):
+    engagement.add_scope("example.com", "in")
+    engagement.add_service(host="10.0.0.5", port=443, service="https", version="nginx")
+    engagement.add_finding(
+        title="SQL Injection", severity="high", host="10.0.0.5",
+        evidence="' OR 1=1 --", recommendation="parameterize",
+        tags="needs-validation", notes="found via sqlmap",
+        cvss="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+    )
+
+
+def test_markdown_has_exec_summary_and_tags(engagement):
+    from riftor.engagement.report import build_markdown, report_data
+
+    _seed(engagement)
+    md = build_markdown(report_data(engagement))
+    assert "Executive summary" in md
+    assert "needs-validation" in md and "found via sqlmap" in md
+    assert "9.8" in md  # cvss derived
+
+
+def test_json_report(engagement):
+    from riftor.engagement.report import build_json, report_data
+
+    _seed(engagement)
+    payload = json.loads(build_json(report_data(engagement)))
+    assert payload["tool"] == "riftor"
+    assert payload["findings"][0]["cvss_score"] == 9.8
+    assert payload["summary"]["total"] == 1
+
+
+def test_sarif_report(engagement):
+    from riftor.engagement.report import build_sarif, report_data
+
+    _seed(engagement)
+    sarif = json.loads(build_sarif(report_data(engagement)))
+    assert sarif["version"] == "2.1.0"
+    run = sarif["runs"][0]
+    assert run["tool"]["driver"]["name"] == "riftor"
+    assert run["results"][0]["level"] == "error"  # high → error
+
+
+def test_write_reports_all(engagement, tmp_workdir):
+    from riftor.engagement.report import write_reports
+
+    _seed(engagement)
+    paths = write_reports(engagement, "all")
+    suffixes = sorted(p.suffix for p in paths)
+    assert suffixes == [".html", ".json", ".md", ".sarif"]
+    assert all(p.exists() for p in paths)
+
+
+def test_unknown_format_raises(engagement):
+    import pytest
+
+    from riftor.engagement.report import write_reports
+
+    with pytest.raises(ValueError):
+        write_reports(engagement, "pdf")
+
+
+def test_exec_summary_empty(engagement):
+    from riftor.engagement.report import report_data
+
+    data = report_data(engagement)
+    assert "No findings" in data["exec_summary"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,26 @@
+"""Session persistence: round-trip plus the crash-safe ``complete`` flag."""
+
+from __future__ import annotations
+
+from riftor.agent import session
+
+
+def test_save_load_roundtrip(tmp_workdir):
+    msgs = [{"role": "user", "content": "enumerate"}, {"role": "assistant", "content": "ok"}]
+    session.save(tmp_workdir, "20260101-000000", msgs, "anthropic/claude-sonnet-4-6")
+    loaded = session.load(tmp_workdir, "20260101-000000")
+    assert loaded["messages"] == msgs
+    assert loaded["title"] == "enumerate"
+    assert loaded["complete"] is True
+
+
+def test_incomplete_flag(tmp_workdir):
+    session.save(tmp_workdir, "sid", [{"role": "user", "content": "x"}], "m", complete=False)
+    rows = session.list_sessions(tmp_workdir)
+    assert rows[0]["complete"] is False
+
+
+def test_atomic_write_leaves_no_tmp(tmp_workdir):
+    session.save(tmp_workdir, "sid", [{"role": "user", "content": "x"}], "m")
+    leftovers = list((tmp_workdir / ".riftor" / "sessions").glob("*.tmp"))
+    assert not leftovers

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,79 @@
+"""Tool behavior: diff preview, finding tools, import dedup, list_hosts."""
+
+from __future__ import annotations
+
+import pytest
+
+from riftor import tools
+
+
+@pytest.mark.asyncio
+async def test_write_then_edit_diff_preview(toolctx, tmp_workdir):
+    write = tools.get("write")
+    (tmp_workdir / "a.txt").write_text("line one\nline two\n")
+    detail = tools.get("edit").confirm_detail(
+        {"path": "a.txt", "old_string": "line two", "new_string": "line 2"}, toolctx
+    )
+    assert detail and "-line two" in detail and "+line 2" in detail
+
+    new_file_detail = write.confirm_detail({"path": "b.txt", "content": "fresh\n"}, toolctx)
+    assert "new file" in new_file_detail
+
+
+@pytest.mark.asyncio
+async def test_edit_finding_tool(toolctx):
+    eng = toolctx.engagement
+    fid = eng.add_finding(title="X", severity="low", host="h")
+    r = await tools.get("edit_finding").execute(
+        {"id": fid, "severity": "high", "tags": "fp"}, toolctx
+    )
+    assert not r.is_error
+    assert eng.store.get_finding(fid)["severity"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_edit_finding_bad_severity(toolctx):
+    fid = toolctx.engagement.add_finding(title="X", severity="low")
+    r = await tools.get("edit_finding").execute({"id": fid, "severity": "spicy"}, toolctx)
+    assert r.is_error
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_tool(toolctx):
+    eng = toolctx.engagement
+    fid = eng.add_finding(title="X", severity="low")
+    r = await tools.get("delete_finding").execute({"id": fid}, toolctx)
+    assert not r.is_error
+    r2 = await tools.get("delete_finding").execute({"id": fid}, toolctx)
+    assert r2.is_error  # already gone
+
+
+@pytest.mark.asyncio
+async def test_import_scan_dedup(toolctx):
+    eng = toolctx.engagement
+    out = (
+        "Nmap scan report for h (10.0.0.9)\n"
+        "PORT STATE SERVICE VERSION\n22/tcp open ssh OpenSSH\n"
+    )
+    r1 = await tools.get("import_scan").execute({"tool": "nmap", "output": out}, toolctx)
+    assert "1 service" in r1.content
+    r2 = await tools.get("import_scan").execute({"tool": "nmap", "output": out}, toolctx)
+    assert "skipped" in r2.content
+    assert len(eng.store.list_services()) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_hosts_tool(toolctx):
+    eng = toolctx.engagement
+    eng.add_service(host="10.0.0.5", port=443, service="https")
+    r = await tools.get("list_hosts").execute({}, toolctx)
+    assert "10.0.0.5" in r.content
+
+
+@pytest.mark.asyncio
+async def test_record_finding_dedup_skip(toolctx):
+    rf = tools.get("record_finding")
+    await rf.execute({"title": "Dup", "severity": "high", "host": "h"}, toolctx)
+    r = await rf.execute({"title": "Dup", "severity": "high", "host": "h"}, toolctx)
+    assert "skipped" in r.content
+    assert toolctx.engagement.findings_count() == 1

--- a/todo.md
+++ b/todo.md
@@ -102,6 +102,44 @@ The agent tracks the current stage; the TUI shows `[R·I·F·T]` in the status b
 - [ ] Docs site
 - [ ] Launch
 
+### Phase 6 — Quality of life  ✅
+Driven by a verified QoL audit of the codebase. Everything below is implemented,
+tested (pytest + headless smoke), type-checked (pyright) and lint-clean.
+
+**UX / interaction**
+- [x] Input history recall (`↑/↓`), fuzzy "did you mean" on unknown commands
+- [x] Keyboard chat navigation (`PgUp/PgDn`, `Ctrl+Home/End`) + sticky autoscroll
+- [x] `/copy` (last output) + restored clipboard; `/show <id>` expands truncated results
+- [x] Command palette (`Ctrl+P`); colored RIFT stage-transition dividers
+- [x] Expanded `/help` with examples; configurable truncation/preview limits
+
+**Trust & safety**
+- [x] Persistent granular permissions (`permissions.toml`: allow/deny + regex
+      patterns); real "allow once" vs session vs **always**/**never**
+- [x] Default deny rules for destructive bash (`rm -rf`, `dd of=/dev/…`, `mkfs`, fork bomb)
+- [x] Diff/new-file preview in the approval modal for write/edit
+- [x] Config written `0600`; `/permissions`, `/audit` (with gzip log rotation)
+- [x] Scope: `dry-run` mode, `import`/`export`, `--scope-file` preload
+
+**Agent loop**
+- [x] Provider retry/backoff + classified errors (`auth`/`rate_limit`/`context`/…); `/retry`
+- [x] Token + cost meter in the status bar; `/cost`; context-window gauge + 80% warning
+- [x] Crash-safe checkpoints (atomic save each step) + incomplete-session detection
+- [x] `/continue [N]` step extension; `/compact` shrinks old tool output
+
+**Engagement & reporting**
+- [x] Edit/delete findings (`/edit-finding`, `/delete-finding` + agent tools); tags + notes
+- [x] Import dedup (skip/merge/allow-all) + richer `import_scan` diagnostics
+- [x] `/hosts`, `/services`, `/timeline` (activity log), `/export` (zip archive)
+- [x] Reports gain JSON + **SARIF** export and an executive summary; severity-sorted `/findings`
+
+**Onboarding & contributors**
+- [x] Graceful first-run when no API key; model-id validation; configurable keybindings
+- [x] Headless one-shot mode (`-p/--prompt`, `--headless`) + `--model/--workdir/--api-key`
+- [x] `tests/` pytest suite + fixtures; pyright + pytest wired into CI
+- [x] `.pre-commit-config.yaml`, `Makefile`, shell completions, man page, `docs/configuration.md`
+- [x] Docker tool-variant (`--build-arg INSTALL_TOOLS=1`) + `docker-compose.yml`
+
 ---
 
 ## Environment notes

--- a/uv.lock
+++ b/uv.lock
@@ -610,6 +610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,6 +1065,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1090,6 +1108,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1330,6 +1357,48 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1541,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },
@@ -1551,6 +1620,9 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "textual-dev" },
 ]
@@ -1559,6 +1631,9 @@ dev = [
 requires-dist = [
     { name = "litellm", specifier = ">=1.55" },
     { name = "pydantic", specifier = ">=2.6" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "textual", specifier = ">=0.79" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = ">=1.5" },


### PR DESCRIPTION
Implements the full **Phase 6 quality-of-life roadmap**, driven by a verified audit of the codebase. Every change is tested (pytest + headless smoke), type-checked (pyright, 0 errors) and lint-clean.

## Highlights
**Trust & safety** (the audit's top item)
- Persistent **granular permissions** (`permissions.toml`: allow/deny + regex patterns); a real "allow once" vs session vs **always**/**never**; `/permissions`
- Default deny rules for destructive bash (`rm -rf`, `dd of=/dev/…`, `mkfs`, fork bomb)
- **Diff preview** in the approval modal for write/edit — no more approving blind
- `config.toml` written `0600`; `/audit` view + gzip log rotation; scope `dry-run`/`import`/`export` + `--scope-file`

**UX / interaction**
- `↑/↓` input history; fuzzy "did you mean" on typos
- Keyboard chat nav (`PgUp/PgDn`, `Ctrl+Home/End`) with sticky autoscroll
- `/copy` (restored clipboard) and `/show <id>` to expand truncated results
- `Ctrl+P` command palette; colored RIFT stage-transition dividers; expanded `/help`

**Agent loop**
- Provider retry/backoff + classified errors (`auth`/`rate_limit`/`context`/…); `/retry`
- Token + cost meter in the status bar; `/cost`; context-window gauge + 80% warning
- Crash-safe atomic checkpoints + incomplete-session detection; `/continue [N]`; `/compact`

**Engagement & reporting**
- Edit/delete findings (commands + agent tools); tags + notes (schema migrated)
- Import dedup (skip/merge/allow-all) + richer `import_scan` diagnostics
- `/hosts`, `/services`, `/timeline` (activity log), `/export` (zip archive)
- Reports gain **JSON + SARIF** + an executive summary; severity-sorted `/findings`

**Onboarding & contributors**
- Graceful first-run when no API key; model-id validation; configurable keybindings
- **Headless one-shot mode** (`-p/--prompt`, `--headless`) + `--model/--workdir/--api-key`
- `tests/` pytest suite + fixtures; pyright + pytest wired into CI
- `.pre-commit-config`, `Makefile`, shell completions, man page, `docs/configuration.md`
- Docker tool-variant (`--build-arg INSTALL_TOOLS=1`) + `docker-compose.yml`

Bumps version to **0.0.5**.

## Verification
- `ruff` clean · `pyright` **0 errors** · **48 pytest tests pass** · **10 smoke suites pass**
- Real TUI boot confirmed (palette opens, diff preview renders, stage transitions work)
- A real bug was caught and fixed in the process: regex patterns weren't escaped for TOML, which would have silently broken persistent permissions — fixed with TOML literal strings.

## Notes
- New SQLite columns (`findings.tags`, `findings.notes`, `activity` table) migrate automatically for existing engagements.
- No breaking changes to existing commands; the original behaviors are preserved and still covered by `dev/smoke.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)