### PR TITLE
ci: bump astral-sh/setup-uv v6 → v8 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
       - name: Sync (locked)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - name: Sync (locked)

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install riftor (on PATH for VHS)
         run: |
           uv venv /opt/rv

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
       - name: Install riftor (on PATH for VHS)
         run: |
           uv venv /opt/rv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
       - name: Verify tag matches pyproject version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - name: Verify tag matches pyproject version

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.0.8"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary

`astral-sh/setup-uv@v6` runs on **Node.js 20**, which GitHub Actions is retiring — runners force Node 24 on **2026-06-16** and remove Node 20 on 2026-09-16. The `v0.1.0` release workflow surfaced this deprecation annotation.

This bumps `setup-uv` to **`@v8`** (latest major) in all three workflows. v8's `action.yml` declares `runs.using: node24`, clearing the warning. This matches the repo's earlier "bump actions to Node-24 majors" pass (`09e3f32`), which had updated the other actions but left `setup-uv` on v6.

Also commits the `uv.lock` `0.0.8 → 0.1.0` version sync that should have landed with the release bump.

### Changed
- `.github/workflows/ci.yml` — `setup-uv@v6` → `@v8`
- `.github/workflows/demo.yml` — `setup-uv@v6` → `@v8`
- `.github/workflows/release.yml` — `setup-uv@v6` → `@v8`
- `uv.lock` — sync riftor to 0.1.0

## Test Plan
- [ ] CI (`test (3.11)`, `test (3.12)`) passes on this PR with no Node 20 deprecation annotation from setup-uv