### PR TITLE
ci: verify Docker image in CI + fix riftor --version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
         run: uv run pytest
       - name: Smoke (headless TUI integration)
         run: uv run python dev/smoke.py
+
+  docker:
+    # Builds the image and runs it once, so Dockerfile changes (and Dependabot
+    # base-image bumps) are actually verified — `test` runs on the runner's
+    # Python and never exercises the container.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build image
+        run: docker build -t riftor:ci .
+      - name: Smoke (riftor runs in the container)
+        run: docker run --rm riftor:ci --version

--- a/riftor/__init__.py
+++ b/riftor/__init__.py
@@ -3,4 +3,12 @@
 Find the rift. Open it. Cross through.
 """
 
-__version__ = "0.0.8"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Single source of truth: the version declared in pyproject.toml, read from
+    # the installed package metadata. Avoids drift between the package version
+    # and what `riftor --version` reports.
+    __version__ = version("riftor")
+except PackageNotFoundError:  # running from a source tree that isn't installed
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

Adds a **`docker` job** to `ci.yml` that builds the image and runs it once (`riftor --version`). Until now `test` only ran on the runner's Python and never exercised the container, so Dockerfile changes — including Dependabot base-image bumps like #18 — shipped unverified by CI.

While wiring that up, the new container smoke surfaced a **real bug**: `riftor/__init__.py` hardcoded `__version__ = "0.0.8"` separately from `pyproject.toml`. So `riftor --version` reported `0.0.8` **even on the 0.1.0 release**. Fixed by deriving `__version__` from `importlib.metadata.version("riftor")` (single source of truth = the installed package metadata), with a `0.0.0+unknown` fallback for uninstalled source trees.

### Changes
- `.github/workflows/ci.yml` — new `docker` job: `docker build` + `docker run … --version`.
- `riftor/__init__.py` — `__version__` now reads package metadata; no more drift.

## Test Plan
- [x] `uv run pytest` — 93 passed; `ruff` clean; `pyright` 0 errors
- [x] Local: `uv run riftor --version` → `riftor 0.1.0` (was `0.0.8`)
- [x] Local: `docker build --no-cache` + `docker run --rm riftor:ci --version` → `riftor 0.1.0`
- [ ] CI: new `docker` job passes on this PR

> Note: the published `riftor 0.1.0` on PyPI will still self-report `0.0.8` until a subsequent release carries this fix. Worth a patch release (0.1.1) after merge if the reported version matters.