### PR TITLE
fix(tui): keep /config Save·Cancel buttons on-screen on short terminals

### DIFF
--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -73,6 +73,14 @@ ConfirmScreen, ConfigScreen {
     border: round $violet;
 }
 
+/* config card lays out as: title (auto) · body (flexes/scrolls) · footer (auto).
+   The flexing body is what keeps the Save/Cancel footer on-screen even on short
+   terminals — without this the body's fixed height pushed the buttons off the
+   bottom. */
+#config-box {
+    layout: vertical;
+}
+
 /* title bar — bold, with an underline rule that spans the card */
 #confirm-title, #config-title {
     width: 1fr;
@@ -84,9 +92,11 @@ ConfirmScreen, ConfigScreen {
 }
 
 /* — config body & field rows — */
+/* 1fr so the body takes only the space left after the title + footer, and
+   scrolls inside it. This guarantees the footer buttons stay visible on short
+   terminals. height:auto would let the body grow and shove the footer off. */
 #config-body {
-    height: auto;
-    max-height: 28;
+    height: 1fr;
     padding: 0;
 }
 

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from textual.widgets import Input, Select, Switch
+from textual.widgets import Button, Input, Select, Switch
 
 import riftor.config as cfgmod
 from riftor.config import Config
@@ -45,6 +45,26 @@ async def test_config_modal_renders_all_fields():
             assert len(list(screen.query(".field-label"))) == 6
             await pilot.press("escape")
             await pilot.pause()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("height", [24, 30, 40])
+async def test_save_cancel_buttons_visible_on_short_terminals(height):
+    # regression: the footer used to render below the viewport on short terminals
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="ollama_chat/x", api_base="http://localhost:11434")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test(size=(90, height)) as pilot:
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            for bid in ("#save", "#cancel"):
+                btn = app.screen.query_one(bid, Button)
+                r = btn.region
+                assert r.y >= 0 and (r.y + r.height) <= height, (
+                    f"{bid} off-screen at height={height}: y={r.y} h={r.height}"
+                )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug
The Save/Cancel buttons don't show in `/config` on a normal-height terminal.

**Cause:** the modal body had a fixed `max-height: 28` while the card was capped at `90%` of the screen. On a 24–30 row terminal, title + body + footer exceeded the viewport, so the footer rendered *below* the screen (buttons at y=34 on a 24-row terminal). It only appeared on tall 40+ row terminals — which is why the earlier screenshot test missed it.

## Fix
Lay the card out vertically with the **body as the flexing region** (`height: 1fr`): it takes only the space left after the title and footer and scrolls inside it, so the footer is always pinned and visible. The fields still all reachable via the body's scroll.

Verified buttons on-screen at heights **24 / 30 / 40 / 50** (were off-screen at 24/30 before).

## Tests
- New parametrized regression test asserts both buttons stay within the viewport at heights 24/30/40.
- ruff PASS · pyright 0 errors · **65 tests** · smoke PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)