### PR TITLE
release: 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.2.0"
+version = "0.5.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.2.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary

Bumps the version `0.2.0 → 0.5.0`. Headline feature of this release is **subagents** (Phase 7a, merged in #28): the main agent **Baaj** dispatches cheap **Chakla** worker subagents via the `dispatch_chakla` tool to run independent tasks (e.g. recon) in parallel.

Per the release runbook (`.github/workflows/release.yml` / CONTRIBUTING.md), this lands the version bump on `main` first; tagging `v0.5.0` on the merged commit then triggers the trusted-publishing workflow → PyPI + GitHub Release.

## Test Plan
- [x] `uv version 0.5.0` bumped `pyproject.toml` + `uv.lock`
- [x] 154 tests pass; `import riftor` ok
- [ ] CI green on this PR, then merge
- [ ] tag `v0.5.0` on main → release workflow publishes (tag-vs-pyproject check will pass: both 0.5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)