### PR TITLE
fix(tui): redesign config + permission modals (aligned, grouped, polished)

### DIFF
--- a/riftor/safety/permissions.py
+++ b/riftor/safety/permissions.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
@@ -205,7 +205,8 @@ class ConfirmScreen(ModalScreen[str]):
                 )
             yield Static(Text(self.preview or "(no detail)", style="#e9e9f2"), id="confirm-detail")
             if self.detail:
-                yield Static(self._render_detail(), id="confirm-diff")
+                with VerticalScroll(id="confirm-diff"):
+                    yield Static(self._render_detail(), id="confirm-diff-body")
             with Horizontal(id="confirm-buttons"):
                 yield Button("Once (a)", id="once", variant="success")
                 yield Button("Session (s)", id="session", variant="primary")

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -1,18 +1,24 @@
-"""The /config settings modal."""
+"""The /config settings modal — a grouped, aligned settings card."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Label, Select, Switch
+from textual.widget import Widget
+from textual.widgets import Button, Input, Label, Rule, Select, Switch
 
 from riftor.tui.theme import THEMES
 
 if TYPE_CHECKING:
     from riftor.config import Config
+
+
+def _row(label: str, field: Widget) -> Horizontal:
+    """A label-column + field row, so every field's left edge lines up."""
+    return Horizontal(Label(label, classes="field-label"), field, classes="field-row")
 
 
 class ConfigScreen(ModalScreen[dict | None]):
@@ -25,27 +31,34 @@ class ConfigScreen(ModalScreen[dict | None]):
         self.config = config
 
     def compose(self) -> ComposeResult:
+        theme = self.config.theme if self.config.theme in THEMES else "rift"
         with Vertical(id="config-box"):
             yield Label("riftor · config", id="config-title")
-            yield Label("model")
-            yield Input(value=self.config.model, id="cfg-model")
-            yield Label("temperature")
-            yield Input(value=str(self.config.temperature), id="cfg-temp")
-            yield Label("max tokens")
-            yield Input(value=str(self.config.max_tokens), id="cfg-maxtok")
-            yield Label("theme")
-            theme = self.config.theme if self.config.theme in THEMES else "rift"
-            yield Select(
-                [(name, name) for name in THEMES],
-                value=theme,
-                allow_blank=False,
-                id="cfg-theme",
-            )
-            with Horizontal(id="cfg-lore-row"):
-                yield Label("lore  ")
-                yield Switch(value=self.config.lore, id="cfg-lore")
-            yield Label("api key (blank = keep current)")
-            yield Input(password=True, placeholder="leave blank to keep", id="cfg-key")
+            with VerticalScroll(id="config-body"):
+                yield Label("MODEL", classes="config-section")
+                yield _row("Model", Input(value=self.config.model, id="cfg-model"))
+                yield _row(
+                    "API key",
+                    Input(password=True, placeholder="leave blank to keep", id="cfg-key"),
+                )
+
+                yield Rule()
+                yield Label("GENERATION", classes="config-section")
+                yield _row("Temperature", Input(value=str(self.config.temperature), id="cfg-temp"))
+                yield _row("Max tokens", Input(value=str(self.config.max_tokens), id="cfg-maxtok"))
+
+                yield Rule()
+                yield Label("APPEARANCE", classes="config-section")
+                yield _row(
+                    "Theme",
+                    Select(
+                        [(name, name) for name in THEMES],
+                        value=theme,
+                        allow_blank=False,
+                        id="cfg-theme",
+                    ),
+                )
+                yield _row("Lore", Switch(value=self.config.lore, id="cfg-lore"))
             with Horizontal(id="config-buttons"):
                 yield Button("Save", id="save", variant="success")
                 yield Button("Cancel", id="cancel", variant="error")

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -57,27 +57,74 @@ Screen {
     color: $error;
 }
 
-/* modals: permission + config */
+/* ───────────────────────── modals: permission + config ───────────────────── */
 ConfirmScreen, ConfigScreen {
     align: center middle;
-    background: $background 70%;
+    background: $background 75%;
 }
 
 #confirm-box, #config-box {
-    width: 76;
+    width: 72;
     max-width: 90%;
     height: auto;
-    padding: 1 2;
+    max-height: 90%;
+    padding: 1 2 1 2;
     background: $panel;
     border: round $violet;
 }
 
+/* title bar — bold, with an underline rule that spans the card */
 #confirm-title, #config-title {
-    padding-bottom: 1;
+    width: 1fr;
+    padding: 0 0 1 0;
+    margin-bottom: 1;
+    border-bottom: solid $border;
     color: $violet;
     text-style: bold;
 }
 
+/* — config body & field rows — */
+#config-body {
+    height: auto;
+    max-height: 28;
+    padding: 0;
+}
+
+.config-section {
+    width: 1fr;
+    color: $cyan;
+    text-style: bold;
+    margin: 1 0 0 0;
+}
+
+.field-row {
+    height: 3;
+    align: left middle;
+    margin-bottom: 0;
+}
+
+.field-label {
+    width: 14;
+    height: 3;
+    color: $muted;
+    content-align: left middle;
+}
+
+.field-row Input,
+.field-row Select {
+    width: 1fr;
+}
+
+.field-row Switch {
+    height: 3;
+}
+
+#config-body Rule {
+    color: $border;
+    margin: 0;
+}
+
+/* — confirm modal detail/diff — */
 #confirm-scope {
     height: auto;
     padding-bottom: 1;
@@ -85,11 +132,21 @@ ConfirmScreen, ConfigScreen {
 
 #confirm-detail {
     height: auto;
-    max-height: 12;
     padding-bottom: 1;
     color: $foreground;
 }
 
+#confirm-diff {
+    height: auto;
+    max-height: 14;
+    margin-bottom: 1;
+    padding: 0 1;
+    background: $tool-bg;
+    border: round $border;
+    scrollbar-color: $border;
+}
+
+/* — shared footer — */
 #confirm-buttons, #config-buttons {
     height: auto;
     align: center middle;
@@ -97,20 +154,8 @@ ConfirmScreen, ConfigScreen {
 }
 
 #confirm-buttons Button, #config-buttons Button {
+    min-width: 12;
     margin: 0 1;
-}
-
-#config-box Label {
-    color: $muted;
-}
-
-#config-box Input {
-    margin-bottom: 1;
-}
-
-#cfg-lore-row {
-    height: auto;
-    margin-bottom: 1;
 }
 
 StatusBar {

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -1,0 +1,65 @@
+"""ConfigScreen: the redesigned modal renders its fields and round-trips values."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from textual.widgets import Input, Select, Switch
+
+import riftor.config as cfgmod
+from riftor.config import Config
+from riftor.tui.app import RiftorApp
+from riftor.tui.config_screen import ConfigScreen
+
+
+def _patch_paths(tmp: Path) -> None:
+    cfgmod.CONFIG_DIR = tmp
+    cfgmod.CONFIG_PATH = tmp / "config.toml"
+    cfgmod.PERMISSIONS_PATH = tmp / "permissions.toml"
+    cfgmod.KEYBINDINGS_PATH = tmp / "kb.toml"
+
+
+@pytest.mark.asyncio
+async def test_config_modal_renders_all_fields():
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="ollama_chat/x", api_base="http://localhost:11434")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfigScreen)
+            screen = app.screen
+            # every field is present and addressable by its stable id
+            for fid, kind in [
+                ("#cfg-model", Input), ("#cfg-key", Input), ("#cfg-temp", Input),
+                ("#cfg-maxtok", Input), ("#cfg-theme", Select), ("#cfg-lore", Switch),
+            ]:
+                assert screen.query_one(fid, kind) is not None, fid
+            # three grouped section headers (MODEL / GENERATION / APPEARANCE)
+            assert len(list(screen.query(".config-section"))) == 3
+            # aligned label column: one .field-label per field row
+            assert len(list(screen.query(".field-label"))) == 6
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_config_modal_saves_changes():
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="ollama_chat/x", api_base="http://localhost:11434")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            app.screen.query_one("#cfg-temp", Input).value = "0.7"
+            app.screen.query_one("#cfg-maxtok", Input).value = "4096"
+            app.screen.query_one("#save").press()
+            await pilot.pause()
+            assert app.config.temperature == 0.7
+            assert app.config.max_tokens == 4096


### PR DESCRIPTION
The `/config` modal looked messy — bare labels/inputs stacked with no alignment, a `"lore  "` spacing hack, uneven buttons. Rebuilt both modals into a clean, Claude-Code-style layout.

## Config modal
- Titled card with an underlined header bar
- Grouped sections: **MODEL · GENERATION · APPEARANCE** with `Rule` dividers
- Each setting is a **label-column + field row** — a fixed 14-col label width lines up every field's left edge; inputs/select fill the rest (`width: 1fr`)
- Equal-width Save/Cancel footer; body scrolls on small terminals
- All widget ids + `on_button_pressed` logic unchanged → save round-trip intact

```
╭─ riftor · config ─────────────────────╮
│ MODEL                                 │
│ Model        [ anthropic/claude-… ]   │
│ API key      [ leave blank to keep ]  │
│ ─────────────────────────────────────│
│ GENERATION                            │
│ Temperature  [ 0.3 ]                  │
│ Max tokens   [ 2048 ]                 │
│ ─────────────────────────────────────│
│ APPEARANCE                            │
│ Theme        [ rift          ▾ ]      │
│ Lore         ( ● )                    │
│        [ Save ]    [ Cancel ]         │
╰───────────────────────────────────────╯
```

## Permission modal
- Diff preview moved into a **framed, scrollable box** (no more clipping at 12 lines)
- Shares the new title-bar + equal-width footer styling

## Notes
- **TypeScript:** I'd advise against switching — out of scope here. The ~3.2k-line tested Python codebase + Textual TUI (Python-only, best-in-class) have no TS-equivalent upside for a terminal app; it'd be a pure-cost rewrite. Happy to discuss separately.
- All colors stay theme-variable driven — all four themes still render correctly.

## Verification
- Rendered **both modals via Textual `save_screenshot`** and parsed the text layout to confirm fields align and the full form shows (this caught + fixed a body-clipping bug where APPEARANCE was cut off)
- ruff PASS · pyright 0 errors · **61 tests** (+2 in `test_config_screen.py`: field structure + save round-trip) · smoke PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)