### PR TITLE
release: 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.6.0"
+version = "0.7.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Bump 0.6.0 → 0.7.0.

Ships the display settings (#35):
- **show_thinking** — render the model's reasoning as a dim block above each answer (stderr in `--headless`)
- **show_tool_output** — hide tool-result blocks while keeping the `⛏` call line and `/show <id>` reachability
- **reasoning_effort** — `none`/`low`/`medium`/`high`, validated on load

The provider streams litellm `reasoning_content` as a display-only `("thinking")` event (never persisted to conversation history). All settings are surfaced in the `/config` DISPLAY section.

Bump only — `pyproject.toml` + `uv.lock`. Tag `v0.7.0` will be pushed after merge to trigger the PyPI + GitHub Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)