### PR TITLE
feat(tui): light/mid themes + live theme preview in /config

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -252,7 +252,8 @@ def test_parsers() -> None:
 def test_themes() -> None:
     from riftor.tui.theme import THEMES, css_variable_defaults
 
-    assert {"rift", "void", "fracture", "singularity"} <= set(THEMES)
+    # dark signatures + the new light/mid themes
+    assert {"rift", "void", "fracture", "singularity", "dusk", "dawn", "paper"} <= set(THEMES)
     required = {
         "violet", "cyan", "magenta", "danger", "muted", "dim", "faint", "border",
         "user-bg", "user-fg", "assistant-bg", "tool-bg",
@@ -261,6 +262,9 @@ def test_themes() -> None:
         missing = required - set(theme.variables)
         assert not missing, (name, missing)
     assert required <= set(css_variable_defaults())
+    # at least one genuinely light theme exists (dark=False)
+    assert any(not t.dark for t in THEMES.values()), "expected a light theme"
+    assert THEMES["paper"].dark is False and THEMES["rift"].dark is True
     print("THEMES OK")
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ commands — those persist your changes back to the file.
 | `api_key` | string | — | Prefer the provider's env var; only set this if you must. |
 | `temperature` | float | `0.3` | Sampling temperature, `0.0`–`2.0`. Lower = more deterministic. |
 | `max_tokens` | int | `2048` | Max tokens per model response. |
-| `theme` | string | `rift` | One of `rift`, `void`, `fracture`, `singularity`. |
+| `theme` | string | `rift` | Dark: `rift` `dusk` `void` `fracture` `singularity` · Light: `dawn` `paper`. Changing it in `/config` previews live. |
 | `lore` | bool | `true` | The subtle rift persona; off = strictly professional voice. |
 | `max_steps` | int | `16` | Tool-call steps per task before pausing (extend live with `/continue`). |
 | `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -77,7 +77,7 @@ _Engagement_
 - `/timeline` — engagement activity log · `/export` — archive the whole engagement
 
 _Settings & sessions_
-- `/model [name]` — show or switch the model · `/theme [name]` (rift/void/fracture/singularity)
+- `/model [name]` — show or switch the model · `/theme [name]` (dark: rift/dusk/void/fracture/singularity · light: dawn/paper)
 - `/config` — settings panel · `/permissions` — review allow/deny rules
 - `/lore` — toggle the rift persona · `/audit` — recent tool-call audit log
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -14,6 +14,7 @@ from riftor.tui.theme import THEMES
 
 if TYPE_CHECKING:
     from riftor.config import Config
+    from riftor.tui.app import RiftorApp
 
 
 def _row(label: str, field: Widget) -> Horizontal:
@@ -29,6 +30,8 @@ class ConfigScreen(ModalScreen[dict | None]):
     def __init__(self, config: "Config") -> None:
         super().__init__()
         self.config = config
+        # theme active when the modal opened — to revert if the user cancels
+        self._original_theme = config.theme
 
     def compose(self) -> ComposeResult:
         theme = self.config.theme if self.config.theme in THEMES else "rift"
@@ -63,10 +66,26 @@ class ConfigScreen(ModalScreen[dict | None]):
                 yield Button("Save", id="save", variant="success")
                 yield Button("Cancel", id="cancel", variant="error")
 
+    @property
+    def _riftor_app(self) -> "RiftorApp":
+        return self.app  # type: ignore[return-value]  # always a RiftorApp at runtime
+
     def on_mount(self) -> None:
         self.query_one("#cfg-model", Input).focus()
 
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Live-preview the theme as the operator picks it in the dropdown."""
+        if event.select.id != "cfg-theme":
+            return
+        value = event.value
+        if isinstance(value, str) and value in THEMES:
+            self._riftor_app._apply_theme(value)  # reuses the /theme live-switch path
+
+    def _revert_theme(self) -> None:
+        self._riftor_app._apply_theme(self._original_theme)
+
     def action_cancel(self) -> None:
+        self._revert_theme()
         self.dismiss(None)
 
     def _fail(self, message: str) -> None:
@@ -74,6 +93,7 @@ class ConfigScreen(ModalScreen[dict | None]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "cancel":
+            self._revert_theme()
             self.dismiss(None)
             return
         try:

--- a/riftor/tui/theme.py
+++ b/riftor/tui/theme.py
@@ -30,21 +30,34 @@ def _theme(name: str, palette: dict[str, str]) -> Theme:
         success=palette["cyan"],
         warning=palette["magenta"],
         error=palette["danger"],
-        dark=True,
+        # palette-driven so light themes get correct built-in-widget contrast
+        dark=palette.get("dark", True),
         variables={k: palette[k] for k in _KEYS},
     )
 
 
-_PALETTES: dict[str, dict[str, str]] = {
-    # Signature: deep indigo background, violet / cyan rift glow.
+# Each palette: bg/fg/surface/panel + the shared accent/_KEYS, plus a "dark" flag
+# that drives Textual's built-in-widget contrast. Ordered dark → light.
+_PALETTES: dict[str, dict] = {
+    # Signature: deep indigo background, violet / cyan rift glow. (default)
     "rift": {
+        "dark": True,
         "bg": "#08060f", "fg": "#cbd5e1", "surface": "#0f0d1a", "panel": "#141124",
         "violet": "#a855f7", "cyan": "#22d3ee", "magenta": "#f0abfc", "danger": "#fca5a5",
         "muted": "#8b8ba7", "dim": "#5a5a6a", "faint": "#3a3a4a", "border": "#2a2a3a",
         "user-bg": "#1a1426", "user-fg": "#e9d5ff", "assistant-bg": "#101019", "tool-bg": "#0c0c14",
     },
+    # Dark but NOT black: a slate-gray dusk with brighter accents.
+    "dusk": {
+        "dark": True,
+        "bg": "#1e2130", "fg": "#d7dcec", "surface": "#262a3d", "panel": "#2c3144",
+        "violet": "#b794ff", "cyan": "#5ad1e6", "magenta": "#f0a6e0", "danger": "#ff8a8a",
+        "muted": "#9aa0b8", "dim": "#6b7090", "faint": "#454a64", "border": "#3a3f57",
+        "user-bg": "#2a2f48", "user-fg": "#e6dcff", "assistant-bg": "#242838", "tool-bg": "#1b1e2b",
+    },
     # Cold, icy: blue-steel background, electric cyan accent.
     "void": {
+        "dark": True,
         "bg": "#0a1628", "fg": "#c4d6f0", "surface": "#102540", "panel": "#142d4a",
         "violet": "#6d8bff", "cyan": "#38e0ff", "magenta": "#7dd3fc", "danger": "#fb7185",
         "muted": "#7a90aa", "dim": "#4a6080", "faint": "#2a4058", "border": "#1e3048",
@@ -52,6 +65,7 @@ _PALETTES: dict[str, dict[str, str]] = {
     },
     # Warm magma: dark cherry base, magenta + hot amber accents.
     "fracture": {
+        "dark": True,
         "bg": "#140a10", "fg": "#e2cfd6", "surface": "#200e19", "panel": "#261022",
         "violet": "#e040c0", "cyan": "#f59e0b", "magenta": "#f0abfc", "danger": "#ef4444",
         "muted": "#a88c94", "dim": "#6e505a", "faint": "#3a2830", "border": "#2e1c24",
@@ -59,10 +73,27 @@ _PALETTES: dict[str, dict[str, str]] = {
     },
     # Deep purple: extreme contrast, intense violet-on-black.
     "singularity": {
+        "dark": True,
         "bg": "#060210", "fg": "#e7dffc", "surface": "#0e0624", "panel": "#140a30",
         "violet": "#b388ff", "cyan": "#d0bcff", "magenta": "#f5d0fe", "danger": "#fb7185",
         "muted": "#9080bc", "dim": "#5e4a80", "faint": "#382a52", "border": "#281c3c",
         "user-bg": "#1a0e36", "user-fg": "#efe4ff", "assistant-bg": "#0e0820", "tool-bg": "#080414",
+    },
+    # LIGHT — warm daylight: off-white bg, dark slate text, the rift glow by day.
+    "dawn": {
+        "dark": False,
+        "bg": "#faf7ff", "fg": "#2a2438", "surface": "#f1ecfb", "panel": "#e9e1f7",
+        "violet": "#7c3aed", "cyan": "#0891b2", "magenta": "#c026d3", "danger": "#dc2626",
+        "muted": "#6b6480", "dim": "#8b84a0", "faint": "#cabfe0", "border": "#d8cef0",
+        "user-bg": "#ede4ff", "user-fg": "#3b1f6b", "assistant-bg": "#f4eefc", "tool-bg": "#f0ecf6",
+    },
+    # LIGHT — neutral paper: calm near-white, near-black text, low-chroma accents.
+    "paper": {
+        "dark": False,
+        "bg": "#f7f7f5", "fg": "#222220", "surface": "#efefec", "panel": "#e7e7e3",
+        "violet": "#6d28d9", "cyan": "#0e7490", "magenta": "#a21caf", "danger": "#b91c1c",
+        "muted": "#6a6a64", "dim": "#8c8c84", "faint": "#cfcfc8", "border": "#dcdcd5",
+        "user-bg": "#eceae4", "user-fg": "#2a2a26", "assistant-bg": "#f2f1ec", "tool-bg": "#eeeee9",
     },
 }
 
@@ -74,7 +105,7 @@ DEFAULT_THEME = "rift"
 def css_variable_defaults() -> dict[str, str]:
     """Fallback CSS variables so ``$name`` always resolves, even before our
     theme is active (e.g. during the very first paint under a built-in theme)."""
-    return dict(_PALETTES[DEFAULT_THEME])
+    return {k: v for k, v in _PALETTES[DEFAULT_THEME].items() if isinstance(v, str)}
 
 
 def palette(app) -> dict[str, str]:

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -48,6 +48,27 @@ async def test_config_modal_renders_all_fields():
 
 
 @pytest.mark.asyncio
+async def test_theme_previews_live_and_reverts_on_cancel():
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="ollama_chat/x", api_base="http://localhost:11434", theme="rift")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            assert app.theme == "rift"
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            # changing the dropdown previews instantly — before Save
+            app.screen.query_one("#cfg-theme", Select).value = "paper"
+            await pilot.pause()
+            assert app.theme == "paper", "theme should preview live"
+            # cancelling reverts to the original
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.theme == "rift", "cancel should revert the preview"
+
+
+@pytest.mark.asyncio
 async def test_config_modal_saves_changes():
     with tempfile.TemporaryDirectory() as d:
         _patch_paths(Path(d))


### PR DESCRIPTION
Two issues: every theme was near-black, and changing the theme in `/config` didn't apply until you hit Save and the dialog closed.

## Lighter / more varied themes (`theme.py`)
The four themes all had near-black backgrounds. Added **3 new themes** spanning the range (kept the 4 dark signatures; `rift` stays default per your call):
- **`dusk`** — slate-gray (`#1e2130`), "dark but not black" with brighter accents
- **`dawn`** — light, warm off-white (`#faf7ff`) with dark slate text
- **`paper`** — light, calm near-white (`#f7f7f5`) with near-black text

**Key fix:** the `dark` flag was hardcoded `True`, which would make Textual render built-in widgets (buttons, dropdowns, scrollbars) with wrong contrast on a light background. It's now **palette-driven** — light themes set `dark=False`. Verified by rendering screenshots and measuring luminance: `paper`/`dawn` are dark-on-light (readable), `dusk` is light-on-slate (correct for a dark theme).

Theme set is now: `rift` · `dusk` · `void` · `fracture` · `singularity` (dark) · `dawn` · `paper` (light).

## Live theme preview in `/config` (`config_screen.py`)
- Picking a theme in the dropdown now **previews instantly** (`on_select_changed` → reuses the existing `/theme` live-switch path) — no Save needed.
- **Cancel/Escape reverts** to the theme that was active when you opened the modal, so backing out doesn't strand you on a half-chosen theme.
- Save behaves as before (keeps + persists the choice).

## Verification
- Rendered `paper`/`dawn`/`dusk` via `save_screenshot`; confirmed backgrounds + `dark=False` apply and text contrasts correctly
- ruff PASS · pyright 0 errors · **62 tests** (+ live-preview/revert test) · smoke PASS (asserts the 7-theme set + that a light theme exists)
- `rift` confirmed still the default; HELP + `docs/configuration.md` list the new set

🤖 Generated with [Claude Code](https://claude.com/claude-code)