### PR TITLE
release 0.0.8 — fix /config buttons off-screen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.0.7"
+version = "0.0.8"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/__init__.py
+++ b/riftor/__init__.py
@@ -3,4 +3,4 @@
 Find the rift. Open it. Cross through.
 """
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/todo.md
+++ b/todo.md
@@ -146,10 +146,11 @@ tested (pytest + headless smoke), type-checked (pyright) and lint-clean.
 - uv 0.11.14, Python 3.12.3 at /usr/bin/python3
 - **Cloud-first**: default model `anthropic/claude-sonnet-4-6`; key in local
   config (`~/.config/riftor/config.toml`, perms 600, outside the repo)
-- Latest release: **0.0.7** (auto-published via trusted publishing + auto GitHub Release).
+- Latest release: **0.0.8** (auto-published via trusted publishing + auto GitHub Release).
   0.0.5 lazy-loaded litellm (fast startup) + tighter demo; 0.0.6 synced the PyPI
   readme; 0.0.7 adds `/doctor`, the redesigned config/permission modals, and
-  light themes + live theme preview.
+  light themes + live theme preview; 0.0.8 patches the `/config` Save·Cancel
+  buttons rendering off-screen on short terminals.
 - Local Ollama is a supported fallback, not the identity
 - Reference reads: NousResearch/hermes-agent (Python analog), earendil-works/pi (minimal core)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Patch release. Bumps to **0.0.8** (`pyproject.toml` + `__init__.py` + `uv.lock`) + roadmap.

## Fixes
- **`/config` Save·Cancel buttons rendered off-screen** on normal-height (24–30 row) terminals — the modal footer is now always pinned and visible (body flexes/scrolls). Shipped fix from #9.

On merge, tag `v0.0.8` → `release.yml` builds, publishes to PyPI, and creates the GitHub Release. `twine check` passes locally; versions consistent across all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)