### PR TITLE
ci: bump actions to Node-24 majors (silence Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Run JS actions on Node 24 (silences the Node 20 deprecation notice).
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - name: Sync (locked)

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,16 +17,15 @@ permissions:
   contents: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   ANTHROPIC_API_KEY: sk-demo  # dummy; the tape only uses offline commands
 
 jobs:
   gif:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
       - name: Install riftor (on PATH for VHS)
         run: |
           uv venv /opt/rv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,13 @@ on:
     tags:
       - "v*"
 
-# Run JS actions on Node 24 (silences the Node 20 deprecation notice).
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - name: Verify tag matches pyproject version
@@ -41,7 +37,7 @@ jobs:
           test "$TAG" = "$VER" || { echo "::error::tag v$TAG != pyproject version $VER"; exit 1; }
       - name: Build sdist + wheel
         run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -53,7 +49,7 @@ jobs:
     permissions:
       id-token: write  # required for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -66,12 +62,12 @@ jobs:
     permissions:
       contents: write  # required to create the GitHub Release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
Silences the recurring **"Node.js 20 is deprecated"** warnings on the release/demo runs by moving every action to a major version that runs on Node 24 natively.

| Action | Was | Now | Note |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | Node-24 major |
| `astral-sh/setup-uv` | v5 | **v6** | Node-24 |
| `actions/upload-artifact` | v4 | **v6** | v6 is the first to *default* to Node 24 (v5 still ran Node 20) |
| `actions/download-artifact` | v4 | **v7** | Node-24; deliberately not v8 (v8 errors on hash mismatch — unneeded here) |
| `softprops/action-gh-release` | v2 | **v3** | Node-24 runtime, no API change |

Also **removed the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env** from all three workflows — that was the workaround that forced Node 24 onto the old actions; it's redundant now that the actions are natively Node 24.

CI-only change (no Python touched). All three workflow YAMLs validated; smoke still passes locally. The real proof is the next release run rendering with no Node 20 annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)