### PR TITLE
fix: subagent worker creds — provider+model picker, no auth-fail

### DIFF
--- a/riftor/config.py
+++ b/riftor/config.py
@@ -66,9 +66,12 @@ class Config(BaseModel):
     onboarded: bool = False
     # Per-provider credentials, keyed by provider key (see riftor.providers.PROVIDERS).
     providers: dict[str, ProviderCreds] = {}
-    # Subagents (Baaj orchestrator → Chakla workers). chakla_model is the cheap
-    # worker model; the labels are renameable terminology surfaced in the UI.
-    chakla_model: str = "anthropic/claude-haiku-4-5-20251001"
+    # Subagents (Baaj orchestrator → Chakla workers). The labels are renameable
+    # terminology surfaced in the UI.
+    # chakla_model is the worker model. Empty => reuse the main model (cfg.model),
+    # which is always credentialed. Set it explicitly (via /config WORKERS) for a
+    # cheaper/different worker — its provider's creds must be configured.
+    chakla_model: str = ""
     chakla_max_workers: int = 5
     chakla_max_steps: int = 8
     chakla_timeout_s: int = 300

--- a/riftor/tools/subagent.py
+++ b/riftor/tools/subagent.py
@@ -88,7 +88,26 @@ class DispatchChaklaTool(Tool):
             grant_list = list(_DEFAULT_GRANT)
         grant = {t for t in grant_list}
 
-        worker_cfg = cfg.model_copy(update={"model": cfg.chakla_model})
+        # Resolve the worker model: empty chakla_model => reuse the main model,
+        # which is always credentialed (the user configured cfg.model). Primary
+        # defense against the "worker has no creds" auth-failure bug.
+        worker_model = cfg.chakla_model or cfg.model
+
+        # Defense-in-depth: if an explicit worker model has no resolvable creds —
+        # and it isn't a local/Ollama model that needs none — refuse to dispatch
+        # with a clear, actionable error instead of fanning out N workers that all
+        # fail "authentication failed" (and possibly leak the wrong provider's key).
+        is_local = worker_model.startswith(("ollama/", "ollama_chat/"))
+        api_key, _api_base = cfg.creds_for(worker_model)
+        if not is_local and api_key is None:
+            return ToolResult(
+                f"no credentials for worker model {worker_model!r}; set them in "
+                f"/config WORKERS (provider + key), or leave the worker model blank "
+                f"to reuse the main model ({cfg.model}).",
+                is_error=True,
+            )
+
+        worker_cfg = cfg.model_copy(update={"model": worker_model})
         worker_provider = Provider(worker_cfg)
         db_lock = asyncio.Lock()
         timeout = max(1, cfg.chakla_timeout_s)

--- a/riftor/tools/subagent.py
+++ b/riftor/tools/subagent.py
@@ -97,6 +97,9 @@ class DispatchChaklaTool(Tool):
         # and it isn't a local/Ollama model that needs none — refuse to dispatch
         # with a clear, actionable error instead of fanning out N workers that all
         # fail "authentication failed" (and possibly leak the wrong provider's key).
+        # We gate on api_key only: the reported failure mode is a missing/mismatched
+        # key. A keyless custom endpoint (api_base but no key) is the rare exception
+        # and is refused here; set any placeholder key or use the blank-reuse path.
         is_local = worker_model.startswith(("ollama/", "ollama_chat/"))
         api_key, _api_base = cfg.creds_for(worker_model)
         if not is_local and api_key is None:

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -542,15 +542,19 @@ class RiftorApp(App):
             if entry.api_key or entry.api_base:
                 self.config.providers[provider] = entry
 
-        # Worker may use a different provider than the main model. Store the shared
-        # key/base under the worker provider too, so creds_for(chakla_model) resolves.
+        # Worker may use a different provider than the main model. Ensure that
+        # provider has resolvable creds WITHOUT corrupting the main provider's
+        # entry: never copy the shared (main) base here — use the worker
+        # provider's own default base. Reuse the shared key only if one was
+        # entered this session and the worker provider has no key yet.
+        from riftor.providers import PROVIDERS as _PROVIDERS  # local: keep import-time light
         w_provider = result.get("chakla_provider")
         if w_provider and w_provider != provider:
             w_entry = self.config.providers.get(w_provider) or ProviderCreds()
-            if result.get("api_base") is not None:
-                w_entry.api_base = result["api_base"]
-            if result.get("api_key"):
+            if not w_entry.api_key and result.get("api_key"):
                 w_entry.api_key = result["api_key"]
+            if not w_entry.api_base:
+                w_entry.api_base = _PROVIDERS[w_provider].default_base
             if w_entry.api_key or w_entry.api_base:
                 self.config.providers[w_provider] = w_entry
 

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -542,6 +542,18 @@ class RiftorApp(App):
             if entry.api_key or entry.api_base:
                 self.config.providers[provider] = entry
 
+        # Worker may use a different provider than the main model. Store the shared
+        # key/base under the worker provider too, so creds_for(chakla_model) resolves.
+        w_provider = result.get("chakla_provider")
+        if w_provider and w_provider != provider:
+            w_entry = self.config.providers.get(w_provider) or ProviderCreds()
+            if result.get("api_base") is not None:
+                w_entry.api_base = result["api_base"]
+            if result.get("api_key"):
+                w_entry.api_key = result["api_key"]
+            if w_entry.api_key or w_entry.api_base:
+                self.config.providers[w_provider] = w_entry
+
         self.provider = Provider(self.config)
         self.context.lore = self.config.lore
         self.status.set_lore(self.config.lore)

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -157,9 +157,10 @@ class ConfigScreen(ModalScreen[dict | None]):
                 self._provider_initialized = True
         elif event.select.id == "cfg-chakla-provider" and isinstance(event.value, str):
             self._worker_provider = event.value
-            # Worker reuses the shared Base URL/API key fields; reflect the worker
-            # provider's default base there for fetch/save.
-            self.query_one("#cfg-base", Input).value = PROVIDERS[event.value].default_base or ""
+            # NOTE: do NOT touch #cfg-base/#cfg-key here — those belong to the MAIN
+            # provider. Switching the worker provider must not mutate the main
+            # provider's fields. The worker's base/key are resolved at save time
+            # in _open_config from the worker provider's stored creds / default base.
             if self._worker_provider_initialized:
                 self._set_chakla_model_options(_model_options(event.value))
             else:

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -46,6 +46,11 @@ class ConfigScreen(ModalScreen[dict | None]):
         self._original_theme = config.theme
         self._provider = provider_key_for_model(config.model)
         self._provider_initialized = False
+        # Worker (Chakla) picker mirrors the main one. Empty chakla_model =>
+        # reuse main model, so seed the worker provider from the main model then.
+        self._worker_provider = provider_key_for_model(
+            self.config.chakla_model or self.config.model)
+        self._worker_provider_initialized = False
 
     def compose(self) -> ComposeResult:
         theme = self.config.theme if self.config.theme in THEMES else "rift"
@@ -65,6 +70,19 @@ class ConfigScreen(ModalScreen[dict | None]):
         if bare and bare not in [v for _, v in model_opts]:
             model_opts = [(bare, bare), *model_opts]
         model_val = bare if bare else Select.NULL
+        # --- worker (Chakla) picker display values, mirroring the main model ---
+        wkey = self._worker_provider
+        wmeta = PROVIDERS[wkey]
+        wsrc = self.config.chakla_model or self.config.model
+        wbare = (wsrc[len(wmeta.prefix):]
+                 if wmeta.prefix and wkey != "openrouter"
+                 and wsrc.startswith(wmeta.prefix)
+                 else wsrc)
+        w_model_opts = _model_options(wkey)
+        if wbare and wbare not in [v for _, v in w_model_opts]:
+            w_model_opts = [(wbare, wbare), *w_model_opts]
+        # Empty chakla_model => "reuse main" => show nothing selected.
+        w_model_val = wbare if self.config.chakla_model and wbare else Select.NULL
         with Vertical(id="config-box"):
             yield Label("riftor · config", id="config-title")
             with VerticalScroll(id="config-body"):
@@ -91,13 +109,21 @@ class ConfigScreen(ModalScreen[dict | None]):
 
                 yield Rule()
                 yield Label("WORKERS", classes="config-section")
-                yield _row("Chakla model", Input(
-                    value=self.config.chakla_model,
-                    placeholder="cheap worker model id", id="cfg-chakla-model"))
+                yield _row("Provider", Select(
+                    [(m.label, k) for k, m in PROVIDERS.items()],
+                    value=wkey, allow_blank=False, id="cfg-chakla-provider"))
+                yield _row("Model", Select(
+                    w_model_opts, value=w_model_val, allow_blank=True,
+                    id="cfg-chakla-model-select"))
+                yield _row("Custom id", Input(
+                    value="", placeholder="blank = reuse main model",
+                    id="cfg-chakla-custom"))
                 yield _row("Main label", Input(
-                    value=self.config.label_main, placeholder="e.g. Baaj", id="cfg-label-main"))
+                    value=self.config.label_main, placeholder="e.g. Baaj",
+                    id="cfg-label-main"))
                 yield _row("Worker label", Input(
-                    value=self.config.label_worker, placeholder="e.g. Chakla", id="cfg-label-worker"))
+                    value=self.config.label_worker, placeholder="e.g. Chakla",
+                    id="cfg-label-worker"))
 
                 yield Rule()
                 yield Label("APPEARANCE", classes="config-section")
@@ -129,9 +155,22 @@ class ConfigScreen(ModalScreen[dict | None]):
                 self._set_model_options(_model_options(event.value))
             else:
                 self._provider_initialized = True
+        elif event.select.id == "cfg-chakla-provider" and isinstance(event.value, str):
+            self._worker_provider = event.value
+            # Worker reuses the shared Base URL/API key fields; reflect the worker
+            # provider's default base there for fetch/save.
+            self.query_one("#cfg-base", Input).value = PROVIDERS[event.value].default_base or ""
+            if self._worker_provider_initialized:
+                self._set_chakla_model_options(_model_options(event.value))
+            else:
+                self._worker_provider_initialized = True
 
     def _set_model_options(self, options: list[tuple[str, str]]) -> None:
         sel = self.query_one("#cfg-model-select", Select)
+        sel.set_options(options or [("(type a custom id below)", "")])
+
+    def _set_chakla_model_options(self, options: list[tuple[str, str]]) -> None:
+        sel = self.query_one("#cfg-chakla-model-select", Select)
         sel.set_options(options or [("(type a custom id below)", "")])
 
     @work(thread=True, exclusive=True, group="fetch")
@@ -190,6 +229,14 @@ class ConfigScreen(ModalScreen[dict | None]):
         chosen = custom or (sel_val if isinstance(sel_val, str) and sel_val else "")
         model = apply_prefix(provider, chosen) if chosen else self.config.model
 
+        # --- worker (Chakla) model ---
+        w_provider = self._worker_provider
+        w_custom = self.query_one("#cfg-chakla-custom", Input).value.strip()
+        w_sel = self.query_one("#cfg-chakla-model-select", Select).value
+        w_chosen = w_custom or (w_sel if isinstance(w_sel, str) and w_sel else "")
+        # Blank => "" => reuse main model at dispatch time.
+        chakla_model = apply_prefix(w_provider, w_chosen) if w_chosen else ""
+
         result: dict = {
             "model": model,
             "provider": provider,
@@ -198,8 +245,8 @@ class ConfigScreen(ModalScreen[dict | None]):
             "max_tokens": max_tokens,
             "theme": self.query_one("#cfg-theme", Select).value,
             "lore": self.query_one("#cfg-lore", Switch).value,
-            "chakla_model": self.query_one("#cfg-chakla-model", Input).value.strip()
-                or self.config.chakla_model,
+            "chakla_model": chakla_model,
+            "chakla_provider": w_provider if w_chosen else None,
             "label_main": self.query_one("#cfg-label-main", Input).value.strip()
                 or self.config.label_main,
             "label_worker": self.query_one("#cfg-label-worker", Input).value.strip()

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -203,6 +203,42 @@ async def test_fetch_button_repopulates_models(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_worker_provider_switch_does_not_clobber_main_base():
+    # Regression: switching the WORKER provider Select used to rewrite the shared
+    # #cfg-base field, so saving corrupted the MAIN provider's stored base. Drive
+    # the REAL ConfigScreen + _open_config and assert the clobber invariant.
+    from riftor.providers import PROVIDERS
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="openai/gpt-5.5")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, ConfigScreen)
+            # main = openai + key; base auto-fills to openai's default
+            screen.query_one("#cfg-provider", Select).value = "openai"
+            await pilot.pause()
+            screen.query_one("#cfg-key", Input).value = "sk-openai"
+            # switch the WORKER provider to a DIFFERENT provider (deepseek) and
+            # pick a worker model, so a distinct worker provider is actually saved
+            screen.query_one("#cfg-chakla-provider", Select).value = "deepseek"
+            await pilot.pause()
+            screen.query_one("#cfg-chakla-custom", Input).value = "deepseek-chat"
+            # save WITHOUT re-touching the base field
+            screen.query_one("#save").press()
+            await pilot.pause()
+        # INVARIANT: the main openai base is untouched (NOT deepseek's base)
+        assert app.config.providers["openai"].api_base == PROVIDERS["openai"].default_base
+        assert app.config.providers["openai"].api_key == "sk-openai"
+        # the worker provider got ITS OWN default base, and reused the shared key
+        assert app.config.providers["deepseek"].api_base == PROVIDERS["deepseek"].default_base
+        assert app.config.providers["deepseek"].api_key == "sk-openai"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_model_no_duplicate_option_on_open():
     with tempfile.TemporaryDirectory() as d:
         _patch_paths(Path(d))

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -38,15 +38,17 @@ async def test_config_modal_renders_all_fields():
                 ("#cfg-provider", Select), ("#cfg-model-select", Select),
                 ("#cfg-model", Input), ("#cfg-base", Input), ("#cfg-key", Input),
                 ("#cfg-temp", Input), ("#cfg-maxtok", Input),
-                ("#cfg-chakla-model", Input), ("#cfg-label-main", Input),
-                ("#cfg-label-worker", Input),
+                ("#cfg-chakla-provider", Select), ("#cfg-chakla-model-select", Select),
+                ("#cfg-chakla-custom", Input),
+                ("#cfg-label-main", Input), ("#cfg-label-worker", Input),
                 ("#cfg-theme", Select), ("#cfg-lore", Switch),
             ]:
                 assert screen.query_one(fid, kind) is not None, fid
             # four grouped section headers (MODEL / GENERATION / WORKERS / APPEARANCE)
             assert len(list(screen.query(".config-section"))) == 4
-            # aligned label column: one .field-label per field row
-            assert len(list(screen.query(".field-label"))) == 13
+            # aligned label column: one .field-label per field row. WORKERS now has
+            # 3 picker rows + 2 label rows (was 1 plain input + 2 labels) => +2.
+            assert len(list(screen.query(".field-label"))) == 15
             await pilot.press("escape")
             await pilot.pause()
 

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -445,3 +445,31 @@ def test_dispatch_ollama_worker_needs_no_key(tmp_workdir, engagement, monkeypatc
     )
     res = asyncio.run(DispatchChaklaTool().execute({"tasks": ["x"], "tools": []}, ctx))
     assert "no credentials for worker model" not in res.content
+
+
+def test_worker_provider_does_not_clobber_main_base():
+    # Reproduce the review footgun: main=openai (real base+key), worker=deepseek.
+    # The worker store must NOT overwrite the main openai entry's base, and must
+    # give deepseek ITS OWN default base — not openai's and not a leaked one.
+    from riftor.providers import PROVIDERS
+    cfg = Config(model="openai/gpt-5.5")
+    # main provider stored first (as _open_config's main block does)
+    cfg.providers["openai"] = ProviderCreds(
+        api_key="sk-openai", api_base=PROVIDERS["openai"].default_base)
+    # Simulate _open_config's WORKER block for a different provider (deepseek),
+    # using the FIXED logic (never copies the shared/main base):
+    w_provider = "deepseek"
+    provider = "openai"
+    result = {"api_key": "sk-openai", "api_base": PROVIDERS["openai"].default_base}
+    if w_provider and w_provider != provider:
+        w_entry = cfg.providers.get(w_provider) or ProviderCreds()
+        if not w_entry.api_key and result.get("api_key"):
+            w_entry.api_key = result["api_key"]
+        if not w_entry.api_base:
+            w_entry.api_base = PROVIDERS[w_provider].default_base
+        if w_entry.api_key or w_entry.api_base:
+            cfg.providers[w_provider] = w_entry
+    # INVARIANT: main openai base is intact (NOT deepseek's base)
+    assert cfg.providers["openai"].api_base == PROVIDERS["openai"].default_base
+    # worker deepseek got ITS OWN default base, not openai's
+    assert cfg.providers["deepseek"].api_base == PROVIDERS["deepseek"].default_base

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -6,7 +6,7 @@ import asyncio
 from riftor import tools as tools_mod
 from riftor.agent.provider import Provider, ToolCall
 from riftor.agent.subagent import ChaklaResult, run_chakla, _run_chakla_tool, worker_schemas
-from riftor.config import Config
+from riftor.config import Config, ProviderCreds
 from riftor.safety.audit import AuditLog
 from riftor.safety.permissions import Permissions
 from riftor.terminology import terminology
@@ -16,7 +16,7 @@ from riftor.tools.subagent import DispatchChaklaTool
 
 def test_config_has_chakla_defaults():
     cfg = Config()
-    assert cfg.chakla_model == "anthropic/claude-haiku-4-5-20251001"
+    assert cfg.chakla_model == ""
     assert cfg.chakla_max_workers == 5
     assert cfg.chakla_max_steps == 8
     assert cfg.chakla_timeout_s == 300
@@ -61,7 +61,7 @@ def test_toolcontext_new_fields_default_to_none(tmp_workdir, engagement):
 
 
 def _worker_provider(cfg: Config) -> Provider:
-    return Provider(cfg.model_copy(update={"model": cfg.chakla_model}))
+    return Provider(cfg.model_copy(update={"model": cfg.chakla_model or cfg.model}))
 
 
 async def _run_one(task, *, cfg, engagement, grant, yolo=False, monkeypatch_env):
@@ -189,7 +189,7 @@ def test_dispatch_requires_config(tmp_workdir, engagement):
 
 def test_dispatch_runs_workers_and_aggregates(tmp_workdir, engagement, monkeypatch):
     monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "worker done: nothing notable")
-    cfg = Config()
+    cfg = Config(api_key="test-key")  # blank worker reuses main model; needs creds
     tool = DispatchChaklaTool()
     ctx = tools_mod.ToolContext(
         workdir=tmp_workdir, engagement=engagement, config=cfg,
@@ -204,7 +204,7 @@ def test_dispatch_runs_workers_and_aggregates(tmp_workdir, engagement, monkeypat
 
 def test_dispatch_clamps_to_max_workers(tmp_workdir, engagement, monkeypatch):
     monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "ok")
-    cfg = Config(chakla_max_workers=2)
+    cfg = Config(chakla_max_workers=2, api_key="test-key")
     tool = DispatchChaklaTool()
     ctx = tools_mod.ToolContext(
         workdir=tmp_workdir, engagement=engagement, config=cfg,
@@ -224,7 +224,7 @@ def test_dispatch_tool_is_registered():
 
 def test_dispatch_timeout_is_reported(tmp_workdir, engagement, monkeypatch):
     monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "ok")
-    cfg = Config(chakla_timeout_s=1)
+    cfg = Config(chakla_timeout_s=1, api_key="test-key")
     tool = DispatchChaklaTool()
     ctx = tools_mod.ToolContext(
         workdir=tmp_workdir, engagement=engagement, config=cfg,
@@ -335,3 +335,53 @@ def test_worker_standing_allow_rule_still_binds(tmp_workdir, engagement):
                          yolo=False, db_lock=asyncio.Lock(), grant=set())
     )
     assert "[denied]" not in content  # standing allow rule authorizes it
+
+
+def test_empty_chakla_model_reuses_main():
+    cfg = Config(model="deepseek/deepseek-v4-pro", chakla_model="")
+    assert (cfg.chakla_model or cfg.model) == "deepseek/deepseek-v4-pro"
+
+
+def test_dispatch_refuses_explicit_worker_without_creds(tmp_workdir, engagement, monkeypatch):
+    # Reproduce the reported bug: deepseek main (with key), explicit anthropic
+    # worker, NO anthropic creds anywhere → must refuse clearly, not 401.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "ok")
+    cfg = Config(model="deepseek/deepseek-v4-pro",
+                 chakla_model="anthropic/claude-haiku-4-5-20251001")
+    cfg.providers["deepseek"] = ProviderCreds(api_key="sk-deepseek-xxx")
+    ctx = tools_mod.ToolContext(
+        workdir=tmp_workdir, engagement=engagement, config=cfg,
+        permissions=Permissions(), audit=AuditLog(),
+    )
+    res = asyncio.run(DispatchChaklaTool().execute({"tasks": ["echo hi"], "tools": []}, ctx))
+    assert res.is_error
+    assert "no credentials for worker model" in res.content
+    assert "anthropic/claude-haiku" in res.content
+    assert "reuse the main model" in res.content
+
+
+def test_dispatch_blank_worker_reuses_main_creds(tmp_workdir, engagement, monkeypatch):
+    # Same deepseek setup but blank chakla_model → reuses deepseek (credentialed) →
+    # NO creds error (this is the out-of-box fix).
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "worker done")
+    cfg = Config(model="deepseek/deepseek-v4-pro", chakla_model="")
+    cfg.providers["deepseek"] = ProviderCreds(api_key="sk-deepseek-xxx")
+    ctx = tools_mod.ToolContext(
+        workdir=tmp_workdir, engagement=engagement, config=cfg,
+        permissions=Permissions(), audit=AuditLog(),
+    )
+    res = asyncio.run(DispatchChaklaTool().execute({"tasks": ["recon"], "tools": []}, ctx))
+    assert "no credentials for worker model" not in res.content
+
+
+def test_dispatch_ollama_worker_needs_no_key(tmp_workdir, engagement, monkeypatch):
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "ok")
+    cfg = Config(model="ollama_chat/llama3", chakla_model="ollama_chat/llama3")
+    ctx = tools_mod.ToolContext(
+        workdir=tmp_workdir, engagement=engagement, config=cfg,
+        permissions=Permissions(), audit=AuditLog(),
+    )
+    res = asyncio.run(DispatchChaklaTool().execute({"tasks": ["x"], "tools": []}, ctx))
+    assert "no credentials for worker model" not in res.content

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -276,18 +276,78 @@ def test_statusbar_has_chakla_usage_setter():
 
 def test_config_screen_result_keys_persist():
     # Simulate the dict ConfigScreen.dismiss returns, then apply it like _open_config.
+    from riftor.config import ProviderCreds
     cfg = Config()
     result = {
         "model": cfg.model, "provider": "anthropic", "api_base": None,
         "temperature": 0.3, "max_tokens": 2048, "theme": "rift", "lore": True,
         "chakla_model": "anthropic/claude-haiku-4-5-20251001",
+        "chakla_provider": "anthropic", "api_key": "sk-anth",
         "label_main": "Hawk", "label_worker": "Finch",
     }
-    cfg.chakla_model = result["chakla_model"]
+    # Mirror _open_config: persist worker model + main provider creds.
+    cfg.chakla_model = result.get("chakla_model", cfg.chakla_model)
     cfg.label_main = result["label_main"]
     cfg.label_worker = result["label_worker"]
+    provider = result.get("provider")
+    if provider:
+        entry = cfg.providers.get(provider) or ProviderCreds()
+        if result.get("api_base") is not None:
+            entry.api_base = result["api_base"]
+        if result.get("api_key"):
+            entry.api_key = result["api_key"]
+        if entry.api_key or entry.api_base:
+            cfg.providers[provider] = entry
+    # Worker creds block (worker provider == main here, so main block covered it).
+    w_provider = result.get("chakla_provider")
+    if w_provider and w_provider != provider:
+        w_entry = cfg.providers.get(w_provider) or ProviderCreds()
+        if result.get("api_base") is not None:
+            w_entry.api_base = result["api_base"]
+        if result.get("api_key"):
+            w_entry.api_key = result["api_key"]
+        if w_entry.api_key or w_entry.api_base:
+            cfg.providers[w_provider] = w_entry
+
     assert cfg.label_main == "Hawk"
     assert 'label_main = "Hawk"' in cfg._to_toml()
+    assert cfg.chakla_model == "anthropic/claude-haiku-4-5-20251001"
+    # The worker model's creds resolve from the stored provider table.
+    assert cfg.creds_for(cfg.chakla_model)[0] == "sk-anth"
+
+
+def test_worker_picker_creds_resolve_for_different_provider():
+    # Main model on anthropic, worker pointed at a DIFFERENT provider (openai):
+    # the worker provider gets the shared key stored and creds_for resolves it.
+    from riftor.config import ProviderCreds
+    cfg = Config(model="anthropic/claude-sonnet-4-6")
+    result = {
+        "model": "anthropic/claude-sonnet-4-6", "provider": "anthropic",
+        "api_base": None, "api_key": "sk-openai-worker",
+        "chakla_model": "openai/gpt-5.5-mini", "chakla_provider": "openai",
+    }
+    cfg.chakla_model = result.get("chakla_model", cfg.chakla_model)
+    provider = result.get("provider")
+    if provider:
+        entry = cfg.providers.get(provider) or ProviderCreds()
+        if result.get("api_base") is not None:
+            entry.api_base = result["api_base"]
+        if result.get("api_key"):
+            entry.api_key = result["api_key"]
+        if entry.api_key or entry.api_base:
+            cfg.providers[provider] = entry
+    w_provider = result.get("chakla_provider")
+    if w_provider and w_provider != provider:
+        w_entry = cfg.providers.get(w_provider) or ProviderCreds()
+        if result.get("api_base") is not None:
+            w_entry.api_base = result["api_base"]
+        if result.get("api_key"):
+            w_entry.api_key = result["api_key"]
+        if w_entry.api_key or w_entry.api_base:
+            cfg.providers[w_provider] = w_entry
+
+    assert "openai" in cfg.providers
+    assert cfg.creds_for(cfg.chakla_model)[0] == "sk-openai-worker"
 
 
 def test_system_prompt_mentions_dispatch():


### PR DESCRIPTION
## Summary

Fixes the **"authentication failed"** error when dispatching Chakla subagents, and adds a real **provider + model picker** for the worker so users can point Chakla at a provider they've actually configured — no `.env` reliance.

### The bug
`chakla_model` defaulted to `anthropic/claude-haiku-4-5-20251001`. A user whose main model runs on a different provider (e.g. `deepseek/...` or via OpenRouter) has **no Anthropic credentials**, so the worker provider fell back to the global `api_key` (belonging to another provider) and sent it to the Anthropic endpoint → **401 authentication failed**.

### The fix (three commits)
1. **`983580e` — root cause:** `chakla_model` now defaults to `""` = *reuse the main model* (always credentialed → works out-of-box on any provider). A dispatch-time guard refuses with a clear, actionable message if an explicitly-chosen worker model has **no resolvable credentials**, instead of fanning out N workers that all 401 (and possibly leak the wrong provider's key). Ollama/local models bypass the guard.
2. **`2d5996f` — worker picker:** replaces the plain Chakla-model text input in `/config` with a **Provider + Model + Custom-id picker** mirroring the main model picker. The worker provider's key is stored in `config.providers[<provider>]` — the same per-provider credential store the main picker uses, so `creds_for(worker_model)` resolves **without any env var**.
3. **`81ee240` — regression fix (from code review):** switching the worker provider no longer rewrites the shared Base URL field, so it can't clobber the **main** provider's stored base on Save. The worker base is derived from its own provider default at save time; the main entry is never touched. Covered by an end-to-end test driving the real `ConfigScreen` + `_open_config`.

### Behavior
- **Out-of-box:** leave the worker model blank → workers reuse Baaj's model + creds. No auth failure on any provider.
- **Cheaper/different worker:** pick a provider + model in `/config WORKERS`, enter its key → stored under that provider, resolves correctly.
- **Misconfigured:** explicit worker model with no creds → clear error pointing to `/config WORKERS` or the blank-reuse path.

## Test Plan
- [x] `make check` green: ruff clean, pyright 0 errors, **161 tests**, smoke all OK
- [x] Reproduced the reported scenario (deepseek main + default worker, no Anthropic key) → now runs on deepseek; explicit anthropic-no-key → clear refusal (verified end-to-end offline)
- [x] New regression tests: blank-reuses-main, explicit-no-creds-refuses, ollama-needs-no-key, worker-creds-resolve-on-different-provider, main-base-not-clobbered (real ConfigScreen E2E)
- [ ] (reviewer) manual: `/config` → WORKERS → pick a provider+model+key, dispatch workers, confirm they run

🤖 Generated with [Claude Code](https://claude.com/claude-code)