### PR TITLE
perf: lazy-load litellm (2.4s→0.35s startup); tighter demo GIF

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -1,5 +1,5 @@
 # riftor demo — rendered by VHS (https://github.com/charmbracelet/vhs)
-# Showcases offline features only (no API key / model calls needed).
+# Offline: a dummy key + a mock agent response mean no model/API call is made.
 # Regenerate locally:  vhs demo.tape   (or push this file — CI renders it)
 
 Output demo.gif
@@ -13,42 +13,43 @@ Set Height 720
 Set Padding 18
 Set TypingSpeed 55ms
 
-# --- setup (hidden): dummy key avoids the Ollama probe; we never call a model
+# --- setup (hidden) --------------------------------------------------------
+# Dummy key avoids the Ollama probe; RIFTOR_DEMO_RESPONSE makes the agent task
+# stream a canned reply (no model call). Pre-seed one finding so /findings and
+# /report have real content. Start from a clean engagement for a reproducible run.
 Hide
 Type "export ANTHROPIC_API_KEY=sk-demo" Enter
+Type `export RIFTOR_DEMO_RESPONSE='Recon on 10.0.0.5 shows 22/ssh and 80/http (nginx). The exposed SSH service is the seam — recorded as a finding. Advancing to Intrusion.'` Enter
+Type "rm -rf .riftor" Enter
+Type `python -c "from pathlib import Path; from riftor.engagement import Engagement; e=Engagement(Path('.')); e.add_finding(title='Exposed SSH', severity='medium', host='10.0.0.5', evidence='22/tcp open ssh OpenSSH 8.2', recommendation='Restrict SSH to a bastion / VPN')"` Enter
 Type "clear" Enter
 Show
 
+# --- launch ----------------------------------------------------------------
 Type "riftor" Enter
 Sleep 2.5s
 
+# orient
 Type "/help" Enter
 Sleep 2.5s
 
+# the guardrail — riftor's identity: scope is enforced
 Type "/scope add 10.0.0.0/24 example.com" Enter
 Sleep 1.8s
 
-# live theme switching
-Type "/theme void" Enter
-Sleep 1.4s
-Type "/theme fracture" Enter
-Sleep 1.4s
-Type "/theme singularity" Enter
-Sleep 1.4s
-Type "/theme rift" Enter
-Sleep 1.2s
+# task the agent (offline mock) — it reasons and narrates the recon
+Type "enumerate 10.0.0.5 and flag exposed services" Enter
+Sleep 3.5s
 
-# advance the RIFT stage + review findings
+# advance the RIFT methodology (shows the colored stage divider)
 Type "/stage I" Enter
-Sleep 1.2s
+Sleep 1.5s
+
+# review findings (severity-sorted) and write the report
 Type "/findings" Enter
 Sleep 1.8s
-
-# settings modal
-Type "/config" Enter
-Sleep 2.5s
-Escape
-Sleep 1s
+Type "/report md" Enter
+Sleep 1.8s
 
 Type "/exit" Enter
-Sleep 1.5s
+Sleep 1.2s

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -15,16 +15,26 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, AsyncIterator
 
-os.environ.setdefault("LITELLM_LOG", "ERROR")
-
-import litellm  # noqa: E402
-
-litellm.telemetry = False
-litellm.drop_params = True
-litellm.suppress_debug_info = True
-
 if TYPE_CHECKING:
     from riftor.config import Config
+
+# litellm is heavy (~2.4s to import, pulling in openai/pydantic/etc.). It is only
+# needed on the first model call, so we import + configure it lazily — keeping app
+# startup fast. The cost then hides behind the network round-trip of that call.
+_litellm = None
+
+
+def _get_litellm():
+    global _litellm
+    if _litellm is None:
+        os.environ.setdefault("LITELLM_LOG", "ERROR")
+        import litellm
+
+        litellm.telemetry = False
+        litellm.drop_params = True
+        litellm.suppress_debug_info = True
+        _litellm = litellm
+    return _litellm
 
 
 @dataclass
@@ -138,10 +148,17 @@ class Provider:
             kwargs["api_base"] = self.config.api_base
         if self.config.api_key:
             kwargs["api_key"] = self.config.api_key
+        # Offline demo hook: return canned streamed text instead of calling a model.
+        # Only active when the env var is set (used by demo.tape / CI), so normal
+        # runs are unaffected.
+        demo = os.environ.get("RIFTOR_DEMO_RESPONSE")
+        if demo:
+            kwargs["mock_response"] = demo
         return kwargs
 
     async def _acompletion(self, **kwargs):
         """litellm.acompletion with classified retry/backoff for transient errors."""
+        litellm = _get_litellm()
         last: ProviderError | None = None
         for attempt in range(self.max_retries):
             try:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,58 @@
+"""Provider: lazy litellm loading + the offline demo mock hook."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from riftor.agent import provider as prov
+from riftor.config import Config
+
+
+def test_importing_provider_does_not_load_litellm():
+    # The whole point of the lazy accessor: importing the module is cheap.
+    # (It may already be loaded by another test; this asserts the module import
+    # path itself doesn't force it — checked via the accessor cache being lazy.)
+    assert "litellm" not in sys.modules or prov._litellm is sys.modules.get("litellm")
+
+
+def test_get_litellm_configures_and_caches():
+    lit = prov._get_litellm()
+    assert lit.telemetry is False
+    assert lit.drop_params is True
+    assert prov._get_litellm() is lit  # cached
+
+
+def test_kwargs_no_mock_by_default(monkeypatch):
+    monkeypatch.delenv("RIFTOR_DEMO_RESPONSE", raising=False)
+    p = Provider_for_test()
+    kw = p._kwargs([{"role": "user", "content": "hi"}])
+    assert "mock_response" not in kw
+    assert kw["stream"] is True
+
+
+def test_kwargs_injects_mock_when_env_set(monkeypatch):
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "canned reply")
+    p = Provider_for_test()
+    kw = p._kwargs([{"role": "user", "content": "hi"}])
+    assert kw["mock_response"] == "canned reply"
+
+
+@pytest.mark.asyncio
+async def test_mock_response_streams_offline(monkeypatch):
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "The rift opens.")
+    p = Provider_for_test()
+    text = []
+    turn = None
+    async for event, payload in p.stream_turn([{"role": "user", "content": "go"}]):
+        if event == "text":
+            text.append(str(payload))
+        elif event == "done":
+            turn = payload
+    assert "".join(text) == "The rift opens."
+    assert turn is not None and turn.text == "The rift opens."
+
+
+def Provider_for_test() -> "prov.Provider":
+    return prov.Provider(Config(model="anthropic/claude-sonnet-4-6", api_key="sk-demo"))


### PR DESCRIPTION
Addresses two issues with the demo GIF — and one real startup delay it exposed.

## 1. Startup was slow (the 3–4s delay)
The delay is **real on every launch**, not just the GIF. `import riftor.tui.app` took **2.43s**, of which **litellm is ~2.46s of cumulative import time** (with transitive `openai`/`pydantic`). It was imported at the top of `provider.py`, on the app-launch path — but it's only needed on the first model call.

**Fix:** lazy-load litellm via a cached `_get_litellm()` accessor called from `_acompletion`. The pure-Python parts of the module (dataclasses, `classify_error`) stay instantly importable.

| | before | after |
|---|---|---|
| `import riftor.tui.app` | 2.43s | **~0.35s** |
| litellm loaded at startup | yes | **no** (loads on first agent turn) |

## 2. Demo showed too many low-value commands
Dropped the four `/theme` switches and the `/config` modal. New sequence:
launch → `/help` → `/scope add` (**the guardrail**) → a real agent task → `/stage I` (colored stage divider) → `/findings` → `/report md`.

## 3. Real agent task, offline
The demo runs in CI with a dummy key, so a real task would error on camera. Added a one-line, env-gated hook (`RIFTOR_DEMO_RESPONSE`) in `_kwargs` that injects litellm's native `mock_response`, so the task streams a canned reply with **no API call**. Zero effect on normal runs. The hidden tape block pre-seeds one finding (so `/findings` + `/report` have content) and cleans `.riftor` for a reproducible render.

## Verification
- `ruff` clean · `pyright` 0 errors · **53 pytest tests** (5 new in `test_provider.py`: lazy load, mock injection, offline streaming)
- Startup measured 0.34–0.36s across runs
- The **entire new tape sequence** was simulated end-to-end through the headless TUI (scope adds, agent streams the mock, stage advances, findings show, report writes)
- Merging triggers `demo.yml` (fixed last PR) to render + commit the new `demo.gif`

🤖 Generated with [Claude Code](https://claude.com/claude-code)