### PR TITLE
release: 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.5.1"
+version = "0.6.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Bump `0.5.1` → `0.6.0`.

## What's in this release

**Phase 7b — live worker visibility (#33):** a `dispatch_chakla` worker batch is now observable in real time.

- Tool→UI progress channel (optional `progress` callback on `ToolContext`, `None`-safe and UI-agnostic).
- Live "flock" `DataTable` in the TUI: one row per worker (`queued → running → done/timeout/error`) with per-tool-call detail and token counts. Ephemeral — removed when the dispatch finishes; the aggregated text summary remains.
- Worker token/cost in the status-bar 🐦 segment (summed from terminal events; no double-counting with the main gauge; resets with `/clear` and `/new`).
- Headless mode prints one stderr progress line per finished worker (stdout stays the answer stream).

## Release checklist
- [x] `version` bumped in `pyproject.toml` and `uv.lock` (0.5.1 → 0.6.0)
- [x] `make check` green (lint, pyright 0 errors, 174 tests, smoke)
- [x] `uv build` succeeds (`riftor-0.6.0` sdist + wheel)
- [x] `riftor --version` reports `0.6.0`

A `v0.6.0` tag will be pushed to the merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)