### PR TITLE
release: 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.5.0"
+version = "0.5.1"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary

Patch release `0.5.0 → 0.5.1`. Fixes the subagent **"authentication failed"** bug (#30):
- Workers default to reusing the main model (works on any provider out-of-box; no more wrong-key 401).
- A real Provider+Model picker for Chakla workers in `/config`, storing creds in `config.providers` — no `.env` reliance.
- A clear-error guard when a chosen worker model has no resolvable credentials.

Follows the release runbook: bump on `main` first (this PR), then tag `v0.5.1` on the merged commit → trusted-publishing workflow → PyPI + GitHub Release.

## Test Plan
- [x] `uv version 0.5.1` bumped pyproject.toml + uv.lock
- [x] 161 tests pass; `import riftor` ok
- [ ] CI green on this PR, then merge
- [ ] tag `v0.5.1` on main → release workflow publishes (tag-vs-pyproject check passes: both 0.5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)