### PR TITLE
ci: add Dependabot (github-actions, uv, docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot keeps dependencies current across the repo's three ecosystems.
+# Minor/patch bumps are grouped into one PR per ecosystem to keep noise low;
+# majors come as their own PRs (they may need code changes). CI (ci.yml) runs
+# on every Dependabot PR, so a green check is the signal it's safe to merge.
+version: 2
+updates:
+  # GitHub Actions — e.g. setup-uv, checkout, upload-artifact.
+  # NB: setup-uv pins an exact version (v8.x dropped floating major tags), so
+  # Dependabot is how those action pins stay current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:17"
+    groups:
+      actions:
+        update-types: ["minor", "patch"]
+
+  # Python deps (pyproject.toml + uv.lock).
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:17"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Dockerfile base image.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:17"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to keep dependencies current across the repo's three ecosystems:

- **`github-actions`** — action pins (setup-uv, checkout, upload/download-artifact, etc.). This is the main motivation: `setup-uv` now pins an exact version (`v8.x` dropped floating major tags), so Dependabot is how those pins stay current.
- **`uv`** — Python deps in `pyproject.toml` / `uv.lock` (uses Dependabot's native `uv` ecosystem).
- **`docker`** — the `Dockerfile` base image.

### Noise control
- **Weekly** schedule (Monday, off-peak minute).
- Minor + patch updates **grouped into one PR per ecosystem**; majors come as separate PRs since they may need code changes.
- Existing CI (`ci.yml`: lint, types, pytest, smoke) runs on each Dependabot PR — a green check is the merge signal.

## Test Plan
- [x] `dependabot.yml` validates as YAML, `version: 2`, 3 ecosystems, `directory: /`, weekly
- [ ] After merge: GitHub parses the config without errors (Insights → Dependency graph → Dependabot shows the three ecosystems)