### PR TITLE
docs: correct release runbook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,13 @@ name: release
 #     Workflow:     release.yml
 #     Environment:  pypi
 #
-# Release flow:
-#   1. bump `version` in pyproject.toml
-#   2. commit, then: git tag vX.Y.Z && git push origin vX.Y.Z
-#   3. this workflow builds + publishes; PyPI rejects duplicate versions.
+# Release flow (main is protected, so land the bump first, THEN tag):
+#   1. uv version X.Y.Z   (bumps pyproject.toml + uv.lock)
+#   2. open a PR with the bump, get CI green, and merge it to main
+#   3. tag the merged commit: git checkout main && git pull
+#                             git tag vX.Y.Z && git push origin vX.Y.Z
+#   4. this workflow builds + publishes; PyPI rejects duplicate versions.
+# See CONTRIBUTING.md "Releases" for why tagging before the merge is unsafe.
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,28 @@ A high-level roadmap lives in [`todo.md`](./todo.md).
 - Conventional-ish commit messages (`fix:`, `docs:`, `Phase N: …`).
 
 ## Releases (maintainers)
-1. Bump `version` in `pyproject.toml` (and `riftor/__init__.py`).
-2. Commit, then `git tag vX.Y.Z && git push origin main --tags`.
-3. The `release` workflow builds and publishes to PyPI via trusted publishing.
+`pyproject.toml` is the single source of truth for the version — `riftor
+--version` reads it from the installed package metadata, so there's nothing to
+bump in `riftor/__init__.py`.
+
+`main` is protected (changes land via PR), and the `release` workflow fires on a
+`v*` tag and **verifies the tag matches the `pyproject.toml` version**. So land
+the bump on `main` *first*, then tag the merged commit:
+
+1. `uv version X.Y.Z` — bumps `pyproject.toml` and `uv.lock` together.
+2. Open a PR with that bump, get CI green, and merge it to `main`.
+3. Tag the merged commit on `main` and push **only the tag**:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+4. The `release` workflow then builds, publishes to PyPI via trusted publishing,
+   and creates the GitHub Release. PyPI rejects duplicate versions, so a given
+   `X.Y.Z` can only be published once.
+
+> Do **not** push the tag before the bump is merged to `main`: the workflow
+> would publish to PyPI from a commit that isn't on `main`, leaving `main`'s
+> version out of sync with what's on PyPI.
 
 ## License
 By contributing, you agree your contributions are licensed under the project's


### PR DESCRIPTION
Fixes the stale release instructions in `CONTRIBUTING.md` (and the matching
header comment in `release.yml`).

**What was wrong**
- Said to bump `riftor/__init__.py` — but the version is read from package
  metadata (`version("riftor")`), so there's nothing to bump there;
  `pyproject.toml` is the single source of truth.
- Said `git push origin main --tags` — `main` is protected (PR-only), so a
  direct push fails. We hit exactly this during the 0.2.0 release: the tag
  triggered a PyPI publish from a commit not yet on `main`.

**What it now documents**
1. `uv version X.Y.Z` (bumps pyproject + uv.lock together)
2. Land the bump on `main` via PR, CI green
3. Tag the merged commit and push **only the tag**
4. Workflow builds → publishes to PyPI → creates the GitHub Release

Plus a warning on why tagging before the merge is unsafe. Docs/comment only —
no code or workflow-behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)