### PR TITLE
feat: command autocomplete with dropdown in TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development commands
+
+All commands use `uv` (Astral's Python package manager). Install dev dependencies once: `uv sync --extra dev`.
+
+| Task | Command |
+|------|---------|
+| Launch TUI | `uv run riftor` |
+| Lint | `uv run ruff check riftor dev tests` |
+| Type check | `uv run pyright riftor` |
+| Unit tests | `uv run pytest` |
+| Single test | `uv run pytest tests/test_tools.py::test_function_name` |
+| Smoke test | `uv run python dev/smoke.py` |
+| All CI gates | `make check` (runs lint → typecheck → test → smoke) |
+| Build | `uv build` |
+| Pre-commit hooks | `make install-hooks` or `uv run pre-commit install` |
+
+CI runs lint, type check, unit tests, and smoke on Python 3.11 + 3.12. All tests run **offline** — no API key or model needed.
+
+## Architecture
+
+riftor is a Python 3.11+ TUI pentest assistant: a Textual full-screen app backed by litellm, organized around the **RIFT** methodology (Recon → Intrusion → Foothold → Takeover).
+
+### Entry and dispatch (`riftor/__main__.py`)
+
+CLI arg parsing → loads config → dispatches to one of three paths:
+- `--config`: prints config path and exits
+- `--doctor`: checks installed recon tools and exits
+- `--prompt` / `--headless`: runs `headless.py` (one-shot, non-interactive)
+- default: launches `tui/app.py` (the full Textual app)
+
+### Agent loop (shared by TUI and headless)
+
+The core loop lives in both `tui/app.py` and `headless.py` — they share the same pattern:
+
+1. User input → added to `Context` (conversation history)
+2. `Provider.stream_turn(messages, tool_schemas)` — streams text deltas via litellm, yields a `Turn` with optional tool calls
+3. If the turn has tool calls, execute each one via the tool registry (`tools/__init__.py`)
+4. Dangerous tools (bash/write/edit) go through the `Permissions` engine for approval; scope-sensitive tools are checked against the engagement scope
+5. Tool results are added to context; loop continues up to `max_steps` iterations or until no tool calls remain
+
+### Sub-packages
+
+- **`riftor/agent/`** — LLM abstraction. `provider.py` wraps litellm (streaming, tool calling, retry/backoff, error classification). litellm is **lazily imported** (~2.4s) on first model call to keep startup fast. `context.py` manages conversation history with compaction and repair. `session.py` persists sessions as JSON with crash-safe atomic writes.
+- **`riftor/tui/`** — Textual app. `app.py` contains the agent loop, all slash commands, scope enforcement, and permission modals. `theme.py` defines 6 themes (rift/dusk/void/fracture/singularity/dawn/paper) using Textual CSS variables.
+- **`riftor/tools/`** — Agent-callable tool system. **All tools must be registered in `tools/__init__.py`** in the `ALL_TOOLS` list (order is safe→mutating, which is also the order shown to the model). Each tool extends `Tool` (ABC in `base.py`) and returns `ToolResult`. Tools are UI-agnostic — they return data; the app renders it. `core.py` has bash/read/write/edit/grep/glob/webfetch. `engagement.py` has RIFT-specific tools.
+- **`riftor/engagement/`** — RIFT methodology engine. `scope.py` does IP/CIDR/domain/wildcard matching for scope enforcement. `state.py` is the SQLite-backed persistence layer (scope, hosts, services, findings, activity log). `cvss.py` is pure-Python CVSS v3.1 scoring (no deps). `report.py` renders reports in md/html/json/SARIF.
+- **`riftor/safety/`** — Trust and safety. `permissions.py` implements layered permissions (deny rules → allow rules → session grants → operator prompt). Default deny rules guard against destructive bash commands (`rm -rf`, `dd of=/dev/…`, `mkfs`, fork bombs). `audit.py` provides JSONL audit logging with gzip rotation.
+
+### Key design conventions
+
+- **Bad config never crashes.** Malformed config or permission files degrade silently to defaults on load — the app always starts. This pattern appears in `Config.load()`, `Permissions.load()`, and scope-file preloading.
+- **Tools are independent of the UI.** `Tool.execute()` returns a `ToolResult`; both the TUI and headless mode call the same execute methods and just render results differently.
+- **Headless mode is restrictive.** Dangerous tools (bash/write/edit) auto-deny in headless mode unless an explicit allow rule exists in `permissions.toml` (no interactive operator to approve). Out-of-scope calls are always blocked.
+- **Engagement state is per-workdir.** Each working directory gets its own `.riftor/` directory with an `engagement.db` (SQLite), `sessions/`, and `reports/`. Sessions auto-save and resume.
+- **Context windows vary by provider.** The status bar shows a context-window gauge using per-provider estimates: Anthropic 200k, OpenAI/OpenRouter 128k, Gemini 1M, Ollama 8k, default 128k.
+- **`uv.lock` is committed** for reproducible installs. Dependencies are pinned.

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -35,7 +35,7 @@ from riftor.safety.permissions import ConfirmScreen, Permissions
 from riftor.tools import ToolContext, ToolResult
 from riftor.tui.config_screen import ConfigScreen
 from riftor.tui.theme import THEMES, css_variable_defaults, palette
-from riftor.tui.widgets import STAGE_NAMES, Banner, StatusBar
+from riftor.tui.widgets import STAGE_NAMES, Banner, CommandDropdown, StatusBar
 
 if TYPE_CHECKING:
     from riftor.config import Config
@@ -175,6 +175,7 @@ class RiftorApp(App):
         yield Banner(id="banner")
         yield VerticalScroll(id="chat")
         yield StatusBar(self.config.model, lore=self.config.lore)
+        yield CommandDropdown(_COMMANDS, id="cmd-dropdown")
         yield Input(placeholder="task riftor — or /help", id="prompt")
 
     def get_css_variables(self) -> dict[str, str]:
@@ -274,6 +275,10 @@ class RiftorApp(App):
     def status(self) -> StatusBar:
         return self.query_one(StatusBar)
 
+    @property
+    def cmd_dropdown(self) -> CommandDropdown:
+        return self.query_one("#cmd-dropdown", CommandDropdown)
+
     # ---- mount helpers ---------------------------------------------------------
     def _pal(self) -> dict[str, str]:
         return palette(self)
@@ -304,6 +309,21 @@ class RiftorApp(App):
 
     # ---- events ----------------------------------------------------------------
     def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Dropdown selection: if the dropdown is visible and the user hasn't
+        # typed an exact command match, fill with the highlighted suggestion.
+        # Exact matches pass through to normal command dispatch.
+        if self.cmd_dropdown.visible:
+            text = event.value.strip()
+            if text not in _COMMANDS:
+                cmd = self.cmd_dropdown.highlighted_command
+                if cmd:
+                    inp = self.query_one("#prompt", Input)
+                    inp.value = cmd + " "
+                    inp.cursor_position = len(inp.value)
+                    self.cmd_dropdown.hide()
+                return
+            self.cmd_dropdown.hide()
+
         text = event.value.strip()
         self.query_one("#prompt", Input).clear()
         self._history_idx = None
@@ -317,9 +337,41 @@ class RiftorApp(App):
         self._add_user(text)
         self._agent(text)
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Show the command dropdown when the user starts typing a slash command."""
+        value = event.value
+        if value.startswith("/") and " " not in value:
+            self.cmd_dropdown.filter(value)
+        else:
+            self.cmd_dropdown.hide()
+
     def on_key(self, event) -> None:
-        # ↑/↓ recall previous prompts when the input is focused and empty-ish.
         inp = self.query_one("#prompt", Input)
+
+        # Dropdown navigation — takes priority over history recall.
+        if self.cmd_dropdown.visible and inp.has_focus:
+            if event.key == "tab":
+                cmd = self.cmd_dropdown.highlighted_command
+                if cmd:
+                    inp.value = cmd + " "
+                    inp.cursor_position = len(inp.value)
+                    self.cmd_dropdown.hide()
+                event.prevent_default()
+                return
+            if event.key in ("up", "down"):
+                lv = self.cmd_dropdown.list_view
+                if event.key == "up":
+                    lv.action_cursor_up()
+                else:
+                    lv.action_cursor_down()
+                event.prevent_default()
+                return
+            if event.key == "escape":
+                self.cmd_dropdown.hide()
+                event.prevent_default()
+                return
+
+        # ↑/↓ recall previous prompts when the input is focused.
         if not inp.has_focus or event.key not in ("up", "down"):
             return
         if not self._history:

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -185,3 +185,34 @@ StatusBar {
 #prompt:focus {
     border: round $violet;
 }
+
+/* ──────────────────────────── command dropdown ──────────────────────── */
+#cmd-dropdown {
+    display: none;
+    height: auto;
+    max-height: 12;
+    margin: 0 1 0 1;
+    border: round $violet;
+    background: $panel;
+    padding: 0;
+}
+
+#cmd-dropdown.visible {
+    display: block;
+}
+
+#cmd-dropdown ListView {
+    background: $panel;
+    color: $foreground;
+    padding: 0 1;
+}
+
+#cmd-dropdown ListView > ListItem {
+    padding: 0 1;
+    color: $muted;
+}
+
+#cmd-dropdown ListView > ListItem.--highlight {
+    background: $violet 30%;
+    color: $foreground;
+}

--- a/riftor/tui/widgets.py
+++ b/riftor/tui/widgets.py
@@ -1,9 +1,11 @@
-"""Custom widgets: the riftor banner and the [R·I·F·T] status bar."""
+"""Custom widgets: the riftor banner, the [R·I·F·T] status bar, and command dropdown."""
 
 from __future__ import annotations
 
+import difflib
+
 from rich.text import Text
-from textual.widgets import Static
+from textual.widgets import ListItem, ListView, Static
 
 from riftor.tui.theme import palette
 
@@ -112,3 +114,78 @@ class StatusBar(Static):
         if self.busy:
             t.append("   ⟳ opening rift…", style=p["cyan"])
         self.update(t)
+
+
+class CommandDropdown(Static):
+    """Dropdown list of matching slash commands, shown above the input.
+
+    Hidden by default (``display: none`` in CSS). When the user types ``/`` in the
+    prompt, the app calls :meth:`filter` to show matching commands and adds the
+    ``visible`` CSS class. Tab / Enter fill the input with the highlighted command;
+    Escape dismisses the dropdown.
+    """
+
+    def __init__(self, commands: list[str], id: str = "cmd-dropdown") -> None:
+        super().__init__("")
+        self.id = id
+        self._all_commands = commands
+        self._filtered: list[str] = []
+        self._list_view: ListView | None = None
+
+    def compose(self):
+        self._list_view = ListView()
+        yield self._list_view
+
+    @property
+    def list_view(self) -> ListView:
+        assert self._list_view is not None, "ListView not mounted yet"
+        return self._list_view
+
+    @property
+    def highlighted_command(self) -> str | None:
+        if not self._filtered:
+            return None
+        idx = self.list_view.index
+        if idx is None:
+            return None
+        if 0 <= idx < len(self._filtered):
+            return self._filtered[idx]
+        return None
+
+    @property
+    def visible(self) -> bool:
+        return self.has_class("visible")
+
+    def show(self) -> None:
+        self.add_class("visible")
+
+    def hide(self) -> None:
+        self.remove_class("visible")
+
+    def filter(self, value: str) -> None:
+        """Filter commands by *value* (the raw input text, e.g. ``/fin``).
+
+        Populates the inner ``ListView`` with matching items. If nothing matches
+        by prefix, falls back to fuzzy matching via ``difflib``.
+        """
+        prefix = value.lstrip("/").casefold()
+        if not prefix:
+            matches = list(self._all_commands)
+        else:
+            matches = [c for c in self._all_commands if c.casefold().startswith("/" + prefix)]
+            if not matches:
+                fuzzy = difflib.get_close_matches(
+                    value, self._all_commands, n=8, cutoff=0.4
+                )
+                matches = fuzzy
+        self._filtered = matches
+        lv = self.list_view
+        lv.clear()
+        if matches:
+            for cmd in matches:
+                lv.append(ListItem(Static(Text(cmd))))
+            lv.index = 0
+        if matches:
+            self.show()
+        else:
+            self.hide()


### PR DESCRIPTION
## What

Adds live command autocomplete to the riftor TUI. When the user types `/` in the prompt, a dropdown appears above the input showing matching slash commands. The list filters in real-time as they type.

- **Tab** or **Enter** — fills the input with the highlighted command
- **Up/Down arrows** — navigate the dropdown
- **Escape** — dismisses the dropdown
- Typing a space or non-`/` text — auto-hides the dropdown
- Exact command matches (`/config`) — execute immediately (no intercept)

Matching uses prefix matching with fuzzy fallback via `difflib`.

## Changes

Three files + CLAUDE.md:

- **`riftor/tui/widgets.py`** — new `CommandDropdown` widget (ListView-based, hidden by default)
- **`riftor/tui/app.py`** — wires up the dropdown to `Input.Changed`, `Input.Submitted`, and key events
- **`riftor/tui/themes/rift.tcss`** — styles the dropdown using theme variables (adapts to all 6 themes)
- **`CLAUDE.md`** — initial developer guide for the repository

## Verification

- `make check` — lint ✅, typecheck ✅ (0 errors), 100 tests ✅, smoke ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)