### PR TITLE
docs: sync PyPI description with README (absolute links) + release 0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 [![PyPI](https://img.shields.io/pypi/v/riftor)](https://pypi.org/project/riftor/)
 [![CI](https://github.com/Estudely/riftor/actions/workflows/ci.yml/badge.svg)](https://github.com/Estudely/riftor/actions/workflows/ci.yml)
-[![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue)](./LICENSE)
+[![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue)](https://github.com/Estudely/riftor/blob/main/LICENSE)
 
-![riftor demo](./demo.gif)
+![riftor demo](https://raw.githubusercontent.com/Estudely/riftor/main/demo.gif)
 
 riftor is a Python TUI pentest assistant: a full-screen [Textual](https://textual.textualize.io/)
 interface backed by [litellm](https://docs.litellm.ai/), organised around the
@@ -22,7 +22,7 @@ behaviour, with local [Ollama](https://ollama.com/) supported as an option.
 > import-export), RIFT stage tracking, per-engagement findings store (edit/tag/
 > dedup), CVSS reports in **md/html/json/sarif**, crash-safe sessions, input
 > history + command palette, headless one-shot mode, Docker, pytest + types in CI.
-> See [`todo.md`](./todo.md) for the roadmap and [`docs/`](./docs) for configuration.
+> See [`todo.md`](https://github.com/Estudely/riftor/blob/main/todo.md) for the roadmap and [`docs/`](https://github.com/Estudely/riftor/tree/main/docs) for configuration.
 
 ## Install
 ```bash
@@ -111,11 +111,11 @@ lives in `.riftor/` per working directory; sessions auto-save and resume.
 `Esc` cancels a running response. Dangerous tools (bash/write/edit) prompt for
 approval (with a **diff preview**); `rm -rf`/`dd` and friends are denied by
 default; every tool call is written to an audit log. See
-[`docs/configuration.md`](./docs/configuration.md) for all settings.
+[`docs/configuration.md`](https://github.com/Estudely/riftor/blob/main/docs/configuration.md) for all settings.
 
 ## Use responsibly
 riftor is for **authorized** security testing only. You are responsible for
 having explicit, written permission for any system you assess.
 
 ## License
-[GPL-3.0](./LICENSE).
+[GPL-3.0](https://github.com/Estudely/riftor/blob/main/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.0.5"
+version = "0.0.6"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/__init__.py
+++ b/riftor/__init__.py
@@ -3,4 +3,4 @@
 Find the rift. Open it. Cross through.
 """
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Why
PyPI builds its long-description from `README.md` at release time, so the text was already in sync as of 0.0.5. The real problem: the README used **relative links** (`./demo.gif`, `./LICENSE`, `./todo.md`, `./docs/…`) that resolve on GitHub but **404 on the PyPI page** — the demo GIF didn't render and the doc links were dead.

## Fix
Rewrite all relative references as absolute URLs so a single README renders identically on GitHub and PyPI:
- `./demo.gif` → `https://raw.githubusercontent.com/Estudely/riftor/main/demo.gif`
- `./LICENSE`, `./todo.md`, `./docs/…` → `https://github.com/Estudely/riftor/blob/main/…` (and `/tree/main/docs`)

Bump to **0.0.6** so the corrected description actually reaches PyPI (it only updates on a new release).

## Verification
- No relative links remain in README
- `uv build` + **`twine check` PASSED** on both wheel and sdist
- Confirmed the packaged wheel METADATA embeds the absolute `raw.githubusercontent.com` demo URL (so it renders on PyPI)
- ruff + smoke green; version consistent in `pyproject.toml` and `__init__.py`

On merge + tag `v0.0.6`, `release.yml` republishes to PyPI with the fixed description and creates the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)