### PR TITLE
ci(demo): don't run on tag pushes; push gif to an explicit branch

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -6,6 +6,9 @@ name: demo
 on:
   workflow_dispatch:
   push:
+    # Only on branch pushes to main — NOT on tags. A tag checkout is a detached
+    # HEAD, so the "commit demo.gif back" step has no branch to push to.
+    branches: [main]
     paths:
       - "demo.tape"
       - ".github/workflows/demo.yml"
@@ -47,12 +50,20 @@ jobs:
           vhs demo.tape
       - name: Commit demo.gif if changed
         run: |
-          if [ -n "$(git status --porcelain demo.gif)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add demo.gif
-            git commit -m "chore: regenerate demo.gif [skip ci]"
-            git push
-          else
+          set -euo pipefail
+          if [ -z "$(git status --porcelain demo.gif)" ]; then
             echo "demo.gif unchanged"
+            exit 0
           fi
+          # Resolve the branch to push to. On a tag/detached checkout there is
+          # none — skip rather than fail (the workflow shouldn't run there anyway).
+          BRANCH="${GITHUB_REF_NAME}"
+          if [ "${GITHUB_REF_TYPE}" != "branch" ]; then
+            echo "not on a branch (ref_type=${GITHUB_REF_TYPE}); skipping commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add demo.gif
+          git commit -m "chore: regenerate demo.gif [skip ci]"
+          git push origin "HEAD:${BRANCH}"


### PR DESCRIPTION
## Problem
The **demo** workflow has failed on every tag/release push (`v0.0.4`, `v0.0.5`) with:
```
fatal: You are not currently on a branch.
##[error]Process completed with exit code 128.
```
A workflow triggered by a tag checks out a **detached HEAD** (the tag commit), so the "Commit demo.gif if changed" step has no branch to `git push` to. This is a **pre-existing bug**, unrelated to the 0.0.5 feature work — the last green demo run was a push to `main`; both subsequent tag-triggered runs failed identically.

No damage was done: the push fails *after* the local commit, so nothing reached `main` (verified `origin/main` has no stray regenerate-gif commit).

## Fix
- **Restrict the auto-trigger to branch pushes on `main`** (`branches: [main]`), so tag/release pushes no longer trigger it. Regenerating + committing the gif back from a detached tag checkout was never the intent.
- **Push to an explicit branch** (`HEAD:<branch>`) and **skip (not fail)** the commit step when the ref isn't a branch (e.g. a manual `workflow_dispatch` on a tag).

YAML validated. Merging this is itself a `demo.yml` path-change on `main`, so it will trigger one demo run that exercises the fixed path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)