### PR TITLE
feat: yolo mode — bypass all safety guardrails

### DIFF
--- a/riftor/__main__.py
+++ b/riftor/__main__.py
@@ -34,6 +34,12 @@ def main() -> None:
         "--headless", action="store_true",
         help="non-interactive mode; implied by --prompt. Prints the result and exits.",
     )
+    parser.add_argument(
+        "--i-know-what-i-am-doing-give-me-full-access",
+        action="store_true",
+        dest="yolo",
+        help="bypass all permission prompts, deny rules, scope enforcement, and step limits",
+    )
     args = parser.parse_args()
 
     from riftor.config import CONFIG_PATH, Config
@@ -59,7 +65,7 @@ def main() -> None:
     if args.prompt or args.headless:
         from riftor.headless import run_headless
 
-        code = run_headless(cfg, workdir, prompt=args.prompt, scope_file=args.scope_file)
+        code = run_headless(cfg, workdir, prompt=args.prompt, scope_file=args.scope_file, yolo=args.yolo)
         sys.exit(code)
 
     # Graceful first-run: if no credentials are configured, guide the operator.
@@ -68,7 +74,7 @@ def main() -> None:
 
     from riftor.tui.app import RiftorApp
 
-    app = RiftorApp(cfg, workdir=workdir)
+    app = RiftorApp(cfg, workdir=workdir, yolo=args.yolo)
     if args.scope_file:
         _preload_scope(app, args.scope_file)
     app.run()

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -28,6 +28,7 @@ def run_headless(
     *,
     prompt: str | None,
     scope_file: str | None = None,
+    yolo: bool = False,
 ) -> int:
     if not prompt:
         if not sys.stdin.isatty():
@@ -40,12 +41,12 @@ def run_headless(
         print(f"riftor: no API key for {cfg.model}; set {env}", file=sys.stderr)
         return 3
     try:
-        return asyncio.run(_run(cfg, workdir, prompt, scope_file))
+        return asyncio.run(_run(cfg, workdir, prompt, scope_file, yolo=yolo))
     except KeyboardInterrupt:
         return 130
 
 
-async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None) -> int:
+async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, yolo: bool = False) -> int:
     context = Context(lore=cfg.lore)
     provider = Provider(cfg)
     engagement = Engagement(workdir)
@@ -62,7 +63,8 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None) 
     schemas = tools.schemas()
 
     context.add_user(prompt)
-    for _ in range(cfg.max_steps):
+    max_steps = 10**9 if yolo else cfg.max_steps
+    for _ in range(max_steps):
         context.repair()
         text_parts: list[str] = []
         turn = None
@@ -83,7 +85,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None) 
         if not turn.tool_calls:
             break
         for call in turn.tool_calls:
-            await _run_tool_headless(call, engagement, permissions, audit, toolctx, context)
+            await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
     print()  # trailing newline
     return 0
 
@@ -95,6 +97,7 @@ async def _run_tool_headless(
     audit: AuditLog,
     toolctx: ToolContext,
     context: Context,
+    yolo: bool = False,
 ) -> None:
     tool = tools.get(call.name)
     if tool is None:
@@ -103,7 +106,7 @@ async def _run_tool_headless(
     preview = tool.preview(call.arguments)
     print(f"\n  ⛏ {tool.name}  {preview}", file=sys.stderr)
 
-    if getattr(tool, "scope_sensitive", False):
+    if not yolo and getattr(tool, "scope_sensitive", False):
         violations = engagement.violations(" ".join(str(v) for v in call.arguments.values()))
         if violations:
             context.add_tool_result(
@@ -113,13 +116,13 @@ async def _run_tool_headless(
             audit.record(tool.name, preview, allowed=False)
             return
 
-    if permissions.is_denied(tool.name, preview):
+    if not yolo and permissions.is_denied(tool.name, preview):
         context.add_tool_result(call.id, "[blocked by policy] denied by a deny rule.")
         audit.record(tool.name, preview, allowed=False)
         return
 
     # No operator present: dangerous tools require a standing allow rule.
-    if tool.requires_permission and not permissions.is_allowed(tool.name, preview):
+    if not yolo and tool.requires_permission and not permissions.is_allowed(tool.name, preview):
         context.add_tool_result(
             call.id,
             "[denied: headless] This tool needs approval and no allow rule exists. "

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -143,10 +143,11 @@ class RiftorApp(App):
         Binding("ctrl+end", "scroll_chat('end')", "Bottom", show=False),
     ]
 
-    def __init__(self, config: "Config", workdir: Path | None = None) -> None:
+    def __init__(self, config: "Config", workdir: Path | None = None, yolo: bool = False) -> None:
         super().__init__()
         self.config = config
         self.workdir = workdir or Path.cwd()
+        self.yolo = yolo
         self.context = Context(lore=config.lore)
         self.provider = Provider(config)
         self.tools = tools.all_tools()
@@ -174,7 +175,7 @@ class RiftorApp(App):
     def compose(self) -> ComposeResult:
         yield Banner(id="banner")
         yield VerticalScroll(id="chat")
-        yield StatusBar(self.config.model, lore=self.config.lore)
+        yield StatusBar(self.config.model, lore=self.config.lore, yolo=self.yolo)
         yield CommandDropdown(_COMMANDS, id="cmd-dropdown")
         yield Input(placeholder="task riftor — or /help", id="prompt")
 
@@ -254,6 +255,7 @@ class RiftorApp(App):
             self.engagement.scope_count(), self.engagement.enforce, self.engagement.dry_run
         )
         self.status.set_findings(self.engagement.findings_count())
+        self.status.set_yolo(self.yolo)
 
     def _context_window(self) -> int:
         for prefix, window in _CONTEXT_WINDOWS.items():
@@ -992,7 +994,7 @@ class RiftorApp(App):
             self.context.add_user(user_text)
             self._last_user_text = user_text
         self.status.set_busy(True)
-        budget = self.max_steps + extra_steps
+        budget = 10**9 if self.yolo else self.max_steps + extra_steps
         try:
             for step in range(budget):
                 self._save_session(complete=False)  # crash-safe checkpoint
@@ -1068,17 +1070,17 @@ class RiftorApp(App):
 
         # scope enforcement for target-touching tools (bash, webfetch)
         scope_warning: list[str] = []
-        if getattr(tool, "scope_sensitive", False):
+        if not self.yolo and getattr(tool, "scope_sensitive", False):
             probe = " ".join(str(v) for v in call.arguments.values())
             scope_warning = self.engagement.violations(probe)
 
         # dry-run: warn but don't block
-        if scope_warning and self.engagement.dry_run:
+        if not self.yolo and scope_warning and self.engagement.dry_run:
             self._note(f"⚠ dry-run: out of scope — {', '.join(scope_warning)} (allowed)")
             scope_warning = []
 
         # hard deny rules (e.g. bash rm -rf) — refuse without prompting
-        if self.permissions.is_denied(tool.name, preview):
+        if not self.yolo and self.permissions.is_denied(tool.name, preview):
             reason = "blocked by a deny rule"
             await self._show_tool_result(reason, is_error=True)
             self.context.add_tool_result(
@@ -1089,9 +1091,9 @@ class RiftorApp(App):
             self.audit.record(tool.name, preview, allowed=False)
             return
 
-        if scope_warning or self.permissions.needs_prompt(
+        if not self.yolo and (scope_warning or self.permissions.needs_prompt(
             tool.name, tool.requires_permission, preview
-        ):
+        )):
             detail = tool.confirm_detail(call.arguments, self.toolctx)
             decision = await self.push_screen_wait(
                 ConfirmScreen(tool.name, preview, scope_warning=scope_warning, detail=detail)

--- a/riftor/tui/widgets.py
+++ b/riftor/tui/widgets.py
@@ -24,11 +24,12 @@ class Banner(Static):
 
 
 class StatusBar(Static):
-    def __init__(self, model: str, stage: str = "R", lore: bool = True) -> None:
+    def __init__(self, model: str, stage: str = "R", lore: bool = True, yolo: bool = False) -> None:
         super().__init__()
         self.model = model
         self.stage = stage
         self.lore = lore
+        self.yolo = yolo
         self.busy = False
         self.scope_count = 0
         self.enforce = True
@@ -51,6 +52,10 @@ class StatusBar(Static):
 
     def set_lore(self, lore: bool) -> None:
         self.lore = lore
+        self.refresh_bar()
+
+    def set_yolo(self, yolo: bool) -> None:
+        self.yolo = yolo
         self.refresh_bar()
 
     def set_stage(self, stage: str) -> None:
@@ -111,6 +116,8 @@ class StatusBar(Static):
         t.append(self.model, style=p["muted"])
         t.append("   lore:", style=p["dim"])
         t.append("on" if self.lore else "off", style=p["muted"])
+        if self.yolo:
+            t.append("   ⚡ yolo", style=f"bold {p['danger']}")
         if self.busy:
             t.append("   ⟳ opening rift…", style=p["cyan"])
         self.update(t)


### PR DESCRIPTION
## What

Adds `--i-know-what-i-am-doing-give-me-full-access` CLI flag that bypasses all safety guardrails:

- **Permission prompts** — bash/write/edit auto-approved, no ConfirmScreen
- **Deny rules** — `rm -rf`/`dd`/`mkfs`/fork bombs all allowed
- **Scope enforcement** — any target allowed, in or out of scope
- **Step budget** — unlimited tool-call turns (10⁹ instead of 16)
- **Status bar** — shows `⚡ yolo` in bold red when active

## Design

- **CLI-only** — not persisted in config.toml. Yolo is a deliberate per-run choice.
- **Audit log still records** — all tool calls are logged. Yolo skips prompts, not accountability.
- **Headless mode** — same bypass behavior applies.
- **Unlimited steps** — uses 10⁹ as the step budget so the agent never hits the limit.

## Changes

4 files:
- **`__main__.py`** — `--i-know-what-i-am-doing-give-me-full-access` flag
- **`tui/widgets.py`** — `⚡ yolo` indicator in StatusBar
- **`tui/app.py`** — guard scope/deny/prompt checks with `not self.yolo`, unlimited budget
- **`headless.py`** — same guards and unlimited budget for headless mode

## Verification

- `make check` — lint ✅, typecheck ✅ (0 errors), 100 tests ✅, smoke ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)