### PR TITLE
feat: /doctor — surface missing recon tools up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ riftor --model openai/gpt-4o           # override the model for this run
 riftor --workdir ./engagement          # set the engagement directory
 riftor --scope-file scope.txt          # preload scope targets
 riftor -p "enumerate 10.0.0.5"         # headless one-shot (also reads stdin)
+riftor --doctor                        # check which recon tools are installed
 ```
 
 On first launch riftor writes a config file and picks a default model from your
@@ -57,8 +58,11 @@ uv sync && uv run riftor
 docker build -t riftor .
 docker run -it --rm -e ANTHROPIC_API_KEY -v "$PWD:/work" riftor
 ```
-The image is minimal (no `nmap`/`httpx`/etc.). For full recon tooling, run riftor
-on a host that has the tools installed, or extend the image.
+The image is minimal (no `nmap`/`httpx`/etc.). For full recon tooling, build the
+bundled variant (`docker build --build-arg INSTALL_TOOLS=1 -t riftor:full .`), run
+riftor on a host that has the tools, or extend the image. Missing tools aren't
+fatal — the agent sees the failed command and adapts; run `/doctor` (or
+`riftor --doctor`) to see which tools are on `PATH` up front.
 
 ## Configure
 `~/.config/riftor/config.toml`:
@@ -104,6 +108,7 @@ lives in `.riftor/` per working directory; sessions auto-save and resume.
 | `/report [md\|html\|json\|sarif\|both\|all]` | write a report to `.riftor/reports/` |
 | `/timeline` · `/export` | engagement activity log · archive the engagement |
 | `/permissions` · `/audit` | review allow/deny rules · recent tool-call log |
+| `/doctor` | check which external recon tools (nmap/httpx/…) are installed |
 | `/sessions` · `/resume <id>` · `/new` | manage saved sessions |
 | `/config` · `/tools` · `/lore` · `/exit` | settings · tools · persona · quit |
 

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -123,7 +123,7 @@ async def main() -> None:
         app.engagement.add_finding(title="Test finding", severity="high", host="10.0.0.1")
         for cmd in (
             "/findings", "/hosts", "/services", "/timeline", "/permissions",
-            "/cost", "/audit", "/scope dry", "/scope on",
+            "/cost", "/audit", "/doctor", "/scope dry", "/scope on",
         ):
             inp.value = cmd
             await pilot.press("enter")

--- a/riftor/__main__.py
+++ b/riftor/__main__.py
@@ -18,6 +18,10 @@ def main() -> None:
     parser.add_argument(
         "--config", action="store_true", help="print the config file path and exit"
     )
+    parser.add_argument(
+        "--doctor", action="store_true",
+        help="check which external recon tools (nmap/httpx/…) are installed, then exit",
+    )
     parser.add_argument("--model", help="override the model for this run")
     parser.add_argument("--api-key", dest="api_key", help="override the API key for this run")
     parser.add_argument("--workdir", help="engagement working directory (default: cwd)")
@@ -36,6 +40,12 @@ def main() -> None:
 
     if args.config:
         print(CONFIG_PATH)
+        return
+
+    if args.doctor:
+        from riftor.engagement.doctor import check_toolchain, render_plain
+
+        print(render_plain(check_toolchain()))
         return
 
     cfg = Config.load()

--- a/riftor/engagement/doctor.py
+++ b/riftor/engagement/doctor.py
@@ -1,0 +1,115 @@
+"""Toolchain check: which recon/exploitation binaries are on PATH.
+
+riftor runs external tools (nmap, httpx, nuclei, …) through the ``bash`` tool —
+it never bundles them. A missing tool isn't fatal (the agent sees the failed
+command and adapts), but discovering that mid-task is annoying. ``/doctor`` (and
+``riftor --doctor``) surface the gaps up front, grouped by RIFT stage.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+
+# Tools the methodology + system prompt reference, grouped by RIFT stage.
+# (binary, one-line purpose). Kept in sync with prompts/system.md.
+TOOLCHAIN: dict[str, list[tuple[str, str]]] = {
+    "R": [
+        ("nmap", "port/service scanning"),
+        ("httpx", "HTTP probing"),
+        ("subfinder", "subdomain enumeration"),
+        ("dig", "DNS lookups"),
+        ("whatweb", "tech fingerprinting"),
+        ("curl", "ad-hoc HTTP requests"),
+    ],
+    "I": [
+        ("nuclei", "template-based vuln scanning"),
+        ("ffuf", "content/parameter fuzzing"),
+        ("gobuster", "directory brute-forcing"),
+        ("nikto", "web server scanning"),
+        ("sqlmap", "SQL injection"),
+    ],
+    # Optional helpers riftor itself can use, not stage-specific.
+    "_helpers": [
+        ("rg", "faster grep (riftor falls back to python)"),
+    ],
+}
+
+_STAGE_NAMES = {"R": "Recon", "I": "Intrusion"}
+
+
+@dataclass
+class ToolStatus:
+    name: str
+    purpose: str
+    path: str | None  # resolved path, or None if not found
+    stage: str
+
+    @property
+    def present(self) -> bool:
+        return self.path is not None
+
+
+def check_toolchain() -> list[ToolStatus]:
+    """Probe every known tool on PATH. Pure except for shutil.which()."""
+    out: list[ToolStatus] = []
+    for stage, tools in TOOLCHAIN.items():
+        for name, purpose in tools:
+            out.append(ToolStatus(name, purpose, shutil.which(name), stage))
+    return out
+
+
+def summarize(statuses: list[ToolStatus]) -> dict:
+    present = [s for s in statuses if s.present]
+    missing = [s for s in statuses if not s.present]
+    return {
+        "present": len(present),
+        "missing": len(missing),
+        "total": len(statuses),
+        "missing_names": [s.name for s in missing],
+    }
+
+
+def render_markdown(statuses: list[ToolStatus]) -> str:
+    """A grouped, human-readable report for the TUI / CLI."""
+    by_stage: dict[str, list[ToolStatus]] = {}
+    for s in statuses:
+        by_stage.setdefault(s.stage, []).append(s)
+
+    lines = ["**riftor doctor — external toolchain**", ""]
+    for stage, items in by_stage.items():
+        if stage == "_helpers":
+            header = "Helpers"
+        else:
+            header = f"{stage} · {_STAGE_NAMES.get(stage, stage)}"
+        lines.append(f"_{header}_")
+        for s in items:
+            mark = "✓" if s.present else "✗"
+            where = f" `{s.path}`" if s.present else " — *not on PATH*"
+            lines.append(f"- {mark} `{s.name}` — {s.purpose}{where}")
+        lines.append("")
+
+    summary = summarize(statuses)
+    lines.append(
+        f"**{summary['present']}/{summary['total']} present.** "
+        + (
+            "Missing tools aren't fatal — the agent works around them, but install "
+            f"them for full coverage: {', '.join(summary['missing_names'])}."
+            if summary["missing"]
+            else "Full toolchain available."
+        )
+    )
+    return "\n".join(lines)
+
+
+def render_plain(statuses: list[ToolStatus]) -> str:
+    """A no-markup version for the headless CLI / stderr."""
+    lines = ["riftor doctor — external toolchain"]
+    for s in statuses:
+        mark = "ok " if s.present else "MISSING"
+        lines.append(f"  [{mark}] {s.name:<10} {s.purpose}")
+    summary = summarize(statuses)
+    lines.append(f"{summary['present']}/{summary['total']} present.")
+    if summary["missing"]:
+        lines.append("missing (not fatal): " + ", ".join(summary["missing_names"]))
+    return "\n".join(lines)

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -53,7 +53,7 @@ _COMMANDS = [
     "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
     "/sessions", "/resume", "/new", "/theme", "/config", "/tools", "/permissions",
     "/lore", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
-    "/timeline", "/audit", "/export", "/exit",
+    "/timeline", "/audit", "/export", "/doctor", "/exit",
 ]
 
 HELP = """\
@@ -80,6 +80,7 @@ _Settings & sessions_
 - `/model [name]` — show or switch the model · `/theme [name]` (rift/void/fracture/singularity)
 - `/config` — settings panel · `/permissions` — review allow/deny rules
 - `/lore` — toggle the rift persona · `/audit` — recent tool-call audit log
+- `/doctor` — check which external recon tools (nmap/httpx/…) are installed
 - `/sessions` · `/resume <id>` · `/new` — manage saved sessions
 - `/tools` — list tools · `/exit` — quit (`Ctrl+C`)
 
@@ -99,6 +100,7 @@ _PALETTE_COMMANDS = [
     ("/timeline", "Timeline", "Engagement activity log"),
     ("/export", "Export engagement", "Archive the whole engagement"),
     ("/permissions", "Permissions", "Review allow/deny rules"),
+    ("/doctor", "Doctor", "Check installed recon tools"),
     ("/audit", "Audit log", "Recent tool-call audit entries"),
     ("/cost", "Cost", "Token + cost for this session"),
     ("/compact", "Compact context", "Shrink old tool output"),
@@ -213,9 +215,22 @@ class RiftorApp(App):
         warning = self.config.model_warning()
         if warning:
             self._note("⚠ " + warning)
+        self._toolchain_heads_up()
         if not self._resume_latest():
             self._note(
                 "rift online · set scope with /scope add <target> before tasking the agent"
+            )
+
+    def _toolchain_heads_up(self) -> None:
+        """One-line note if recon tools are missing — surfaced up front, not mid-task."""
+        from riftor.engagement.doctor import check_toolchain, summarize
+
+        s = summarize(check_toolchain())
+        if s["missing"]:
+            self._note(
+                f"⚠ {s['missing']}/{s['total']} recon tools not on PATH "
+                f"({', '.join(s['missing_names'][:4])}{'…' if s['missing'] > 4 else ''}) "
+                "· /doctor for details"
             )
 
     def _resume_latest(self) -> bool:
@@ -377,6 +392,7 @@ class RiftorApp(App):
             "/timeline": self._timeline_cmd,
             "/audit": self._audit_cmd,
             "/export": self._export_cmd,
+            "/doctor": self._doctor_cmd,
         }
         if cmd in ("/exit", "/quit"):
             self._save_session()
@@ -705,6 +721,11 @@ class RiftorApp(App):
             err = " ⚠" if e.get("is_error") else ""
             rows.append(f"`{when}` {flag} **{e.get('tool', '?')}** {e.get('preview', '')[:80]}{err}")
         self._markdown("**audit log** (recent)\n\n" + "\n".join(rows))
+
+    def _doctor_cmd(self) -> None:
+        from riftor.engagement.doctor import check_toolchain, render_markdown
+
+        self._markdown(render_markdown(check_toolchain()))
 
     def _export_cmd(self) -> None:
         import json

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,50 @@
+"""Toolchain doctor: detection, summary, and rendering (deterministic via mock)."""
+
+from __future__ import annotations
+
+from riftor.engagement import doctor
+
+
+def test_check_toolchain_all_present(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+    statuses = doctor.check_toolchain()
+    assert statuses and all(s.present for s in statuses)
+    # one entry per declared tool
+    declared = sum(len(v) for v in doctor.TOOLCHAIN.values())
+    assert len(statuses) == declared
+
+
+def test_check_toolchain_all_missing(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    statuses = doctor.check_toolchain()
+    assert statuses and not any(s.present for s in statuses)
+
+
+def test_summarize(monkeypatch):
+    # only nmap present
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/nmap" if name == "nmap" else None)
+    s = doctor.summarize(doctor.check_toolchain())
+    assert s["present"] == 1
+    assert s["missing"] == s["total"] - 1
+    assert "nuclei" in s["missing_names"] and "nmap" not in s["missing_names"]
+
+
+def test_render_markdown_flags_missing(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    md = doctor.render_markdown(doctor.check_toolchain())
+    assert "not on PATH" in md
+    assert "aren't fatal" in md
+    assert "Recon" in md and "Intrusion" in md
+
+
+def test_render_markdown_full(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+    md = doctor.render_markdown(doctor.check_toolchain())
+    assert "Full toolchain available" in md
+
+
+def test_render_plain(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/nmap" if name == "nmap" else None)
+    plain = doctor.render_plain(doctor.check_toolchain())
+    assert "MISSING" in plain and "ok" in plain
+    assert "missing (not fatal):" in plain


### PR DESCRIPTION
## Why
You asked what happens when the host is missing the tools riftor expects. The answer: **it degrades gracefully** — riftor runs nmap/httpx/nuclei/etc. via the `bash` tool and never bundles them, so a missing tool just produces a failed command (`exit 127`) that the agent sees and works around. The only rough edge was **discoverability**: you found out mid-task, not up front. `/doctor` fixes that.

## What
- **`riftor/engagement/doctor.py`** — probes the toolchain via `shutil.which`, grouped by RIFT stage (Recon/Intrusion) plus helpers; provides markdown + plain renderers and a summary. Pure and fully testable.
- **TUI** — `/doctor` command, a `Ctrl+P` palette entry, and a **one-line startup note** when tools are missing (`⚠ N/M recon tools not on PATH (…) · /doctor for details`).
- **CLI** — `riftor --doctor` for offline/scriptable checks.
- **Docs** — README command table, `--doctor` flag, and a note that missing tools aren't fatal.

Sample output:
```
riftor doctor — external toolchain
  [ok ] nmap       port/service scanning
  [MISSING] nuclei  template-based vuln scanning
  …
11/12 present.
missing (not fatal): nuclei
```

## Verification
- ruff PASS · pyright 0 errors · **59 tests** (6 new in `test_doctor.py`, deterministic via mocked `shutil.which`) · smoke (now exercises `/doctor`) PASS
- `riftor --doctor` verified live against the real PATH and against an all-missing toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)