### PR TITLE
release 0.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.0.6"
+version = "0.0.7"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/__init__.py
+++ b/riftor/__init__.py
@@ -3,4 +3,4 @@
 Find the rift. Open it. Cross through.
 """
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/todo.md
+++ b/todo.md
@@ -146,7 +146,10 @@ tested (pytest + headless smoke), type-checked (pyright) and lint-clean.
 - uv 0.11.14, Python 3.12.3 at /usr/bin/python3
 - **Cloud-first**: default model `anthropic/claude-sonnet-4-6`; key in local
   config (`~/.config/riftor/config.toml`, perms 600, outside the repo)
-- Latest release: **0.0.4** (auto-published via trusted publishing + auto GitHub Release)
+- Latest release: **0.0.7** (auto-published via trusted publishing + auto GitHub Release).
+  0.0.5 lazy-loaded litellm (fast startup) + tighter demo; 0.0.6 synced the PyPI
+  readme; 0.0.7 adds `/doctor`, the redesigned config/permission modals, and
+  light themes + live theme preview.
 - Local Ollama is a supported fallback, not the identity
 - Reference reads: NousResearch/hermes-agent (Python analog), earendil-works/pi (minimal core)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Version bump to **0.0.7** (`pyproject.toml` + `riftor/__init__.py` + `uv.lock`) + roadmap refresh.

## What ships since 0.0.6
- **`/doctor`** — surface which external recon tools (nmap/httpx/nuclei/…) are installed, up front instead of mid-task (TUI command, `Ctrl+P` palette, startup heads-up, and `riftor --doctor`)
- **Redesigned config + permission modals** — aligned label/field rows, grouped sections, diff preview before write/edit, equal-width footer
- **Light/mid themes** — `dawn`, `paper` (light) and `dusk` (slate), with the `dark` flag now palette-driven; plus **live theme preview** in `/config` (reverts on cancel)

## On merge
Tagging `v0.0.7` triggers `release.yml` → builds, publishes to PyPI (trusted publishing), and creates the GitHub Release. `twine check` already passes locally on both artifacts; version is consistent across all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)