### PR TITLE
feat(tools): add_scope — agent can request in-scope additions (approval-gated)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,6 +112,12 @@ Manage rules live with `/permissions allow <tool> [pattern]` and
 an approval prompt. In headless mode (`--prompt`), approval-gated tools only run
 if a standing `allow` rule exists.
 
+The agent can **request** adding in-scope targets itself via the `add_scope` tool
+(e.g. a subdomain it discovered on an in-scope host). Like other privileged tools
+it is **approval-gated**: you confirm it in the prompt, and in headless mode it is
+blocked unless you add an `allow` rule for `add_scope`. The agent can only *widen*
+scope this way — removing, excluding, and clearing remain operator-only via `/scope`.
+
 ## Keybindings — `~/.config/riftor/keybindings.toml`
 
 Override the built-in hotkeys (`action = key`):

--- a/riftor/tools/__init__.py
+++ b/riftor/tools/__init__.py
@@ -13,6 +13,7 @@ from riftor.tools.core import (
     WriteTool,
 )
 from riftor.tools.engagement import (
+    AddScopeTool,
     DeleteFindingTool,
     EditFindingTool,
     GenerateReportTool,
@@ -39,6 +40,7 @@ ALL_TOOLS: list[Tool] = [
     EditFindingTool(),
     DeleteFindingTool(),
     GenerateReportTool(),
+    AddScopeTool(),
     WriteTool(),
     EditTool(),
     BashTool(),

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -51,6 +51,72 @@ class ScopeListTool(Tool):
         )
 
 
+class AddScopeTool(Tool):
+    name = "add_scope"
+    requires_permission = True
+    description = (
+        "Request adding one or more targets to the IN-SCOPE list so you can test "
+        "them (e.g. a subdomain discovered on an in-scope host). Requires operator "
+        "approval. This only WIDENS scope — you cannot remove or exclude targets. "
+        "Give a clear reason so the operator can decide."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "targets": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Targets to add: IP, CIDR, domain, or *.wildcard.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why these belong in scope (shown to the operator).",
+            },
+        },
+        "required": ["targets", "reason"],
+    }
+
+    def preview(self, args: dict) -> str:
+        targets = args.get("targets") or []
+        if isinstance(targets, str):
+            targets = [targets]
+        joined = ", ".join(str(t) for t in targets) or "(none)"
+        reason = str(args.get("reason") or "").strip()
+        text = f"add to scope: {joined}"
+        if reason:
+            text += f' — "{reason}"'
+        return text[:300]
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        eng = ctx.engagement
+        if eng is None:
+            return ToolResult("error: no active engagement", is_error=True)
+        raw_targets = args.get("targets")
+        if isinstance(raw_targets, str):
+            raw_targets = [raw_targets]
+        targets = [str(t).strip() for t in (raw_targets or []) if str(t).strip()]
+        if not targets:
+            return ToolResult("error: no targets given", is_error=True)
+
+        existing = {t.raw for t in eng.scope.in_scope}
+        added: list[str] = []
+        already: list[str] = []
+        for raw in targets:
+            target = eng.add_scope(raw, "in")  # parse + persist + log
+            if target.raw in existing:
+                already.append(target.raw)
+            else:
+                existing.add(target.raw)
+                added.append(target.raw)
+
+        if not added and already:
+            return ToolResult(f"already in scope: {', '.join(already)}")
+        msg = f"added {len(added)} target(s) to scope: {', '.join(added)}"
+        if already:
+            msg += f" · {len(already)} already present"
+        return ToolResult(msg)
+
+
 class RecordServiceTool(Tool):
     name = "record_service"
     description = "Record a discovered host/port/service in the engagement state."

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -145,3 +145,18 @@ async def test_add_scope_accepts_scalar_target(toolctx):
     )
     assert not r.is_error
     assert any(t.raw == "solo.example.com" for t in toolctx.engagement.scope.in_scope)
+
+
+def test_add_scope_blocked_headless_without_allow_rule():
+    # The headless gate (headless.py) denies a requires_permission tool unless an
+    # allow-rule exists — so the agent cannot self-scope unattended. Assert via the
+    # exact Permissions check headless.py uses:
+    #   `tool.requires_permission and not permissions.is_allowed(tool.name, preview)`
+    from riftor.safety.permissions import Permissions
+    perms = Permissions()  # empty allow-rules + safe default deny
+    tool = tools.get("add_scope")
+    preview = tool.preview({"targets": ["x.com"], "reason": "r"})
+    assert tool.requires_permission is True
+    assert not perms.is_allowed(tool.name, preview)   # no allow-rule -> headless denies
+    perms.add_allow_rule(tool.name)
+    assert perms.is_allowed(tool.name, preview)        # operator opts in -> allowed

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -106,3 +106,42 @@ def test_add_scope_tool_metadata():
     assert set(tool.parameters["required"]) == {"targets", "reason"}
     prev = tool.preview({"targets": ["a.com", "b.com"], "reason": "why"})
     assert "a.com" in prev and "why" in prev
+
+
+@pytest.mark.asyncio
+async def test_add_scope_no_engagement():
+    from riftor.tools.base import ToolContext
+    ctx = ToolContext()  # engagement defaults to None
+    r = await tools.get("add_scope").execute(
+        {"targets": ["x.com"], "reason": "r"}, ctx
+    )
+    assert r.is_error
+    assert "no active engagement" in r.content
+
+
+@pytest.mark.asyncio
+async def test_add_scope_empty_targets(toolctx):
+    r = await tools.get("add_scope").execute({"targets": [], "reason": "r"}, toolctx)
+    assert r.is_error
+    assert "no targets" in r.content
+
+
+@pytest.mark.asyncio
+async def test_add_scope_reports_already_present(toolctx):
+    eng = toolctx.engagement
+    eng.add_scope("dup.example.com", "in")
+    r = await tools.get("add_scope").execute(
+        {"targets": ["dup.example.com"], "reason": "r"}, toolctx
+    )
+    assert not r.is_error
+    assert "already in scope" in r.content
+    assert sum(t.raw == "dup.example.com" for t in eng.scope.in_scope) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_scope_accepts_scalar_target(toolctx):
+    r = await tools.get("add_scope").execute(
+        {"targets": "solo.example.com", "reason": "r"}, toolctx
+    )
+    assert not r.is_error
+    assert any(t.raw == "solo.example.com" for t in toolctx.engagement.scope.in_scope)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -77,3 +77,32 @@ async def test_record_finding_dedup_skip(toolctx):
     r = await rf.execute({"title": "Dup", "severity": "high", "host": "h"}, toolctx)
     assert "skipped" in r.content
     assert toolctx.engagement.findings_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_add_scope_adds_in_scope_targets(toolctx):
+    eng = toolctx.engagement
+    r = await tools.get("add_scope").execute(
+        {"targets": ["admin.example.com", "10.0.0.0/24"],
+         "reason": "found in DNS of in-scope example.com"},
+        toolctx,
+    )
+    assert not r.is_error, r.content
+    raws = {t.raw for t in eng.scope.in_scope}
+    assert "admin.example.com" in raws
+    assert "10.0.0.0/24" in raws
+    # added in-scope only — nothing landed in out-of-scope
+    assert eng.scope.out_of_scope == []
+
+
+def test_add_scope_tool_metadata():
+    tool = tools.get("add_scope")
+    assert tool is not None
+    assert tool.requires_permission is True
+    # must NOT be scope_sensitive (it edits the scope list, doesn't touch a host)
+    assert tool.scope_sensitive is False
+    props = tool.parameters["properties"]
+    assert "targets" in props and "reason" in props
+    assert set(tool.parameters["required"]) == {"targets", "reason"}
+    prev = tool.preview({"targets": ["a.com", "b.com"], "reason": "why"})
+    assert "a.com" in prev and "why" in prev


### PR DESCRIPTION
## Summary

Adds an `add_scope` agent tool so the agent can **request** adding targets to its own **in-scope** list (e.g. a subdomain it discovers on an in-scope host) instead of the operator hand-editing scope.

Safety is the core of the design:
- **Operator-approved, not auto-add.** The tool sets `requires_permission = True`, so it routes through the existing approval flow — `ConfirmScreen` interactively, and blocked in headless mode unless a standing `allow` rule exists. The agent can only *request*; the operator's approval is what widens the guardrail.
- **Widen-only.** It calls `engagement.add_scope(raw, "in")` exclusively — it can never remove, clear, or add out-of-scope/exclusion entries. Those stay operator-only via `/scope`.
- **Not `scope_sensitive`** — it edits the scope list itself, so its own target args aren't circularly checked against scope.

The agent provides `targets` (IP / CIDR / domain / `*.wildcard`) + a `reason`, both shown to the operator in the approval prompt.

### Implementation
- `riftor/tools/engagement.py` — new `AddScopeTool` (preview shows targets + reason; dedupes already-present; coerces a scalar target string; errors cleanly with no engagement / empty targets).
- `riftor/tools/__init__.py` — registered in `ALL_TOOLS` in the mutating/needs-approval region.
- No changes to `app.py`/`headless.py` — the approval gate is reused automatically via `requires_permission`.
- `docs/configuration.md` — documents the approval-gated, widen-only behavior.

Spec: `docs/superpowers/specs/2026-06-03-agent-add-scope-tool-design.md`
Plan: `docs/superpowers/plans/2026-06-03-agent-add-scope-tool.md`

## Test Plan
- [x] `uv run pytest` — 100 passed; `ruff` clean; `pyright` 0 errors
- [x] 7 `add_scope` tests: happy path, no-engagement, empty, dedupe/already-present, scalar coercion, metadata (`requires_permission` True / `scope_sensitive` False), headless-gated-without-allow-rule
- [x] Holistic security review: no path for the agent to widen scope without operator approval
- [ ] CI (`test 3.11/3.12`, `docker`) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)