### PR TITLE
Expose tool-call step limit in /config; share it with workers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,13 +22,12 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `show_thinking` | bool | `true` | Show the model's reasoning as a dim block above each answer (and on stderr in `--headless`). |
 | `show_tool_output` | bool | `true` | Render tool-result blocks in the chat. When off, the `⛏` call line still shows and hidden output stays reachable via `/show <id>`. |
 | `reasoning_effort` | string | `medium` | Thinking budget requested from the model: `none` `low` `medium` `high`. `none` (or `show_thinking = false`) sends no reasoning request. |
-| `max_steps` | int | `16` | Tool-call steps per task before pausing (extend live with `/continue`). |
+| `max_steps` | int | `16` | Tool-call steps per task before pausing (extend live with `/continue`). Also caps each Chakla worker's step budget. |
 | `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |
 | `result_preview_lines` | int | `25` | Lines of a tool result shown before `…/show <id>`. |
 | `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |
 | `chakla_model` | string | `anthropic/claude-haiku-4-5-20251001` | The cheap worker model used by dispatched Chakla subagents. |
 | `chakla_max_workers` | int | `5` | Max number of Chakla workers per dispatch batch. |
-| `chakla_max_steps` | int | `8` | Per-worker agent-loop step budget. |
 | `chakla_timeout_s` | int | `300` | Per-worker wall-clock timeout in seconds. |
 | `label_main` | string | `Baaj` | Display name for the orchestrator agent. |
 | `label_worker` | string | `Chakla` | Display name for the worker subagents. |
@@ -68,8 +67,8 @@ Key properties of the worker fleet:
   `record_service`, `record_finding`, etc. write to the same `.riftor/engagement.db`
   as the main agent.
 - **Concurrency is bounded.** `chakla_max_workers` caps parallel workers;
-  `chakla_max_steps` caps the per-worker step budget; `chakla_timeout_s` sets the
-  wall-clock ceiling. Tune these to stay within rate limits.
+  each worker's step budget is `max_steps` (shared with the main agent);
+  `chakla_timeout_s` sets the wall-clock ceiling. Tune these to stay within rate limits.
 - **Worker model defaults to Haiku.** `chakla_model` defaults to
   `anthropic/claude-haiku-4-5-20251001` — a cheap, fast model well-suited to
   bounded recon tasks. Override it with `--chakla-model` at the CLI or by editing

--- a/docs/riftor.1
+++ b/docs/riftor.1
@@ -64,9 +64,6 @@ Chakla worker model id (default: \fIanthropic/claude-haiku-4-5-20251001\fR).
 .B chakla_max_workers
 Maximum number of Chakla workers per dispatch batch (default: \fI5\fR).
 .TP
-.B chakla_max_steps
-Per-worker agent-loop step budget (default: \fI8\fR).
-.TP
 .B chakla_timeout_s
 Per-worker wall-clock timeout in seconds (default: \fI300\fR).
 .TP

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -80,7 +80,6 @@ class Config(BaseModel):
     # cheaper/different worker — its provider's creds must be configured.
     chakla_model: str = ""
     chakla_max_workers: int = 5
-    chakla_max_steps: int = 8
     chakla_timeout_s: int = 300
     label_main: str = "Baaj"
     label_worker: str = "Chakla"
@@ -232,7 +231,6 @@ class Config(BaseModel):
             f"onboarded = {str(self.onboarded).lower()}",
             f'chakla_model = "{self.chakla_model}"',
             f"chakla_max_workers = {self.chakla_max_workers}",
-            f"chakla_max_steps = {self.chakla_max_steps}",
             f"chakla_timeout_s = {self.chakla_timeout_s}",
             f'label_main = "{self.label_main}"',
             f'label_worker = "{self.label_worker}"',

--- a/riftor/tools/subagent.py
+++ b/riftor/tools/subagent.py
@@ -140,7 +140,7 @@ class DispatchChaklaTool(Tool):
                         toolctx=ctx,
                         permissions=perms,
                         audit=audit,
-                        max_steps=cfg.chakla_max_steps,
+                        max_steps=cfg.max_steps,
                         yolo=ctx.yolo,
                         db_lock=db_lock,
                         grant=grant,

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -567,6 +567,8 @@ class RiftorApp(App):
         self.config.model = result["model"]
         self.config.temperature = result["temperature"]
         self.config.max_tokens = result["max_tokens"]
+        self.config.max_steps = result.get("max_steps", self.config.max_steps)
+        self.max_steps = self.config.max_steps
         self.config.lore = result["lore"]
         self.config.show_thinking = result.get("show_thinking", self.config.show_thinking)
         self.config.show_tool_output = result.get("show_tool_output", self.config.show_tool_output)

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -132,6 +132,7 @@ class ConfigScreen(ModalScreen[dict | None]):
                         yield Label("Generation", classes="config-section")
                         yield _row("Temperature", Input(value=str(self.config.temperature), id="cfg-temp"))
                         yield _row("Max tokens", Input(value=str(self.config.max_tokens), id="cfg-maxtok"))
+                        yield _row("Tool call steps", Input(value=str(self.config.max_steps), id="cfg-maxsteps"))
 
                     with Vertical(id="section-workers", classes="config-section-panel hidden"):
                         yield Label("Workers", classes="config-section")
@@ -288,6 +289,14 @@ class ConfigScreen(ModalScreen[dict | None]):
         except ValueError:
             self._fail("max tokens must be an integer")
             return
+        try:
+            max_steps = int(self.query_one("#cfg-maxsteps", Input).value)
+        except ValueError:
+            self._fail("tool call steps must be an integer")
+            return
+        if max_steps < 1:
+            self._fail("tool call steps must be at least 1")
+            return
 
         provider = self._provider
         custom = self.query_one("#cfg-model", Input).value.strip()
@@ -309,6 +318,7 @@ class ConfigScreen(ModalScreen[dict | None]):
             "api_base": self.query_one("#cfg-base", Input).value.strip() or None,
             "temperature": temperature,
             "max_tokens": max_tokens,
+            "max_steps": max_steps,
             "theme": self.query_one("#cfg-theme", Select).value,
             "lore": self.query_one("#cfg-lore", Switch).value,
             "show_thinking": self.query_one("#cfg-show-thinking", Switch).value,

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -37,7 +37,7 @@ async def test_config_modal_renders_all_fields():
             for fid, kind in [
                 ("#cfg-provider", Select), ("#cfg-model-select", Select),
                 ("#cfg-model", Input), ("#cfg-base", Input), ("#cfg-key", Input),
-                ("#cfg-temp", Input), ("#cfg-maxtok", Input),
+                ("#cfg-temp", Input), ("#cfg-maxtok", Input), ("#cfg-maxsteps", Input),
                 ("#cfg-chakla-provider", Select), ("#cfg-chakla-model-select", Select),
                 ("#cfg-chakla-custom", Input),
                 ("#cfg-label-main", Input), ("#cfg-label-worker", Input),
@@ -50,8 +50,9 @@ async def test_config_modal_renders_all_fields():
             assert len(list(screen.query(".config-section"))) == 5
             # aligned label column: one .field-label per field row. WORKERS now has
             # 3 picker rows + 2 label rows (was 1 plain input + 2 labels) => +2.
-            # +3 field rows for the DISPLAY section => 15 + 3 = 18
-            assert len(list(screen.query(".field-label"))) == 18
+            # +3 field rows for the DISPLAY section => 15 + 3 = 18, plus the
+            # GENERATION "Tool call steps" row => 19.
+            assert len(list(screen.query(".field-label"))) == 19
             await pilot.press("escape")
             await pilot.pause()
 
@@ -109,10 +110,14 @@ async def test_config_modal_saves_changes():
             await pilot.pause()
             app.screen.query_one("#cfg-temp", Input).value = "0.7"
             app.screen.query_one("#cfg-maxtok", Input).value = "4096"
+            app.screen.query_one("#cfg-maxsteps", Input).value = "24"
             app.screen.query_one("#save").press()
             await pilot.pause()
             assert app.config.temperature == 0.7
             assert app.config.max_tokens == 4096
+            # max_steps flows to both the persisted config and the live loop budget.
+            assert app.config.max_steps == 24
+            assert app.max_steps == 24
 
 
 @pytest.mark.asyncio

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -18,7 +18,6 @@ def test_config_has_chakla_defaults():
     cfg = Config()
     assert cfg.chakla_model == ""
     assert cfg.chakla_max_workers == 5
-    assert cfg.chakla_max_steps == 8
     assert cfg.chakla_timeout_s == 300
     assert cfg.label_main == "Baaj"
     assert cfg.label_worker == "Chakla"
@@ -29,7 +28,6 @@ def test_config_toml_roundtrips_chakla_fields():
     toml = cfg._to_toml()
     assert 'chakla_model = "anthropic/claude-haiku-4-5-20251001"' in toml
     assert "chakla_max_workers = 3" in toml
-    assert "chakla_max_steps = 8" in toml
     assert "chakla_timeout_s = 300" in toml
     assert 'label_main = "Baaj"' in toml
     assert 'label_worker = "Chakla"' in toml
@@ -81,7 +79,7 @@ async def _run_one(task, *, cfg, engagement, grant, yolo=False, monkeypatch_env)
         toolctx=toolctx,
         permissions=toolctx.permissions,
         audit=toolctx.audit,
-        max_steps=cfg.chakla_max_steps,
+        max_steps=cfg.max_steps,
         yolo=yolo,
         db_lock=asyncio.Lock(),
         grant=grant,
@@ -499,7 +497,7 @@ def test_run_chakla_emits_detail_events(tmp_workdir, engagement):
         "recon 10.0.0.5",
         worker_provider=_StubProvider(),  # type: ignore[arg-type]
         toolctx=toolctx, permissions=toolctx.permissions, audit=toolctx.audit,
-        max_steps=cfg.chakla_max_steps, yolo=False,
+        max_steps=cfg.max_steps, yolo=False,
         db_lock=asyncio.Lock(), grant=set(),
         progress=lambda e: events.append(e),
     ))
@@ -553,7 +551,7 @@ def test_run_chakla_detail_usage_is_snapshot(tmp_workdir, engagement):
     result = _aio.run(run_chakla(
         "recon", worker_provider=_StubProvider(),  # type: ignore[arg-type]
         toolctx=toolctx, permissions=toolctx.permissions, audit=toolctx.audit,
-        max_steps=cfg.chakla_max_steps, yolo=False,
+        max_steps=cfg.max_steps, yolo=False,
         db_lock=_aio.Lock(), grant=set(), progress=_grab,
     ))
     # At emission time, only turn-1 usage (15) had accumulated. After the run,


### PR DESCRIPTION
## What

Adds a **Tool call steps** field to the Generation section of the `/config` modal, exposing the `max_steps` setting (which already existed in config and TOML but had no UI).

Per the chosen design, **workers share the main `max_steps` budget** rather than having a separate one. This removes `chakla_max_steps` entirely:
- the dispatch path (`tools/subagent.py`) now uses `cfg.max_steps`
- the `chakla_max_steps` config field and its TOML line are dropped

## Behavior notes

- Editing **Tool call steps** applies live: both the persisted `config.max_steps` and the running loop's `self.max_steps` (no restart needed). Validated as an integer `>= 1`.
- Old `config.toml` files with a stray `chakla_max_steps` line are silently ignored (pydantic `extra="ignore"`), not rejected — bad config never crashes startup.
- **Trade-off:** with `chakla_max_workers=5`, a single dispatch now costs up to `5 × max_steps` step-equivalents, so raising the step count also raises worker fan-out cost proportionally. This is the intended consequence of one shared knob.

## Changes

- `riftor/tui/config_screen.py` — new `#cfg-maxsteps` field + validation + result plumbing
- `riftor/tui/app.py` — apply `max_steps` to config and live loop in `_open_config`
- `riftor/config.py` — remove `chakla_max_steps` field and TOML line
- `riftor/tools/subagent.py` — worker dispatch uses `cfg.max_steps`
- `tests/test_config_screen.py`, `tests/test_subagent.py` — updated
- `docs/configuration.md`, `docs/riftor.1` — updated

## Verification

`ruff` clean · `pyright` 0 errors · full `pytest` suite passes · `dev/smoke.py` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)