### PR TITLE
Add Codex (ChatGPT subscription) login

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -147,6 +147,43 @@ async def main() -> None:
         else:
             os.environ["RIFTOR_DEMO_RESPONSE"] = _saved_demo
 
+        # --- Codex (ChatGPT subscription) model: offline, mocked ---
+        # Proves a codex/ model can be selected and a turn driven with NO network
+        # and NO real ~/.codex/auth.json: RIFTOR_DEMO_RESPONSE short-circuits the
+        # provider before the codex handler runs, and CODEX_HOME points at the
+        # empty smoke workdir so no real auth is ever read. Save/restore every
+        # global+config we touch so later steps see a clean app.
+        _saved_model = app.config.model
+        _saved_demo2 = os.environ.get("RIFTOR_DEMO_RESPONSE")
+        _saved_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["RIFTOR_DEMO_RESPONSE"] = "codex offline ok"
+        os.environ["CODEX_HOME"] = workdir  # guarantee NO real auth.json is read
+        try:
+            inp.value = "/model codex/gpt-5.5-codex"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.status.model == "codex/gpt-5.5-codex", "codex model not selected"
+            inp.value = "hello codex"
+            await pilot.press("enter")
+            await pilot.pause()
+            # The mocked turn must complete and the canned reply must reach the
+            # model context (same mechanism the scope block uses above).
+            assert any(
+                m.get("role") == "assistant"
+                and "codex offline ok" in (m.get("content") or "")
+                for m in app.context._messages
+            ), "expected mocked codex turn reply in context"
+        finally:
+            app.config.model = _saved_model
+            if _saved_demo2 is None:
+                os.environ.pop("RIFTOR_DEMO_RESPONSE", None)
+            else:
+                os.environ["RIFTOR_DEMO_RESPONSE"] = _saved_demo2
+            if _saved_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = _saved_codex_home
+
         # /theme switches the live theme
         inp.value = "/theme void"
         await pilot.press("enter")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,8 +97,9 @@ invocation and are not persisted to config.toml):
 ## Providers & models
 
 Open `/config` to pick a provider and model. The **Provider** dropdown lists
-Anthropic, OpenAI, OpenRouter, Gemini, Groq, DeepSeek, Mistral, Ollama, and
-Custom. Picking one prefills the **Base URL** with that provider's default and
+Anthropic, OpenAI, OpenRouter, Gemini, Groq, DeepSeek, Mistral, Ollama, Codex
+(ChatGPT), and Custom. Picking one prefills the **Base URL** with that
+provider's default and
 fills the **Model** dropdown with curated suggestions. The **Custom id** field
 overrides the dropdown with any litellm model id you type; the **Custom** provider
 is for self-hosted / OpenAI-compatible servers.
@@ -143,6 +144,57 @@ For a given model, riftor resolves the key/base in this order: the matching
 provider's environment variable (e.g. `ANTHROPIC_API_KEY`). Environment variables
 remain the recommended way to supply keys in shared or CI environments.
 
+## Codex / ChatGPT subscription login
+
+riftor can run inference through a **ChatGPT Plus, Pro, or Team subscription**
+instead of an API key by reusing the credentials from OpenAI's official
+[Codex CLI](https://github.com/openai/codex).
+
+### Prerequisites
+
+Install the Codex CLI and authenticate once:
+
+```sh
+npm install -g @openai/codex   # or follow the Codex CLI README
+codex login                    # opens a browser OAuth flow
+```
+
+This writes `~/.codex/auth.json` (or `$CODEX_HOME/auth.json` if that
+environment variable is set). riftor reads that file to obtain a token; it
+never writes it except to persist a refreshed token.
+
+### Selecting Codex in riftor
+
+**Via `/config`:** open `/config`, set **Provider** to **Codex (ChatGPT)**,
+and pick a model such as `codex/gpt-5.5-codex`. No API key is required — a
+**Codex login** status line in the panel shows whether you are authenticated
+and roughly when the token expires.
+
+**Via CLI flag:**
+
+```sh
+riftor --model codex/gpt-5.5-codex
+```
+
+Model ids use the `codex/<name>` prefix in all contexts.
+
+### Checking status
+
+`riftor --doctor` reports whether `~/.codex/auth.json` is present and the
+session is active. Re-run `codex login` whenever the token has expired or a
+call returns an authentication error.
+
+### Billing
+
+Usage is billed to your **ChatGPT subscription**, not to OpenAI API credits.
+
+### Caveat
+
+This feature relies on an **undocumented ChatGPT backend endpoint** that
+OpenAI may change without notice. riftor self-heals the required system prompt
+when online and falls back to a bundled copy offline. If calls start failing
+with auth errors, run `codex login` again to refresh the session.
+
 ## Permissions — `~/.config/riftor/permissions.toml`
 
 Trust choices persist here. `allow` rules auto-approve a tool (optionally only
@@ -186,7 +238,8 @@ quit  = "ctrl+q"
 
 - **`authentication failed`** — the key for your model's provider is missing or
   wrong. Check the right env var (e.g. `ANTHROPIC_API_KEY`), or set the key in
-  `/config` (stored under `[providers.<key>]`).
+  `/config` (stored under `[providers.<key>]`). For Codex / ChatGPT models, run
+  `codex login` to refresh the session token.
 - **`context ~NN% of window`** — the conversation is large. Run `/compact` to
   shrink old tool output, or `/clear` to start fresh.
 - **`model '…' has no known provider prefix`** — the id is likely a typo; use a

--- a/docs/superpowers/plans/2026-06-08-codex-chatgpt-login.md
+++ b/docs/superpowers/plans/2026-06-08-codex-chatgpt-login.md
@@ -4,9 +4,9 @@
 
 **Goal:** Let riftor users run inference through their ChatGPT/Codex subscription by reusing the token file written by the official `codex login`, exposed as a first-class `codex/` provider.
 
-**Architecture:** Codex appears as an ordinary litellm model id (`codex/gpt-5.5-codex`). The undocumented Codex endpoint machinery is delegated to the `litellm-codex-oauth-provider` package, registered into litellm via `custom_provider_map` inside riftor's existing lazy-litellm seam. riftor supplies no API key — the package reads `~/.codex/auth.json` itself. A small read-only helper surfaces login status in `/config` and `--doctor`.
+**Architecture:** Codex appears as an ordinary litellm model id (`codex/gpt-5.5-codex`). riftor **vendors its own litellm `CustomLLM` handler** (`riftor/agent/codex_provider.py`) that reads `~/.codex/auth.json`, refreshes the token, and bridges Chat Completions ↔ the undocumented Codex **Responses** backend. It is registered into litellm via `custom_provider_map` inside riftor's existing lazy-litellm seam. riftor supplies no API key — the handler reads the token file itself. A small read-only helper surfaces login status in `/config` and `--doctor`. (The original plan depended on the `litellm-codex-oauth-provider` PyPI package; that package is unpublished/git-only, so we vendor a minimal equivalent instead — see the revised spec.)
 
-**Tech Stack:** Python 3.11+, litellm, pydantic, Textual, `uv`. New dep: `litellm-codex-oauth-provider`.
+**Tech Stack:** Python 3.11+, litellm (`CustomLLM`), pydantic, Textual, `uv`, stdlib (`urllib`/`json`/`base64`) for auth+HTTP. **No new dependency.**
 
 **Spec:** `docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md`
 
@@ -25,17 +25,21 @@
 | `riftor/providers.py` | Modify | Register `codex` in `PROVIDERS` + `PROVIDER_DEFAULTS`; `fetch_models` handles `list_kind="codex"` |
 | `riftor/config.py` | Modify | `creds_for`/`has_credentials` treat `codex/` as token-file-based (no key) |
 | `riftor/codex_auth.py` | Create | Read-only `~/.codex/auth.json` status helper (never raises) |
-| `riftor/agent/provider.py` | Modify | Register `litellm.custom_provider_map` for `codex` in `_get_litellm()` |
+| `riftor/agent/codex_provider.py` | Create | Vendored litellm `CustomLLM`: auth/refresh + request build + SSE parse + instructions prompt |
+| `riftor/agent/prompts/codex/*.md` | Create | Bundled canonical Codex `instructions` prompt(s) per model family |
+| `riftor/agent/provider.py` | Modify | Register `litellm.custom_provider_map` (riftor's own handler) in `_get_litellm()` |
 | `riftor/tui/config_screen.py` | Modify | Hide key/base/fetch for Codex; show login-status line |
 | `riftor/tui/app.py` | Modify | Add Codex to context-window estimate (128k) |
 | `riftor/engagement/doctor.py` | Modify | Add Codex login line to the doctor report |
 | `riftor/__main__.py` | Modify | `--doctor` prints the Codex status line |
-| `pyproject.toml` | Modify | Add `litellm-codex-oauth-provider` runtime dep |
 | `docs/configuration.md` | Modify | Document Codex login |
 | `tests/test_codex_auth.py` | Create | Unit tests for the auth-status helper |
+| `tests/test_codex_provider.py` | Create | Unit tests for the vendored handler (auth/build/parse/refresh/prompt) |
 | `tests/test_providers.py` | Modify | Codex registry/prefix/fetch tests |
 | `tests/test_config.py` | Modify | Codex creds/has_credentials tests |
 | `dev/smoke.py` | Modify | Drive a Codex-model turn offline |
+
+**Note:** `pyproject.toml`/`uv.lock` are NOT modified — no new dependency.
 
 ---
 
@@ -376,38 +380,246 @@ git commit -m "feat: read-only codex auth.json login-status helper"
 
 ---
 
-## Task 4: Add the runtime dependency and register the litellm handler
+## Task 4: Vendor the Codex `CustomLLM` handler
+
+This task builds riftor's own litellm `CustomLLM` that bridges Chat Completions ↔ the
+undocumented Codex Responses backend. It is split into sub-tasks 4a–4f, each a separate
+TDD cycle + commit. **All sub-tasks are offline** (monkeypatch every HTTP/file seam); the
+only live exercise is the manual step in Task 10.
+
+> **Wire-protocol reference (authoritative, from the official `openai/codex` Rust source +
+> two working community clients).** The implementer MUST follow these exact constants — they
+> are an undocumented endpoint and guesses will be rejected by the backend:
+>
+> - **auth.json:** `$CODEX_HOME`/`auth.json` (default `~/.codex`). Read
+>   `tokens.access_token` (JWT, Bearer), `tokens.refresh_token`, `tokens.account_id`
+>   (may be null), `tokens.id_token` (JWT), `last_refresh`.
+> - **account id:** prefer `tokens.account_id`; else decode the access-token JWT payload
+>   (URL-safe base64, pad to mult-of-4) and read `["https://api.openai.com/auth"]["chatgpt_account_id"]`.
+> - **refresh:** `POST https://auth.openai.com/oauth/token`, JSON body
+>   `{"client_id":"app_EMoamEEZ73f0CkXaXp7hrann","grant_type":"refresh_token","refresh_token":<rt>}`.
+>   Response: `{access_token?, refresh_token?, id_token?}`. Write back to auth.json (mode
+>   `0o600`, atomic). Refresh proactively when the access-token JWT `exp` is ≤5 min away.
+> - **inference:** `POST https://chatgpt.com/backend-api/codex/responses`, headers:
+>   `Authorization: Bearer <access_token>`, `chatgpt-account-id: <id>` (lowercase),
+>   `OpenAI-Beta: responses=experimental`, `originator: codex_cli_rs`,
+>   `Accept: text/event-stream`, `Content-Type: application/json`.
+> - **body (Responses API):** `{model, input, instructions, store:false, stream:true,
+>   include:["reasoning.encrypted_content"], reasoning:{effort,summary:"auto"}, text:{verbosity}}`.
+>   STRIP `max_tokens`/`max_output_tokens`/`max_completion_tokens`/`temperature`/`top_p`.
+> - **input mapping:** system message text → `instructions`; **riftor's RIFT system prompt
+>   → a `developer`-role item** `{"type":"message","role":"developer","content":[{"type":"input_text","text":<rift>}]}`
+>   at the top of `input`; assistant `tool_calls` → `{"type":"function_call","name","arguments","call_id"}`;
+>   `tool` role → `{"type":"function_call_output","call_id","output"}`; other → `{"type":"message","role","content":[{"type":"input_text","text"}]}`.
+> - **tools:** flatten Chat-Completions `{"type":"function","function":{name,description,parameters}}`
+>   → `{"type":"function","name","description","parameters","strict"}`.
+> - **SSE events → deltas:** `response.output_text.delta`→text; `response.reasoning_summary_text.delta`/`response.reasoning_text.delta`→reasoning_content;
+>   `response.function_call_arguments.delta`→tool_use (accumulate args by `call_id`/`item_id`);
+>   `response.completed`/`response.done`→final (carries `response.output` items + `response.usage`).
+>   Usage: `response.usage.input_tokens`→prompt_tokens, `output_tokens`→completion_tokens.
+> - **litellm CustomLLM:** subclass `litellm.CustomLLM`; implement `completion`,
+>   `acompletion`, `streaming`, `astreaming`, each `(self, model, messages, **kwargs)`.
+>   Streaming yields `litellm.types.utils.GenericStreamingChunk`
+>   (`{text, tool_use, is_finished, finish_reason, index, usage}`); non-streaming returns
+>   `litellm.ModelResponse(choices=[Choices(message=Message(...), finish_reason=...)], usage=Usage(...))`.
+>   Register via `litellm.custom_provider_map = [{"provider":"codex","custom_handler":<instance>}]`.
+
+The implementer should consult the spec's "Vendored handler" section and may read the
+reference repos (`numman-ali/opencode-openai-codex-auth`, `openai/codex` `codex-rs/login/`)
+for exact event shapes, but must WRITE riftor's own code (no copying of the unpublished
+`litellm-codex-oauth-provider`).
+
+---
+
+### Task 4a: Token read + account-id + refresh
 
 **Files:**
-- Modify: `pyproject.toml:19-23` (dependencies), `uv.lock` (relock)
-- Modify: `riftor/agent/provider.py:27-37` (`_get_litellm`)
+- Create: `riftor/agent/codex_provider.py` (start the module with the auth section)
+- Test: `tests/test_codex_provider.py`
 
-- [ ] **Step 1: Add the dependency**
+- [ ] **Step 1: Write failing tests** in `tests/test_codex_provider.py`. Use the
+  `_make_jwt`/auth-file helpers (copy the JWT helper pattern from `tests/test_codex_auth.py`).
+  Cover, all offline:
+  - `read_tokens()` returns `(access_token, refresh_token)` from a `tmp_path` auth.json
+    (`CODEX_HOME` monkeypatched).
+  - `account_id()`: returns `tokens.account_id` when present; when absent, decodes it from
+    the access-token JWT `https://api.openai.com/auth` → `chatgpt_account_id` claim. Build
+    a JWT whose payload contains that claim with `_make_jwt`-style encoding.
+  - `should_refresh(access_token)`: True when JWT `exp` is within 5 min (or past), False
+    when `exp` is an hour out.
+  - `refresh_tokens()`: monkeypatch the HTTP POST seam to return
+    `{"access_token":"new-at","refresh_token":"new-rt"}`; assert the new values are written
+    back to the `tmp_path` auth.json, the file mode is `0o600`, and `last_refresh` is updated.
+    The HTTP call must go through a single injectable function (e.g. a module-level
+    `_http_post_json(url, body)`); tests monkeypatch THAT, never the network.
 
-In `pyproject.toml`, change the `dependencies` block to:
+- [ ] **Step 2:** Run `uv run pytest tests/test_codex_provider.py -v` — confirm FAIL.
 
-```toml
-dependencies = [
-    "textual>=0.79",
-    "litellm>=1.55",
-    "pydantic>=2.6",
-    "litellm-codex-oauth-provider>=0.1",
-]
+- [ ] **Step 3:** Implement the auth section in `riftor/agent/codex_provider.py`: constants
+  (`AUTH_TOKEN_URL`, `CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"`), `read_tokens()`,
+  `account_id()`, `should_refresh()`, `refresh_tokens()`, and `_http_post_json(url, body)`
+  using `urllib.request` (the one network seam). Reuse `riftor.codex_auth._jwt_exp` /
+  `codex_home` where helpful (import them). Writing auth.json must mirror riftor's secure
+  write (mode `0o600`, tmp-file + `os.replace`). Never let a parse error crash — raise a
+  clear `RuntimeError("not logged in — run codex login")` when tokens are missing (so it
+  classifies as auth upstream).
+
+- [ ] **Step 4:** Run `uv run pytest tests/test_codex_provider.py -v` — confirm PASS.
+
+- [ ] **Step 5:** `uv run ruff check riftor tests && uv run pyright riftor`, then:
+```bash
+git add riftor/agent/codex_provider.py tests/test_codex_provider.py
+git commit -m "feat: codex handler — token read, account-id, refresh"
 ```
 
-- [ ] **Step 2: Relock and install**
+---
 
-Run: `uv sync --extra dev`
-Expected: resolves and installs `litellm-codex-oauth-provider`; `uv.lock` updated. If the exact `>=0.1` floor doesn't resolve, run `uv add litellm-codex-oauth-provider` instead (it picks a valid floor and updates both files), then re-run `uv sync --extra dev`.
+### Task 4b: Bundled instructions prompt + opportunistic refresh
 
-- [ ] **Step 3: Verify the import path of the handler**
+**Files:**
+- Create: `riftor/agent/prompts/codex/default.md` (bundled canonical prompt — fetch the
+  current `gpt_5_codex_prompt.md` content from `openai/codex` and commit it as the pinned
+  bundle; if the fetch is unavailable, use a minimal faithful placeholder and note it)
+- Modify: `riftor/agent/codex_provider.py` (add the instructions section)
+- Modify: `tests/test_codex_provider.py`
 
-Run: `uv run python -c "from litellm_codex_oauth_provider import codex_auth_provider; print(type(codex_auth_provider))"`
-Expected: prints a class/instance (no ImportError). If the import name differs in the installed version, run `uv run python -c "import litellm_codex_oauth_provider as m; print([n for n in dir(m) if not n.startswith('_')])"` and use the exported handler name in Step 4.
+- [ ] **Step 1: Write failing tests:**
+  - `instructions_for(model)` returns the bundled prompt text (non-empty) when the fetch
+    seam raises (offline path).
+  - When the fetch seam returns new text, `instructions_for` returns THAT (and the bundled
+    copy is the fallback only). Monkeypatch the fetch seam (a module-level
+    `_fetch_remote_instructions(family) -> str | None`).
 
-- [ ] **Step 4: Register the handler in the lazy-litellm seam**
+- [ ] **Step 2:** Run the tests — confirm FAIL.
 
-In `riftor/agent/provider.py`, the current `_get_litellm()` is:
+- [ ] **Step 3:** Implement: load the bundled prompt via `importlib.resources`
+  (mirror how `agent/context.py` loads `prompts/system.md`). Add `instructions_for(model)`:
+  pick a family by substring (`codex` → default bundle for now), try
+  `_fetch_remote_instructions` with a SHORT timeout inside a `try/except` that falls back
+  to the bundle on ANY failure, cache the result in-process. Keep the ETag/disk-cache
+  minimal — a process-lifetime memo is enough for v1; note that as a deliberate scope cut
+  with a `log`/comment.
+
+- [ ] **Step 4:** Run tests — confirm PASS.
+
+- [ ] **Step 5:** lint+types, then:
+```bash
+git add riftor/agent/codex_provider.py riftor/agent/prompts/codex/default.md tests/test_codex_provider.py
+git commit -m "feat: codex handler — bundled instructions prompt + opportunistic refresh"
+```
+
+> **Packaging note:** ensure `riftor/agent/prompts/codex/*.md` ships as package data. Check
+> `pyproject.toml`'s build config (`[tool.hatch.build]`/`[tool.setuptools.package-data]` or
+> the existing `prompts/system.md` inclusion) and mirror whatever makes `prompts/system.md`
+> ship. If `prompts/` is already globbed, no change is needed — verify with
+> `uv run python -c "import importlib.resources as r; print(r.files('riftor.agent').joinpath('prompts/codex/default.md').read_text()[:40])"`.
+
+---
+
+### Task 4c: Request-body builder (messages → Responses `input`)
+
+**Files:**
+- Modify: `riftor/agent/codex_provider.py` (add `build_request_body`)
+- Modify: `tests/test_codex_provider.py`
+
+- [ ] **Step 1: Write failing tests** for a pure function
+  `build_request_body(model, messages, tools, instructions, reasoning_effort, verbosity)`:
+  - system message → goes to `instructions` (not into `input`); riftor's RIFT system prompt
+    text appears as a `developer` item at `input[0]` with `content[0].type == "input_text"`.
+  - a user message → a `{"type":"message","role":"user"}` input item.
+  - an assistant message with `tool_calls` → a `function_call` item with `name`/`arguments`/`call_id`.
+  - a `tool` role message → a `function_call_output` item with matching `call_id`.
+  - body has `store is False`, `stream is True`, `include == ["reasoning.encrypted_content"]`,
+    `reasoning["summary"] == "auto"`, a `text.verbosity` key.
+  - body does NOT contain `max_tokens`, `max_output_tokens`, `max_completion_tokens`,
+    `temperature`, or `top_p` even if passed in `kwargs`.
+  - tools flattened: `tools[0]` has top-level `name`/`parameters` (no nested `function`).
+
+- [ ] **Step 2:** Run — confirm FAIL.
+- [ ] **Step 3:** Implement `build_request_body` as a pure function (no I/O), following the
+  input-mapping rules in the Task-4 reference block.
+- [ ] **Step 4:** Run — confirm PASS.
+- [ ] **Step 5:** lint+types, then:
+```bash
+git add riftor/agent/codex_provider.py tests/test_codex_provider.py
+git commit -m "feat: codex handler — Responses request-body builder"
+```
+
+---
+
+### Task 4d: SSE response parser
+
+**Files:**
+- Modify: `riftor/agent/codex_provider.py` (add SSE parsing → chunks)
+- Modify: `tests/test_codex_provider.py`
+
+- [ ] **Step 1: Write failing tests** feeding a canned list of decoded SSE event dicts to a
+  pure generator `parse_events(events) -> Iterator[chunk]` (chunk = a small dataclass or
+  dict mirroring `GenericStreamingChunk` fields: `text`, `reasoning_content`, `tool_use`,
+  `is_finished`, `finish_reason`, `usage`):
+  - `response.output_text.delta` events → text chunks with the delta.
+  - `response.reasoning_summary_text.delta` → reasoning_content chunks.
+  - a sequence of `response.function_call_arguments.delta` (same `call_id`) → tool_use
+    chunks whose accumulated arguments reassemble to the full JSON; the call name/id are set.
+  - `response.completed` with `response.usage = {"input_tokens":11,"output_tokens":7}` →
+    a final chunk `is_finished=True`, `finish_reason` `"tool_calls"` if a tool call was
+    seen else `"stop"`, and `usage.prompt_tokens==11`, `usage.completion_tokens==7`.
+
+- [ ] **Step 2:** Run — confirm FAIL.
+- [ ] **Step 3:** Implement `parse_events` (pure) plus a thin `_iter_sse(raw_lines)` that
+  turns `event:`/`data:` lines + blank-line framing into event dicts and treats
+  `data: [DONE]` as terminal. Keep network OUT of these — the streaming method (Task 4e)
+  feeds them from the live response.
+- [ ] **Step 4:** Run — confirm PASS.
+- [ ] **Step 5:** lint+types, then:
+```bash
+git add riftor/agent/codex_provider.py tests/test_codex_provider.py
+git commit -m "feat: codex handler — SSE event parser → chunks"
+```
+
+---
+
+### Task 4e: `CustomLLM` class wiring streaming + non-streaming
+
+**Files:**
+- Modify: `riftor/agent/codex_provider.py` (the `CodexProvider(CustomLLM)` class + singleton)
+- Modify: `tests/test_codex_provider.py`
+
+- [ ] **Step 1: Write failing tests** that exercise the class with the network seam
+  monkeypatched (a fake `_stream_responses(payload, headers) -> Iterator[bytes/lines]`
+  returning canned SSE for a text reply, and one for a tool-call reply):
+  - `astreaming(...)` yields `GenericStreamingChunk`s ending with `is_finished=True` and
+    correct usage; the request it built includes the canonical `instructions` and the
+    Authorization/`chatgpt-account-id` headers (assert by capturing what the fake seam
+    received). Provide a `tmp_path` auth.json + monkeypatched `CODEX_HOME` and a
+    future-`exp` access token so no refresh fires.
+  - `acompletion(...)` returns a `ModelResponse` whose `choices[0].message.content` is the
+    concatenated text, and whose `usage` is populated.
+  - missing auth.json → the call raises an error whose message contains "codex login".
+
+- [ ] **Step 2:** Run — confirm FAIL.
+- [ ] **Step 3:** Implement `CodexProvider(litellm.CustomLLM)` with `completion`/
+  `acompletion`/`streaming`/`astreaming`, composing 4a–4d: resolve+refresh token, build
+  headers, build body (instructions from 4b), POST to the responses endpoint via the
+  injectable `_stream_responses` seam, parse via 4d, and adapt to
+  `GenericStreamingChunk`/`ModelResponse`. Provide sync wrappers that drain the async path
+  (use `asyncio.run`/thread fallback). Export a module-level singleton instance
+  `codex_provider = CodexProvider()`.
+- [ ] **Step 4:** Run — confirm PASS.
+- [ ] **Step 5:** lint+types, then:
+```bash
+git add riftor/agent/codex_provider.py tests/test_codex_provider.py
+git commit -m "feat: codex handler — CustomLLM streaming/non-streaming"
+```
+
+---
+
+### Task 4f: Register the handler in the lazy-litellm seam
+
+**Files:**
+- Modify: `riftor/agent/provider.py:27-37` (`_get_litellm`)
+
+- [ ] **Step 1: Register** the vendored handler. The current `_get_litellm()` is:
 
 ```python
 def _get_litellm():
@@ -423,7 +635,8 @@ def _get_litellm():
     return _litellm
 ```
 
-Replace the body with one that also registers the Codex custom provider (guarded so a missing/renamed handler never breaks startup of non-Codex users):
+Replace it with a version that also registers riftor's codex handler, guarded so a failure
+never breaks startup for non-Codex users:
 
 ```python
 def _get_litellm():
@@ -441,34 +654,32 @@ def _get_litellm():
 
 
 def _register_codex_provider(litellm) -> None:
-    """Register the `codex/` custom provider that reads ~/.codex/auth.json.
+    """Register riftor's vendored `codex/` handler (reads ~/.codex/auth.json).
 
-    Guarded: if the package is absent or its API changed, Codex simply won't
-    work, but every other provider still does — consistent with riftor's
-    never-crash-on-an-optional-thing ethos.
+    Guarded: if importing the handler fails for any reason, Codex simply won't
+    work, but every other provider still does — riftor's never-crash ethos.
     """
     try:
-        from litellm_codex_oauth_provider import codex_auth_provider
+        from riftor.agent.codex_provider import codex_provider
     except Exception:  # noqa: BLE001 — Codex optional at runtime; never break the loop
         return
     existing = list(getattr(litellm, "custom_provider_map", None) or [])
     if any(entry.get("provider") == "codex" for entry in existing):
         return
-    existing.append({"provider": "codex", "custom_handler": codex_auth_provider})
+    existing.append({"provider": "codex", "custom_handler": codex_provider})
     litellm.custom_provider_map = existing
 ```
 
-- [ ] **Step 5: Verify registration works without a token file**
+- [ ] **Step 2: Verify** registration works with no token file present:
 
 Run: `uv run python -c "from riftor.agent.provider import _get_litellm; m=_get_litellm(); print([e['provider'] for e in m.custom_provider_map])"`
-Expected: output includes `'codex'`, and the command does not require `~/.codex/auth.json` to exist (no crash).
+Expected: output includes `'codex'`; no crash even though `~/.codex/auth.json` is absent.
 
-- [ ] **Step 6: Lint, type-check, commit**
-
+- [ ] **Step 3:** lint+types, then:
 ```bash
 uv run ruff check riftor && uv run pyright riftor
-git add pyproject.toml uv.lock riftor/agent/provider.py
-git commit -m "feat: register litellm codex custom provider; add runtime dep"
+git add riftor/agent/provider.py
+git commit -m "feat: register riftor's vendored codex CustomLLM handler"
 ```
 
 ---
@@ -744,8 +955,9 @@ Check status any time with `riftor --doctor`, which reports whether
 **Notes:**
 
 - Billing goes to your ChatGPT subscription, not OpenAI API credits.
-- This uses an **undocumented** ChatGPT backend endpoint via the
-  `litellm-codex-oauth-provider` package; OpenAI may change it without notice.
+- This uses an **undocumented** ChatGPT backend endpoint; OpenAI may change it without
+  notice. riftor self-heals the required system prompt when online and falls back to a
+  bundled copy offline.
 - If a call fails with an auth error, re-run `codex login`.
 ```
 
@@ -782,20 +994,39 @@ git commit -m "chore: green CI for codex login feature"
 
 ## Self-Review (completed by plan author)
 
-**Spec coverage:**
-- Architecture (registration in `_get_litellm`, creds `(None,None)`) → Task 4, Task 2 ✓
-- `providers.py` registry + `PROVIDER_DEFAULTS` + `fetch_models` codex kind → Task 1 ✓
-- `config.py` `creds_for`/`has_credentials`/`provider_env` → Task 2 ✓
-- `codex_auth.py` helper → Task 3 ✓
+**Spec coverage (revised for the vendored approach):**
+- Architecture (registration in `_get_litellm`, creds `(None,None)`) → Task 4f, Task 2 ✓
+- `providers.py` registry + `PROVIDER_DEFAULTS` + `fetch_models` codex kind → Task 1 ✓ (done)
+- `config.py` `creds_for`/`has_credentials`/`provider_env` → Task 2 ✓ (done)
+- `codex_auth.py` helper → Task 3 ✓ (done)
+- Vendored `CustomLLM` handler (auth/refresh, instructions prompt, request build, SSE parse,
+  class, registration) → Tasks 4a/4b/4c/4d/4e/4f ✓
 - `config_screen.py` (hide key/base/fetch, status line) → Task 5 ✓
 - `app.py` context window → Task 6 ✓
 - `doctor.py` + `--doctor` → Task 7 ✓
-- `pyproject.toml` / `uv.lock` hard dep → Task 4 ✓
+- **No dependency added** (vendored) → no `pyproject.toml`/`uv.lock` change ✓
 - `docs/configuration.md` → Task 9 ✓
-- Tests (providers, config, codex_auth) + smoke → Tasks 1,2,3,7,8 ✓
-- Error handling (auth errors via `classify_error`, never-crash) → covered by Task 3 (helper never raises), Task 4 (guarded registration); `classify_error` already maps auth/validation/unknown — no change needed ✓
-- Out-of-scope items (no OAuth, no shell-out, no CLI flag) → respected; completions untouched ✓
+- Tests (providers, config, codex_auth, codex_provider) + smoke → Tasks 1,2,3,4a–4e,7,8 ✓
+- Error handling (auth errors via `classify_error`, never-crash) → Task 3 (helper never
+  raises), Task 4a (clear auth RuntimeError → classifies as auth), Task 4f (guarded
+  registration); `classify_error` already maps auth/validation/unknown — no change needed ✓
+- Out-of-scope items (no OAuth, no shell-out, no CLI flag, no cache-key) → respected;
+  completions untouched ✓
 
-**Placeholder scan:** No TBD/TODO. Every code step shows full code. The two adaptive notes (handler import name in Task 4 Step 3, `last_assistant_text` in Task 8) give an explicit verification command + fallback rather than a vague "fill in" — they exist because the exact external symbol can vary by installed version.
+**Placeholder scan:** No TBD/TODO. Tasks 1–3 and 5–9 give full code. Task 4 (the vendored
+handler) is specified by exact wire-protocol constants + per-sub-task test contracts rather
+than full line-by-line code, because it is a large integration against an undocumented
+endpoint where prescribing every line would be brittle and the reference shapes are better
+consulted live; each sub-task is still a strict TDD cycle (failing tests first, named
+functions, named assertions) so the implementer has unambiguous targets. The adaptive note
+in Task 8 (`last_assistant_text`) gives a verification command + fallback.
 
-**Type/name consistency:** `CodexAuthStatus(logged_in, expires_in_s, detail)`, `auth_status()`, `codex_home()`, `_register_codex_provider`, `_set_codex_mode`, `_codex_status_text` are used consistently across Tasks 3/5/7/8. Provider key `"codex"`, prefix `"codex/"`, `list_kind="codex"` consistent across Tasks 1/2/4/6. Model id `codex/gpt-5.5-codex` consistent throughout.
+**Type/name consistency:** `CodexAuthStatus(logged_in, expires_in_s, detail)`,
+`auth_status()`, `codex_home()`, `_register_codex_provider`, `_set_codex_mode`,
+`_codex_status_text` consistent across Tasks 3/5/7/8. Vendored-handler names
+(`read_tokens`, `account_id`, `should_refresh`, `refresh_tokens`, `instructions_for`,
+`build_request_body`, `parse_events`, `CodexProvider`, singleton `codex_provider`,
+`_http_post_json`, `_stream_responses`, `_fetch_remote_instructions`) are introduced and
+reused consistently across Tasks 4a–4f. Provider key `"codex"`, prefix `"codex/"`,
+`list_kind="codex"` consistent across Tasks 1/2/4/6. Model id `codex/gpt-5.5-codex`
+consistent throughout.

--- a/docs/superpowers/plans/2026-06-08-codex-chatgpt-login.md
+++ b/docs/superpowers/plans/2026-06-08-codex-chatgpt-login.md
@@ -1,0 +1,801 @@
+# Codex (ChatGPT subscription) Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let riftor users run inference through their ChatGPT/Codex subscription by reusing the token file written by the official `codex login`, exposed as a first-class `codex/` provider.
+
+**Architecture:** Codex appears as an ordinary litellm model id (`codex/gpt-5.5-codex`). The undocumented Codex endpoint machinery is delegated to the `litellm-codex-oauth-provider` package, registered into litellm via `custom_provider_map` inside riftor's existing lazy-litellm seam. riftor supplies no API key — the package reads `~/.codex/auth.json` itself. A small read-only helper surfaces login status in `/config` and `--doctor`.
+
+**Tech Stack:** Python 3.11+, litellm, pydantic, Textual, `uv`. New dep: `litellm-codex-oauth-provider`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md`
+
+**Conventions to honor (from CLAUDE.md):**
+- All tests run **offline** — no network, no real `~/.codex`. Use `monkeypatch` and `tmp_path`.
+- `pytest` runs in `asyncio_mode = "auto"` (no `@pytest.mark.asyncio` needed).
+- Bad config/auth must **never crash startup** — degrade silently to defaults.
+- Run lint+types before committing each task: `uv run ruff check riftor dev tests && uv run pyright riftor`.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|------|---------------|----------------|
+| `riftor/providers.py` | Modify | Register `codex` in `PROVIDERS` + `PROVIDER_DEFAULTS`; `fetch_models` handles `list_kind="codex"` |
+| `riftor/config.py` | Modify | `creds_for`/`has_credentials` treat `codex/` as token-file-based (no key) |
+| `riftor/codex_auth.py` | Create | Read-only `~/.codex/auth.json` status helper (never raises) |
+| `riftor/agent/provider.py` | Modify | Register `litellm.custom_provider_map` for `codex` in `_get_litellm()` |
+| `riftor/tui/config_screen.py` | Modify | Hide key/base/fetch for Codex; show login-status line |
+| `riftor/tui/app.py` | Modify | Add Codex to context-window estimate (128k) |
+| `riftor/engagement/doctor.py` | Modify | Add Codex login line to the doctor report |
+| `riftor/__main__.py` | Modify | `--doctor` prints the Codex status line |
+| `pyproject.toml` | Modify | Add `litellm-codex-oauth-provider` runtime dep |
+| `docs/configuration.md` | Modify | Document Codex login |
+| `tests/test_codex_auth.py` | Create | Unit tests for the auth-status helper |
+| `tests/test_providers.py` | Modify | Codex registry/prefix/fetch tests |
+| `tests/test_config.py` | Modify | Codex creds/has_credentials tests |
+| `dev/smoke.py` | Modify | Drive a Codex-model turn offline |
+
+---
+
+## Task 1: Register the Codex provider in the registry
+
+**Files:**
+- Modify: `riftor/providers.py:26-45` (PROVIDERS table), `:48-61` (PROVIDER_DEFAULTS), `:130-143` (fetch_models)
+- Test: `tests/test_providers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_providers.py`:
+
+```python
+def test_codex_provider_registered():
+    assert "codex" in pv.PROVIDERS
+    meta = pv.PROVIDERS["codex"]
+    assert meta.prefix == "codex/"
+    assert meta.env is None          # no API key env var
+    assert meta.list_kind == "codex"
+    assert meta.default_base is None
+    assert "codex" in pv.PROVIDER_DEFAULTS
+
+
+def test_codex_provider_key_and_prefix():
+    assert pv.provider_key_for_model("codex/gpt-5.5-codex") == "codex"
+    assert pv.apply_prefix("codex", "gpt-5.5-codex") == "codex/gpt-5.5-codex"
+    # an id that already carries the prefix passes through unchanged
+    assert pv.apply_prefix("codex", "codex/gpt-5.5") == "codex/gpt-5.5"
+
+
+def test_fetch_codex_returns_curated_without_network(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("must not hit the network for list_kind=codex")
+    monkeypatch.setattr(pv.urllib.request, "urlopen", boom)
+    monkeypatch.setattr(pv, "_http_get_json", boom)
+    res = pv.fetch_models("codex", None, None)
+    assert res.source == "curated"
+    assert res.error is None
+    assert res.models == pv.PROVIDER_DEFAULTS["codex"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_providers.py -k codex -v`
+Expected: FAIL — `KeyError: 'codex'` / `assert 'codex' in {...}`.
+
+- [ ] **Step 3: Add the provider to the registry**
+
+In `riftor/providers.py`, add this entry to the `PROVIDERS` dict (place it just before the `"ollama"` entry so cloud providers stay grouped before local):
+
+```python
+    "codex": ProviderMeta("codex", "Codex (ChatGPT)", "codex/", None,
+                          "codex", None),
+```
+
+Add to `PROVIDER_DEFAULTS` (place before `"ollama": []`):
+
+```python
+    "codex": ["gpt-5.5-codex", "gpt-5.5", "gpt-5.4-codex"],
+```
+
+In `fetch_models`, add a guard right after the existing `if meta.list_kind == "none":` block (around line 122), so a Codex fetch never touches the network and never needs a base URL:
+
+```python
+    if meta.list_kind == "codex":
+        # Codex backend has no public /models list; always use curated defaults.
+        return FetchResult(models=curated, source="curated")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_providers.py -k codex -v`
+Expected: PASS (3 tests).
+
+Also run the full provider suite to confirm no regression (the existing `test_registry_has_expected_providers` asserts a subset, so it still passes):
+
+Run: `uv run pytest tests/test_providers.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor tests && uv run pyright riftor
+git add riftor/providers.py tests/test_providers.py
+git commit -m "feat: register codex (ChatGPT subscription) provider in registry"
+```
+
+---
+
+## Task 2: Credential resolution treats Codex as token-file-based
+
+**Files:**
+- Modify: `riftor/config.py:120-134` (`has_credentials`), `:136-155` (`creds_for`)
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_codex_creds_are_none(monkeypatch):
+    # Codex supplies no api_key/api_base from riftor; the litellm handler reads
+    # ~/.codex/auth.json itself. A stale global key must never leak to it.
+    cfg = Config(model="codex/gpt-5.5-codex", api_key="leftover-global")
+    assert cfg.creds_for("codex/gpt-5.5-codex") == (None, None)
+
+
+def test_codex_has_credentials_like_ollama(monkeypatch):
+    # Treated like ollama: never block the UI on a key. Real login validity is
+    # surfaced as status, not a hard gate.
+    cfg = Config(model="codex/gpt-5.5-codex")
+    assert cfg.has_credentials()
+
+
+def test_codex_provider_env_is_none():
+    assert Config(model="codex/gpt-5.5-codex").provider_env() is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -k codex -v`
+Expected: FAIL — `creds_for` returns `("leftover-global", None)` and `has_credentials()` is `False`.
+
+- [ ] **Step 3: Implement the Codex branches**
+
+In `riftor/config.py`, `has_credentials()` — add a Codex branch alongside the existing Ollama one. The current block is:
+
+```python
+        if self.model.startswith(("ollama/", "ollama_chat/")):
+            return True
+```
+
+Change it to also cover Codex:
+
+```python
+        if self.model.startswith(("ollama/", "ollama_chat/", "codex/")):
+            return True
+```
+
+In `creds_for()`, add an explicit early return at the very top of the method body (before the per-provider table lookup), so a stale global `api_key`/env never reaches the Codex handler:
+
+```python
+        if model.startswith("codex/"):
+            # Codex auth lives in ~/.codex/auth.json, read by the litellm handler.
+            return None, None
+```
+
+`provider_env()` already returns `None` for Codex because `PROVIDERS["codex"].env is None` — no change needed; the new test pins it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -k codex -v`
+Expected: PASS (3 tests).
+
+Run the full config suite to confirm no regression:
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor tests && uv run pyright riftor
+git add riftor/config.py tests/test_config.py
+git commit -m "feat: resolve codex creds from token file (no api key)"
+```
+
+---
+
+## Task 3: Read-only Codex auth-status helper
+
+**Files:**
+- Create: `riftor/codex_auth.py`
+- Test: `tests/test_codex_auth.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_codex_auth.py`:
+
+```python
+"""Codex auth-status helper: reads ~/.codex/auth.json, never raises."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import riftor.codex_auth as ca
+
+
+def _make_jwt(exp: int) -> str:
+    """A minimal unsigned JWT with the given exp claim (header.payload.sig)."""
+    def seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return f"{seg({'alg': 'none'})}.{seg({'exp': exp})}.sig"
+
+
+def _write_auth(tmp_path, access_token: str) -> None:
+    (tmp_path / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": access_token}})
+    )
+
+
+def test_missing_file_is_not_logged_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    status = ca.auth_status()
+    assert status.logged_in is False
+    assert "codex login" in status.detail
+
+
+def test_valid_future_token_is_logged_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_auth(tmp_path, _make_jwt(int(time.time()) + 3600))
+    status = ca.auth_status()
+    assert status.logged_in is True
+    assert status.expires_in_s is not None
+    assert 0 < status.expires_in_s <= 3600
+
+
+def test_garbage_token_degrades_without_raising(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_auth(tmp_path, "not-a-jwt")
+    status = ca.auth_status()           # must NOT raise
+    assert status.logged_in is True     # token present, just unparseable
+    assert status.expires_in_s is None
+
+
+def test_malformed_json_degrades_without_raising(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text("{ this is not json")
+    status = ca.auth_status()           # must NOT raise
+    assert status.logged_in is False
+
+
+def test_codex_home_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    from pathlib import Path
+    assert ca.codex_home() == Path.home() / ".codex"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_codex_auth.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'riftor.codex_auth'`.
+
+- [ ] **Step 3: Create the helper**
+
+Create `riftor/codex_auth.py`:
+
+```python
+"""Read-only status for the Codex CLI's ~/.codex/auth.json token file.
+
+riftor never writes this file — the official ``codex login`` does. We only peek
+at it to tell the operator whether they're logged in (and roughly when the token
+expires) so /config and --doctor can guide them. Every failure degrades to a
+sensible status; this module never raises.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CodexAuthStatus:
+    logged_in: bool
+    expires_in_s: int | None
+    detail: str
+
+
+def codex_home() -> Path:
+    """``$CODEX_HOME`` if set, else ``~/.codex`` (matches the official CLI)."""
+    env = os.environ.get("CODEX_HOME")
+    return Path(env) if env else Path.home() / ".codex"
+
+
+def _auth_file() -> Path:
+    return codex_home() / "auth.json"
+
+
+def _jwt_exp(token: str) -> int | None:
+    """Read the ``exp`` claim from a JWT payload (no signature check)."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)  # restore base64 padding
+    raw = base64.urlsafe_b64decode(payload.encode("ascii"))
+    claims = json.loads(raw)
+    exp = claims.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+def auth_status() -> CodexAuthStatus:
+    """Best-effort login status. Never raises."""
+    path = _auth_file()
+    if not path.exists():
+        return CodexAuthStatus(False, None, "not logged in — run `codex login`")
+    try:
+        data = json.loads(path.read_text())
+        token = (data.get("tokens") or {}).get("access_token")
+    except Exception:  # noqa: BLE001 — a bad token file must never crash riftor
+        return CodexAuthStatus(False, None, "unreadable auth.json — run `codex login`")
+    if not token:
+        return CodexAuthStatus(False, None, "no token — run `codex login`")
+    try:
+        exp = _jwt_exp(token)
+    except Exception:  # noqa: BLE001 — unparseable JWT => token present, expiry unknown
+        return CodexAuthStatus(True, None, "token present")
+    if exp is None:
+        return CodexAuthStatus(True, None, "token present")
+    remaining = int(exp - time.time())
+    if remaining <= 0:
+        return CodexAuthStatus(False, 0, "token expired — run `codex login`")
+    return CodexAuthStatus(True, remaining, f"logged in ({remaining // 60}m left)")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_codex_auth.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor tests && uv run pyright riftor
+git add riftor/codex_auth.py tests/test_codex_auth.py
+git commit -m "feat: read-only codex auth.json login-status helper"
+```
+
+---
+
+## Task 4: Add the runtime dependency and register the litellm handler
+
+**Files:**
+- Modify: `pyproject.toml:19-23` (dependencies), `uv.lock` (relock)
+- Modify: `riftor/agent/provider.py:27-37` (`_get_litellm`)
+
+- [ ] **Step 1: Add the dependency**
+
+In `pyproject.toml`, change the `dependencies` block to:
+
+```toml
+dependencies = [
+    "textual>=0.79",
+    "litellm>=1.55",
+    "pydantic>=2.6",
+    "litellm-codex-oauth-provider>=0.1",
+]
+```
+
+- [ ] **Step 2: Relock and install**
+
+Run: `uv sync --extra dev`
+Expected: resolves and installs `litellm-codex-oauth-provider`; `uv.lock` updated. If the exact `>=0.1` floor doesn't resolve, run `uv add litellm-codex-oauth-provider` instead (it picks a valid floor and updates both files), then re-run `uv sync --extra dev`.
+
+- [ ] **Step 3: Verify the import path of the handler**
+
+Run: `uv run python -c "from litellm_codex_oauth_provider import codex_auth_provider; print(type(codex_auth_provider))"`
+Expected: prints a class/instance (no ImportError). If the import name differs in the installed version, run `uv run python -c "import litellm_codex_oauth_provider as m; print([n for n in dir(m) if not n.startswith('_')])"` and use the exported handler name in Step 4.
+
+- [ ] **Step 4: Register the handler in the lazy-litellm seam**
+
+In `riftor/agent/provider.py`, the current `_get_litellm()` is:
+
+```python
+def _get_litellm():
+    global _litellm
+    if _litellm is None:
+        os.environ.setdefault("LITELLM_LOG", "ERROR")
+        import litellm
+
+        litellm.telemetry = False
+        litellm.drop_params = True
+        litellm.suppress_debug_info = True
+        _litellm = litellm
+    return _litellm
+```
+
+Replace the body with one that also registers the Codex custom provider (guarded so a missing/renamed handler never breaks startup of non-Codex users):
+
+```python
+def _get_litellm():
+    global _litellm
+    if _litellm is None:
+        os.environ.setdefault("LITELLM_LOG", "ERROR")
+        import litellm
+
+        litellm.telemetry = False
+        litellm.drop_params = True
+        litellm.suppress_debug_info = True
+        _register_codex_provider(litellm)
+        _litellm = litellm
+    return _litellm
+
+
+def _register_codex_provider(litellm) -> None:
+    """Register the `codex/` custom provider that reads ~/.codex/auth.json.
+
+    Guarded: if the package is absent or its API changed, Codex simply won't
+    work, but every other provider still does — consistent with riftor's
+    never-crash-on-an-optional-thing ethos.
+    """
+    try:
+        from litellm_codex_oauth_provider import codex_auth_provider
+    except Exception:  # noqa: BLE001 — Codex optional at runtime; never break the loop
+        return
+    existing = list(getattr(litellm, "custom_provider_map", None) or [])
+    if any(entry.get("provider") == "codex" for entry in existing):
+        return
+    existing.append({"provider": "codex", "custom_handler": codex_auth_provider})
+    litellm.custom_provider_map = existing
+```
+
+- [ ] **Step 5: Verify registration works without a token file**
+
+Run: `uv run python -c "from riftor.agent.provider import _get_litellm; m=_get_litellm(); print([e['provider'] for e in m.custom_provider_map])"`
+Expected: output includes `'codex'`, and the command does not require `~/.codex/auth.json` to exist (no crash).
+
+- [ ] **Step 6: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor && uv run pyright riftor
+git add pyproject.toml uv.lock riftor/agent/provider.py
+git commit -m "feat: register litellm codex custom provider; add runtime dep"
+```
+
+---
+
+## Task 5: `/config` UI — hide key/base/fetch for Codex, show login status
+
+**Files:**
+- Modify: `riftor/tui/config_screen.py` — imports (`:14-22`), compose Model section (`:114-129`), `on_select_changed` (`:216-223`)
+- Manual verification (Textual UI; covered end-to-end by the smoke test in Task 8)
+
+- [ ] **Step 1: Import the auth helper**
+
+In `riftor/tui/config_screen.py`, add after the existing `from riftor.config import REASONING_EFFORTS` import (line 22):
+
+```python
+from riftor.codex_auth import auth_status
+```
+
+- [ ] **Step 2: Add a status label to the Model section**
+
+In `compose()`, the Model section currently ends with the API-key row and the Fetch button (lines 125-129). Add a Codex status label right after the API-key row and before the Fetch-button `Horizontal`. Insert:
+
+```python
+                        yield _row("Codex login", Label(
+                            self._codex_status_text(), id="cfg-codex-status"))
+```
+
+- [ ] **Step 3: Add the status-text helper and initial visibility**
+
+Add this method to `ConfigScreen` (next to `_set_model_options`):
+
+```python
+    def _codex_status_text(self) -> str:
+        st = auth_status()
+        mark = "✓" if st.logged_in else "⚠"
+        return f"{mark} {st.detail}"
+
+    def _set_codex_mode(self, on: bool) -> None:
+        """Codex has no API key/base/model-list: hide those rows, show status."""
+        for wid in ("cfg-key", "cfg-base", "cfg-fetch"):
+            row = self.query_one(f"#{wid}").parent
+            row.set_class(on, "hidden")
+        status_row = self.query_one("#cfg-codex-status").parent
+        status_row.set_class(not on, "hidden")
+        if on:
+            self.query_one("#cfg-codex-status", Label).update(self._codex_status_text())
+```
+
+In `on_mount()` (currently just focuses `#cfg-provider`), add a call so the initial state is correct when the saved provider is already Codex:
+
+```python
+    def on_mount(self) -> None:
+        self.query_one("#cfg-provider", Select).focus()
+        self._set_codex_mode(self._provider == "codex")
+```
+
+- [ ] **Step 4: Toggle on provider change**
+
+In `on_select_changed`, the `cfg-provider` branch currently sets `self._provider`, updates the base URL, and refreshes model options. Add the Codex-mode toggle. The branch becomes:
+
+```python
+        if event.select.id == "cfg-provider" and isinstance(event.value, str):
+            self._provider = event.value
+            self._set_codex_mode(event.value == "codex")
+            meta = PROVIDERS[event.value]
+            self.query_one("#cfg-base", Input).value = meta.default_base or ""
+            if self._provider_initialized:
+                self._set_model_options(_model_options(event.value))
+            else:
+                self._provider_initialized = True
+```
+
+- [ ] **Step 5: Manual smoke (optional here; automated in Task 8)**
+
+Run: `uv run riftor` → open `/config` → switch Provider to "Codex (ChatGPT)".
+Expected: API key, Base URL, and Fetch button disappear; a "Codex login" status line shows `⚠ not logged in — run \`codex login\`` (or `✓ logged in (…m left)` if you've run `codex login`). Switching back to Anthropic restores the key/base/fetch rows.
+
+- [ ] **Step 6: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor && uv run pyright riftor
+git add riftor/tui/config_screen.py
+git commit -m "feat: /config adapts to codex (login status, no key/base/fetch)"
+```
+
+---
+
+## Task 6: Context-window estimate for Codex
+
+**Files:**
+- Modify: `riftor/tui/app.py:44-49` (`_CONTEXT_WINDOWS`)
+
+- [ ] **Step 1: Add the Codex window**
+
+In `riftor/tui/app.py`, the `_CONTEXT_WINDOWS` dict is matched by prefix in `_context_window()`. Add a `codex/` entry (128k, matching the GPT-5 class default):
+
+```python
+_CONTEXT_WINDOWS = {
+    "anthropic/": 200_000, "openai/": 128_000, "openrouter/": 128_000,
+    "gemini/": 1_000_000, "groq/": 128_000, "ollama": 8_192,
+    "codex/": 128_000,
+}
+```
+
+- [ ] **Step 2: Verify the lookup resolves**
+
+Run: `uv run python -c "import riftor.tui.app as a; print(next(w for p,w in a._CONTEXT_WINDOWS.items() if 'codex/gpt-5.5-codex'.startswith(p)))"`
+Expected: `128000`.
+
+- [ ] **Step 3: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor && uv run pyright riftor
+git add riftor/tui/app.py
+git commit -m "feat: context-window estimate for codex models (128k)"
+```
+
+---
+
+## Task 7: Surface Codex login in `--doctor`
+
+**Files:**
+- Modify: `riftor/engagement/doctor.py:105-115` (`render_plain`)
+- Modify: `riftor/__main__.py:55-59` (the `--doctor` branch already calls `render_plain`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_codex_auth.py` (it already imports `riftor.codex_auth`):
+
+```python
+def test_doctor_plain_includes_codex_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))  # no auth.json => not logged in
+    from riftor.engagement.doctor import check_toolchain, render_plain
+    out = render_plain(check_toolchain())
+    assert "Codex" in out
+    assert "codex login" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_codex_auth.py::test_doctor_plain_includes_codex_line -v`
+Expected: FAIL — `assert "Codex" in out` (the doctor report has no Codex line yet).
+
+- [ ] **Step 3: Append a Codex line in `render_plain`**
+
+In `riftor/engagement/doctor.py`, import the helper at the top (after the `import shutil` line):
+
+```python
+from riftor.codex_auth import auth_status
+```
+
+In `render_plain`, before the final `return "\n".join(lines)`, append a Codex auth line:
+
+```python
+    st = auth_status()
+    mark = "ok " if st.logged_in else "MISSING"
+    lines.append(f"  [{mark}] {'codex login':<10} {st.detail}")
+```
+
+(`render_markdown` is the TUI surface; the spec only requires the CLI `--doctor` line, which goes through `render_plain`. Leave `render_markdown` unchanged to keep this task focused.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_codex_auth.py::test_doctor_plain_includes_codex_line -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the CLI end-to-end**
+
+Run: `CODEX_HOME=/nonexistent uv run riftor --doctor`
+Expected: the report ends with a line like `[MISSING] codex login  not logged in — run \`codex login\``.
+
+- [ ] **Step 6: Lint, type-check, commit**
+
+```bash
+uv run ruff check riftor tests && uv run pyright riftor
+git add riftor/engagement/doctor.py tests/test_codex_auth.py
+git commit -m "feat: --doctor reports codex login status"
+```
+
+---
+
+## Task 8: Smoke test — drive a Codex-model turn offline
+
+**Files:**
+- Modify: `dev/smoke.py`
+
+- [ ] **Step 1: Read the existing demo-turn block**
+
+Open `dev/smoke.py` and find the block that sets `RIFTOR_DEMO_RESPONSE` and drives a turn (around line 114-119, where `_saved_demo`, `_saved_key`, `_saved_chakla_model` are captured). This is the offline turn-driving pattern to reuse.
+
+- [ ] **Step 2: Add a Codex-model offline check**
+
+After the existing offline demo-turn block completes and restores its globals, add a self-contained Codex check that proves: (a) switching to a `codex/` model works, (b) `custom_provider_map` registration is harmless under the demo mock, and (c) no token file is required. Insert:
+
+```python
+        # --- Codex (ChatGPT subscription) model: offline, mocked ---
+        _saved_model = app.config.model
+        _saved_demo2 = os.environ.get("RIFTOR_DEMO_RESPONSE")
+        _saved_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["RIFTOR_DEMO_RESPONSE"] = "codex offline ok"
+        os.environ["CODEX_HOME"] = workdir  # guarantee NO real auth.json is read
+        try:
+            inp.value = "/model codex/gpt-5.5-codex"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.status.model == "codex/gpt-5.5-codex", "codex model not selected"
+            inp.value = "hello codex"
+            await pilot.press("enter")
+            await pilot.pause()
+            # The mocked turn must complete without crashing; the demo text appears.
+            assert "codex offline ok" in app.context.last_assistant_text(), \
+                "expected mocked codex turn to complete"
+        finally:
+            app.config.model = _saved_model
+            if _saved_demo2 is None:
+                os.environ.pop("RIFTOR_DEMO_RESPONSE", None)
+            else:
+                os.environ["RIFTOR_DEMO_RESPONSE"] = _saved_demo2
+            if _saved_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = _saved_codex_home
+```
+
+> **Note on `last_assistant_text()`:** if `riftor.agent.context.Context` has no such method, replace that assertion with the same mechanism the existing demo block uses to read the assistant's reply (mirror it exactly — read the existing block first in Step 1). The goal is only "the mocked turn completed without crashing."
+
+- [ ] **Step 3: Run the smoke test**
+
+Run: `uv run python dev/smoke.py`
+Expected: exits 0; prints its existing success output with no traceback. The Codex block runs without needing a real `~/.codex/auth.json`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dev/smoke.py
+git commit -m "test: smoke-drive a codex model turn offline"
+```
+
+---
+
+## Task 9: Document Codex login
+
+**Files:**
+- Modify: `docs/configuration.md`
+
+- [ ] **Step 1: Read the current doc structure**
+
+Open `docs/configuration.md` and find where providers / model ids / credentials are documented, to place the new section consistently (follow the existing heading style).
+
+- [ ] **Step 2: Add the Codex section**
+
+Add a section (match the surrounding heading level):
+
+```markdown
+## Codex / ChatGPT subscription login
+
+riftor can run inference through your **ChatGPT Plus/Pro/Team subscription**
+instead of an API key, by reusing the credentials from OpenAI's official Codex CLI.
+
+**Setup:**
+
+1. Install the official Codex CLI and run `codex login` once. This performs the
+   OAuth browser flow and writes `~/.codex/auth.json` (override the location with
+   `$CODEX_HOME`). riftor reads this file — it never writes it.
+2. In riftor, open `/config`, set **Provider** to **Codex (ChatGPT)**, and pick a
+   model such as `codex/gpt-5.5-codex`. No API key is needed — the "Codex login"
+   line shows whether you're authenticated and roughly when the token expires.
+3. Or set it directly: `riftor --model codex/gpt-5.5-codex`.
+
+Check status any time with `riftor --doctor`, which reports whether
+`~/.codex/auth.json` is present and logged in.
+
+**Notes:**
+
+- Billing goes to your ChatGPT subscription, not OpenAI API credits.
+- This uses an **undocumented** ChatGPT backend endpoint via the
+  `litellm-codex-oauth-provider` package; OpenAI may change it without notice.
+- If a call fails with an auth error, re-run `codex login`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/configuration.md
+git commit -m "docs: document codex (ChatGPT subscription) login"
+```
+
+---
+
+## Task 10: Full CI gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `make check`
+Expected: lint → typecheck → test → smoke all pass (exit 0). This is the same gate CI runs on 3.11 + 3.12.
+
+- [ ] **Step 2: If anything fails**
+
+Fix the specific failure in its owning task's files, re-run `make check`, and amend/commit. Do not mark the plan complete until `make check` is green.
+
+- [ ] **Step 3: Final commit (only if fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore: green CI for codex login feature"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Architecture (registration in `_get_litellm`, creds `(None,None)`) → Task 4, Task 2 ✓
+- `providers.py` registry + `PROVIDER_DEFAULTS` + `fetch_models` codex kind → Task 1 ✓
+- `config.py` `creds_for`/`has_credentials`/`provider_env` → Task 2 ✓
+- `codex_auth.py` helper → Task 3 ✓
+- `config_screen.py` (hide key/base/fetch, status line) → Task 5 ✓
+- `app.py` context window → Task 6 ✓
+- `doctor.py` + `--doctor` → Task 7 ✓
+- `pyproject.toml` / `uv.lock` hard dep → Task 4 ✓
+- `docs/configuration.md` → Task 9 ✓
+- Tests (providers, config, codex_auth) + smoke → Tasks 1,2,3,7,8 ✓
+- Error handling (auth errors via `classify_error`, never-crash) → covered by Task 3 (helper never raises), Task 4 (guarded registration); `classify_error` already maps auth/validation/unknown — no change needed ✓
+- Out-of-scope items (no OAuth, no shell-out, no CLI flag) → respected; completions untouched ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows full code. The two adaptive notes (handler import name in Task 4 Step 3, `last_assistant_text` in Task 8) give an explicit verification command + fallback rather than a vague "fill in" — they exist because the exact external symbol can vary by installed version.
+
+**Type/name consistency:** `CodexAuthStatus(logged_in, expires_in_s, detail)`, `auth_status()`, `codex_home()`, `_register_codex_provider`, `_set_codex_mode`, `_codex_status_text` are used consistently across Tasks 3/5/7/8. Provider key `"codex"`, prefix `"codex/"`, `list_kind="codex"` consistent across Tasks 1/2/4/6. Model id `codex/gpt-5.5-codex` consistent throughout.

--- a/docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md
+++ b/docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md
@@ -41,29 +41,74 @@ token file** and delegate the endpoint machinery to a maintained litellm custom 
 }
 ```
 
-## Decisions (locked during brainstorming)
+## Decisions (locked during brainstorming + re-decided mid-implementation)
 
 1. **Token source:** reuse `~/.codex/auth.json` written by the official `codex login`.
-   riftor never runs the OAuth flow and never writes this file.
-2. **Inference path:** delegate to the `litellm-codex-oauth-provider` package (the
-   `codex/` custom provider), which reads `~/.codex/auth.json` and bridges
-   Chat Completions → the Codex Responses backend.
+   riftor never runs the OAuth flow and never writes this file (except to persist a
+   refreshed access/refresh token — see below).
+2. **Inference path (REVISED):** the `litellm-codex-oauth-provider` package turned out to
+   be **unpublished on PyPI** (git-only, in active refactor). Rather than depend on an
+   unstable git source, riftor **vendors its own minimal litellm `CustomLLM` handler**
+   (`riftor/agent/codex_provider.py`) that reads `~/.codex/auth.json`, refreshes the token,
+   and bridges Chat Completions ↔ the undocumented Codex **Responses** backend. No
+   third-party Codex package, no forced litellm bump.
 3. **UX:** first-class **Codex (ChatGPT)** provider in the `/config` picker, with a live
    login-status line. riftor does **not** shell out to `codex login` — it points the user
    to run it themselves.
-4. **Dependency:** `litellm-codex-oauth-provider` is a **hard runtime dependency**.
+4. **Dependency:** none added. The handler uses litellm's `CustomLLM` base (already a dep)
+   and the stdlib (`urllib`/`json`/`base64`) for the auth + HTTP calls.
+5. **`instructions` prompt (REVISED):** the Codex backend rejects requests whose
+   `instructions` field isn't the canonical Codex system prompt. riftor **bundles a pinned
+   copy** of the prompt(s) per model family as the default, and **opportunistically
+   refreshes** it from `raw.githubusercontent.com/openai/codex` with a short timeout
+   (ETag-cached); on any network failure it uses the bundled copy. Always works offline,
+   self-heals when online.
+6. **riftor's RIFT prompt:** the canonical Codex prompt goes in `instructions` (satisfies
+   the backend); riftor's RIFT pentest system prompt is injected as a **`developer`-role
+   message** at the top of the Responses `input` array (the opencode "bridge" trick), so
+   riftor keeps its pentest behavior while the backend stays happy.
 
 ## Architecture
 
 riftor exposes Codex as just another litellm model id (`codex/gpt-5.5-codex`). The agent
-loop, streaming, and tool-call handling are unchanged. Two integration points:
+loop, streaming, and tool-call handling are unchanged — riftor still calls
+`litellm.acompletion(...)` and consumes Chat-Completions-shaped deltas. The vendored
+`CustomLLM` handler does the Chat-Completions ↔ Responses translation. Integration points:
 
 - **Registration:** in `_get_litellm()` (`agent/provider.py`), after configuring litellm,
-  set `litellm.custom_provider_map` to register the `codex` handler exactly once. This
-  sits behind the existing lazy-litellm import, so there is no startup penalty, and every
-  caller (TUI, headless, workers) gets Codex registered automatically.
-- **Credentials:** Codex supplies no api_key/api_base from riftor — the custom handler
-  reads `~/.codex/auth.json` itself. `creds_for("codex/…")` returns `(None, None)`.
+  set `litellm.custom_provider_map` to register riftor's own `codex` handler exactly once
+  (guarded so a failure never breaks startup of non-Codex users). This sits behind the
+  existing lazy-litellm import, so there is no startup penalty, and every caller (TUI,
+  headless, workers) gets Codex registered automatically.
+- **Credentials:** Codex supplies no api_key/api_base from riftor — the handler reads
+  `~/.codex/auth.json` itself. `creds_for("codex/…")` returns `(None, None)`.
+
+### Vendored handler (`riftor/agent/codex_provider.py`)
+
+A `litellm.CustomLLM` subclass with the standard four methods (`completion`/`acompletion`/
+`streaming`/`astreaming`). Responsibilities, decomposed into testable units:
+
+- **Auth** (reuses `riftor/codex_auth.py` for status; adds token read + refresh): read
+  `tokens.access_token`/`refresh_token` from `auth.json`; resolve `chatgpt-account-id`
+  (prefer `tokens.account_id`, else decode the access-token JWT `https://api.openai.com/auth`
+  claim); refresh ≤5 min before `exp` via `POST https://auth.openai.com/oauth/token`
+  (`client_id=app_EMoamEEZ73f0CkXaXp7hrann`, `grant_type=refresh_token`, JSON body) and
+  write the new tokens back to `auth.json` (mode `0o600`, atomic replace).
+- **Request build:** map Chat-Completions `messages` → Responses `input` items
+  (system→`instructions`, riftor's RIFT prompt→a `developer` message, assistant
+  `tool_calls`→`function_call`, `tool` role→`function_call_output`); flatten `tools` to the
+  Responses shape; set `store=false`, `stream=true`, `include=["reasoning.encrypted_content"]`,
+  `reasoning={effort,summary:"auto"}`, `text={verbosity}`; strip `max_tokens`/
+  `max_output_tokens`/`max_completion_tokens`/`temperature`.
+- **Instructions prompt:** bundled pinned copy per model family +
+  opportunistic ETag-cached refresh from `openai/codex` (short timeout, offline-safe).
+- **Endpoint + headers:** `POST https://chatgpt.com/backend-api/codex/responses` with
+  `Authorization: Bearer <access_token>`, `chatgpt-account-id`, `OpenAI-Beta:
+  responses=experimental`, `originator: codex_cli_rs`, `Accept: text/event-stream`.
+- **Response parse:** SSE event stream → litellm `GenericStreamingChunk`s
+  (`response.output_text.delta`→text, `response.reasoning_*`→reasoning_content,
+  `response.function_call_arguments.delta`→tool_use, `response.completed`→final+usage);
+  map Responses `input_tokens`/`output_tokens` → `prompt_tokens`/`completion_tokens`.
 
 ## Components
 
@@ -134,7 +179,16 @@ No new dependency: payload decode is `base64` + `json` on the middle JWT segment
 
 ### `pyproject.toml` / `uv.lock`
 
-- Add `litellm-codex-oauth-provider` to runtime dependencies; relock `uv.lock`.
+- **No new dependency.** The vendored handler uses litellm's `CustomLLM` (already a dep)
+  and the stdlib. (Original plan added `litellm-codex-oauth-provider`; dropped because it
+  is unpublished/git-only.)
+
+### `riftor/agent/codex_provider.py` (new) + bundled prompt(s)
+
+- The vendored `CustomLLM` handler described under **Architecture** above.
+- A bundled canonical Codex `instructions` prompt per model family, shipped as package
+  data (e.g. `riftor/agent/prompts/codex/<family>.md`), with an opportunistic ETag-cached
+  refresh from `openai/codex`.
 
 ### `docs/configuration.md`
 
@@ -148,26 +202,31 @@ user selects "Codex (ChatGPT)" in /config, picks codex/gpt-5.5-codex
   → config.model = "codex/gpt-5.5-codex"; no api_key stored
   → first model call → _get_litellm() registers litellm.custom_provider_map (once)
   → Provider._kwargs(): creds_for() → (None, None); no api_key/api_base set
-  → litellm.acompletion(model="codex/...") routes to the codex custom handler
-  → handler reads ~/.codex/auth.json, refreshes if near expiry, calls the
-    Codex Responses backend, bridges the response back to Chat-Completions shape
+  → litellm.acompletion(model="codex/...") routes to riftor's vendored codex handler
+  → handler reads ~/.codex/auth.json, refreshes if near expiry, builds the Responses
+    request (canonical instructions + RIFT developer msg + mapped input/tools), calls the
+    Codex Responses backend, parses the SSE stream back to Chat-Completions-shaped chunks
   → riftor's stream_turn() consumes deltas + tool calls exactly as today
 ```
 
 ## Error handling
 
-- **Not logged in / no `auth.json`:** the model call fails inside the custom handler; the
-  resulting exception flows through `classify_error()` → an `auth`-kind `ProviderError`
-  ("authentication failed…"). `/config` and `--doctor` proactively show the not-logged-in
-  state so the user fixes it before a call. `auth_status()` itself never raises.
-- **Expired token / refresh failure:** handled by the package (proactive refresh ~5 min
-  before expiry); a hard failure surfaces as a classified `ProviderError`.
+- **Not logged in / no `auth.json`:** the handler raises a clear auth error; it flows
+  through `classify_error()` → an `auth`-kind `ProviderError` ("authentication failed…").
+  `/config` and `--doctor` proactively show the not-logged-in state. `auth_status()` itself
+  never raises.
+- **Expired token / refresh failure:** the handler refreshes ≤5 min before `exp`; a
+  permanent refresh failure (`refresh_token_expired`/`reused`/`invalidated`) raises an auth
+  error → classified `ProviderError` telling the user to re-run `codex login`.
 - **Undocumented endpoint breaks (instructions-prompt/header drift):** surfaces as a
-  `validation` or `unknown` `ProviderError` from `classify_error()`. This risk is owned by
-  the package, not riftor; documented as a known caveat.
+  `validation`/`unknown` `ProviderError`. The bundled-prompt + opportunistic-refresh design
+  mitigates prompt drift; documented as a known caveat. This risk now lives in riftor's own
+  handler, so it is ours to maintain — the handler is decomposed into small, individually
+  testable units to keep that maintainable.
 - **Bad config ethos preserved:** missing/malformed `auth.json`, a missing `$CODEX_HOME`,
-  or a failed `custom_provider_map` registration must never crash startup — they degrade to
-  a not-logged-in status, consistent with riftor's load-time degradation everywhere else.
+  a failed prompt fetch, or a failed `custom_provider_map` registration must never crash
+  startup — they degrade (to a not-logged-in status / the bundled prompt / Codex-disabled),
+  consistent with riftor's load-time degradation everywhere else.
 
 ## Testing
 
@@ -186,6 +245,19 @@ Offline-first, matching the existing suite (`RIFTOR_DEMO_RESPONSE`, no network, 
   (b) `auth.json` with a JWT whose `exp` is in the future → `logged_in=True`,
       positive `expires_in_s`;
   (c) malformed JSON / garbage JWT → degrades, never raises.
+- `tests/test_codex_provider.py` (new): the vendored handler's pure units, all offline
+  (monkeypatch the HTTP seam, never hit the network):
+  - account-id resolution (from `tokens.account_id`; fallback decode of the JWT `auth`
+    claim);
+  - request-body build: maps messages → Responses `input`; RIFT system prompt becomes a
+    `developer` message; canonical prompt lands in `instructions`; `store=false`,
+    `stream=true`, `include=["reasoning.encrypted_content"]` present; `max_*`/`temperature`
+    stripped; tools flattened to Responses shape;
+  - SSE parse: a canned event stream → text/reasoning/tool-call chunks + usage mapping
+    (`input_tokens`/`output_tokens` → `prompt_tokens`/`completion_tokens`);
+  - token refresh: monkeypatched token endpoint → new tokens written back to a `tmp_path`
+    `auth.json` (mode `0o600`); proactive-refresh decision honors the ≤5-min window;
+  - instructions prompt: returns the bundled copy when the fetch seam fails (offline path).
 
 **Smoke (`dev/smoke.py`):** add a step that sets the model to `codex/gpt-5.5-codex`, drives
 a turn with `RIFTOR_DEMO_RESPONSE` set, and asserts the loop runs without crashing —
@@ -203,5 +275,8 @@ token refresh. This is the only step exercising the undocumented endpoint; CI st
 - No OAuth/PKCE flow inside riftor (we reuse the official CLI's token file).
 - No `codex login` shell-out or in-riftor login command.
 - No multi-account / token load-balancing.
-- No native Responses-API support in `provider.py` (the package bridges to Chat Completions).
+- The Responses translation lives only in the vendored `codex_provider.py` handler;
+  riftor's shared `provider.py` agent loop stays Chat-Completions-shaped and untouched.
+- No `conversation_id`/`session_id` prompt-cache key (sent only when a stable key exists;
+  riftor omits it for now).
 - No new CLI flag (so bash/zsh completions need no changes).

--- a/docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md
+++ b/docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md
@@ -1,0 +1,207 @@
+# Codex (ChatGPT subscription) login — design
+
+**Date:** 2026-06-08
+**Status:** Approved for planning
+
+## Problem
+
+riftor authenticates to every model provider with an API key (per-provider creds in
+`config.toml`, or an env var). Users who have a ChatGPT Plus/Pro/Team subscription can
+run inference through that subscription instead of paying for API credits — this is how
+OpenAI's official Codex CLI works. We want riftor users to use their Codex/ChatGPT
+subscription from inside riftor.
+
+## How Codex login actually works (background)
+
+OpenAI's Codex CLI does **not** use an API key for subscription users. `codex login`
+performs an OAuth 2.0 + PKCE browser flow against `auth.openai.com` (loopback callback on
+`localhost:1455`) and writes tokens to `~/.codex/auth.json`. Inference then goes to an
+**undocumented** endpoint, `https://chatgpt.com/backend-api/codex/responses`, using the
+**Responses API** shape (not Chat Completions), with special headers
+(`Authorization: Bearer <jwt>`, `chatgpt-account-id`, `originator: codex_cli_rs`,
+`OpenAI-Beta: responses=experimental`), `store=false`, stripped token-limit fields, and a
+server-side check that the request's `instructions` field matches the canonical Codex
+system prompt. Tokens refresh against `auth.openai.com/oauth/token`.
+
+This is meaningfully different from riftor's Chat-Completions-based providers, and the
+endpoint is unstable. Rather than reimplement any of it, we **reuse the official CLI's
+token file** and delegate the endpoint machinery to a maintained litellm custom provider.
+
+`auth.json` structure (relevant fields):
+```jsonc
+{
+  "tokens": {
+    "access_token": "<JWT>",      // Bearer used for inference; exp lives in the JWT
+    "refresh_token": "<...>",
+    "id_token": "<JWT>",          // chatgpt_account_id etc. in the "auth" claim
+    "account_id": "<...>"
+  },
+  "last_refresh": "<RFC3339>",
+  "OPENAI_API_KEY": null
+}
+```
+
+## Decisions (locked during brainstorming)
+
+1. **Token source:** reuse `~/.codex/auth.json` written by the official `codex login`.
+   riftor never runs the OAuth flow and never writes this file.
+2. **Inference path:** delegate to the `litellm-codex-oauth-provider` package (the
+   `codex/` custom provider), which reads `~/.codex/auth.json` and bridges
+   Chat Completions → the Codex Responses backend.
+3. **UX:** first-class **Codex (ChatGPT)** provider in the `/config` picker, with a live
+   login-status line. riftor does **not** shell out to `codex login` — it points the user
+   to run it themselves.
+4. **Dependency:** `litellm-codex-oauth-provider` is a **hard runtime dependency**.
+
+## Architecture
+
+riftor exposes Codex as just another litellm model id (`codex/gpt-5.5-codex`). The agent
+loop, streaming, and tool-call handling are unchanged. Two integration points:
+
+- **Registration:** in `_get_litellm()` (`agent/provider.py`), after configuring litellm,
+  set `litellm.custom_provider_map` to register the `codex` handler exactly once. This
+  sits behind the existing lazy-litellm import, so there is no startup penalty, and every
+  caller (TUI, headless, workers) gets Codex registered automatically.
+- **Credentials:** Codex supplies no api_key/api_base from riftor — the custom handler
+  reads `~/.codex/auth.json` itself. `creds_for("codex/…")` returns `(None, None)`.
+
+## Components
+
+### `riftor/providers.py`
+
+- Add to `PROVIDERS`:
+  ```python
+  "codex": ProviderMeta("codex", "Codex (ChatGPT)", "codex/", None, "codex", None),
+  ```
+  `env=None`, `list_kind="codex"` (new kind), `default_base=None`.
+- Add `PROVIDER_DEFAULTS["codex"]`: curated bare ids
+  (`["gpt-5.5-codex", "gpt-5.5", "gpt-5.4-codex"]` — exact ids verified against the package
+  at build time).
+- `fetch_models`: `list_kind == "codex"` returns the curated list only (`source="curated"`),
+  never touching the network — the Codex backend exposes no public `/models` list.
+- `apply_prefix("codex", id)`: existing logic already prepends `codex/` to bare ids and
+  passes through already-prefixed ids; works unchanged.
+
+### `riftor/config.py`
+
+- `creds_for(model)`: add an explicit early return for the `codex` provider key →
+  `(None, None)`, so a stale global `api_key` is never forwarded to the Codex handler.
+- `has_credentials()`: treat `codex/` like Ollama — return `True` based on provider type
+  (don't block the UI on it). Real login validity is surfaced as status, not a hard gate.
+- `provider_env()`: returns `None` for Codex (already handled by the `meta.env` check).
+
+### `riftor/codex_auth.py` (new)
+
+Read-only helper; never writes `auth.json`, never raises.
+
+```python
+def codex_home() -> Path            # $CODEX_HOME or ~/.codex
+def auth_status() -> CodexAuthStatus
+```
+
+`CodexAuthStatus` dataclass: `logged_in: bool`, `expires_in_s: int | None`, `detail: str`.
+
+Logic:
+- File missing → `logged_in=False`, `detail="run `codex login`"`.
+- Present → parse `tokens.access_token` as a JWT, base64-decode the **payload** segment
+  (no signature verification — display only), read `exp` → `expires_in_s`.
+- Decode/parse failure → `logged_in=True`, `expires_in_s=None`, `detail="token present"`.
+
+No new dependency: payload decode is `base64` + `json` on the middle JWT segment.
+
+### `riftor/tui/config_screen.py`
+
+- When the selected provider is `codex` (`on_select_changed`, `cfg-provider` branch):
+  hide the `#cfg-key` (API key) and `#cfg-base` (Base URL) rows and the `#cfg-fetch`
+  button (toggle a `hidden` class, the pattern `show_section` already uses), and show a
+  dedicated `#cfg-codex-status` Label populated from `codex_auth.auth_status()`
+  (e.g. `✓ ChatGPT login active (expires in 42m)` or `⚠ not logged in — run \`codex login\``).
+  Restore those rows when switching to a non-Codex provider.
+- Model dropdown is populated from `PROVIDER_DEFAULTS["codex"]` like any other provider;
+  the custom-id Input still works.
+- Save path (`on_button_pressed`): unchanged in shape — `apply_prefix("codex", chosen)`
+  builds the id; no `api_key`/`api_base` are written for Codex.
+
+### `riftor/tui/app.py`
+
+- Add Codex to the per-provider context-window estimate → 128k (matches the OpenAI/GPT-5
+  default). Stage, scope, findings, yolo display unchanged.
+
+### `riftor/engagement/doctor.py` + `--doctor`
+
+- Add a Codex line to the doctor report: whether `~/.codex/auth.json` is present and its
+  login status (reusing `codex_auth.auth_status()`).
+
+### `pyproject.toml` / `uv.lock`
+
+- Add `litellm-codex-oauth-provider` to runtime dependencies; relock `uv.lock`.
+
+### `docs/configuration.md`
+
+- Add a "Codex / ChatGPT subscription login" section: the `codex login` prerequisite,
+  the `codex/<model>` id format, and that billing goes to the ChatGPT subscription.
+
+## Data flow
+
+```
+user selects "Codex (ChatGPT)" in /config, picks codex/gpt-5.5-codex
+  → config.model = "codex/gpt-5.5-codex"; no api_key stored
+  → first model call → _get_litellm() registers litellm.custom_provider_map (once)
+  → Provider._kwargs(): creds_for() → (None, None); no api_key/api_base set
+  → litellm.acompletion(model="codex/...") routes to the codex custom handler
+  → handler reads ~/.codex/auth.json, refreshes if near expiry, calls the
+    Codex Responses backend, bridges the response back to Chat-Completions shape
+  → riftor's stream_turn() consumes deltas + tool calls exactly as today
+```
+
+## Error handling
+
+- **Not logged in / no `auth.json`:** the model call fails inside the custom handler; the
+  resulting exception flows through `classify_error()` → an `auth`-kind `ProviderError`
+  ("authentication failed…"). `/config` and `--doctor` proactively show the not-logged-in
+  state so the user fixes it before a call. `auth_status()` itself never raises.
+- **Expired token / refresh failure:** handled by the package (proactive refresh ~5 min
+  before expiry); a hard failure surfaces as a classified `ProviderError`.
+- **Undocumented endpoint breaks (instructions-prompt/header drift):** surfaces as a
+  `validation` or `unknown` `ProviderError` from `classify_error()`. This risk is owned by
+  the package, not riftor; documented as a known caveat.
+- **Bad config ethos preserved:** missing/malformed `auth.json`, a missing `$CODEX_HOME`,
+  or a failed `custom_provider_map` registration must never crash startup — they degrade to
+  a not-logged-in status, consistent with riftor's load-time degradation everywhere else.
+
+## Testing
+
+Offline-first, matching the existing suite (`RIFTOR_DEMO_RESPONSE`, no network, no real
+`~/.codex`).
+
+**Unit:**
+- `tests/test_providers.py` (extend): `codex` in `PROVIDERS`;
+  `provider_key_for_model("codex/gpt-5.5-codex") == "codex"`;
+  `apply_prefix("codex", "gpt-5.5-codex") == "codex/gpt-5.5-codex"` + pass-through for
+  already-prefixed ids; `fetch_models("codex", …)` returns curated only, no network.
+- `tests/test_config.py` (extend): `creds_for("codex/…") == (None, None)`;
+  `has_credentials()` is `True` for a `codex/` model; `provider_env()` is `None` for Codex.
+- `tests/test_codex_auth.py` (new): with `CODEX_HOME` pointed at `tmp_path` —
+  (a) missing file → `logged_in=False`;
+  (b) `auth.json` with a JWT whose `exp` is in the future → `logged_in=True`,
+      positive `expires_in_s`;
+  (c) malformed JSON / garbage JWT → degrades, never raises.
+
+**Smoke (`dev/smoke.py`):** add a step that sets the model to `codex/gpt-5.5-codex`, drives
+a turn with `RIFTOR_DEMO_RESPONSE` set, and asserts the loop runs without crashing —
+proving `custom_provider_map` registration is harmless when mocked and does not require the
+token file to exist.
+
+**Manual (documented, not in CI):** with a real `codex login`, run
+`uv run riftor --model codex/gpt-5.5-codex -p "say hi"` and confirm a live response and a
+token refresh. This is the only step exercising the undocumented endpoint; CI stays offline.
+
+**CI gates unchanged:** `make check` (ruff → pyright → pytest → smoke) stays green.
+
+## Out of scope / YAGNI
+
+- No OAuth/PKCE flow inside riftor (we reuse the official CLI's token file).
+- No `codex login` shell-out or in-riftor login command.
+- No multi-account / token load-balancing.
+- No native Responses-API support in `provider.py` (the package bridges to Chat Completions).
+- No new CLI flag (so bash/zsh completions need no changes).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.8.0"
+version = "0.9.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -18,6 +18,7 @@ import os
 import time
 import urllib.error
 import urllib.request
+from importlib import resources
 from pathlib import Path
 
 from riftor.codex_auth import _jwt_claims, _jwt_exp, codex_home
@@ -186,3 +187,101 @@ def refresh_tokens() -> str:
     )
     _write_auth_secure(data)
     return new_access
+
+
+# --- instructions prompt (Task 4b) -----------------------------------------
+#
+# The Codex backend rejects requests whose ``instructions`` field isn't the
+# canonical Codex system prompt, so the handler must supply it. We BUNDLE a
+# pinned copy (``prompts/codex/default.md``) and *opportunistically* refresh it
+# from GitHub with a short timeout, falling back to the bundle on any failure.
+#
+# v1 scope cut (deliberate): the refreshed prompt is cached in-process for the
+# lifetime of the process only — there is NO disk / ETag cache. A long-running
+# process picks up an upstream prompt change on its next fresh start, which is
+# good enough for now.
+
+# Bundled prompt resource (loaded via importlib.resources, mirroring how
+# ``context.py`` loads ``prompts/system.md``).
+_BUNDLED_INSTRUCTIONS_RESOURCE = "prompts/codex/default.md"
+
+# Remote source: the canonical Codex prompt in the openai/codex repo. Fetched
+# opportunistically; any failure degrades to the bundled copy.
+_REMOTE_INSTRUCTIONS_URLS = {
+    "codex": (
+        "https://raw.githubusercontent.com/openai/codex/main/"
+        "codex-rs/core/gpt_5_codex_prompt.md"
+    ),
+}
+_REMOTE_FETCH_TIMEOUT_S = 3.0
+
+# Process-level cache keyed by family (no disk cache — see scope note above).
+_INSTRUCTIONS_CACHE: dict[str, str] = {}
+
+
+def _bundled_instructions() -> str:
+    """Return the pinned, bundled Codex instructions prompt.
+
+    Loaded as package data via ``importlib.resources`` (same mechanism as
+    ``context._load_system_prompt``), so it works from an installed wheel.
+    """
+    return (
+        resources.files("riftor.agent")
+        .joinpath(_BUNDLED_INSTRUCTIONS_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+
+
+def _model_family(model: str) -> str:
+    """Map a model id to a prompt family.
+
+    For v1 everything maps to the single bundled "codex" family; this helper
+    exists so future families (e.g. distinct prompts per model) are a one-line
+    change here rather than threaded through the call sites.
+    """
+    return "codex"
+
+
+def _fetch_remote_instructions(family: str) -> str | None:
+    """Fetch the latest instructions prompt for ``family`` from GitHub.
+
+    This is the SINGLE network seam — tests monkeypatch *this*, never the
+    network. Uses a short timeout and returns ``None`` on any failure; it never
+    raises.
+    """
+    url = _REMOTE_INSTRUCTIONS_URLS.get(family)
+    if not url:
+        return None
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(  # noqa: S310 — fixed https raw.githubusercontent URL
+            req, timeout=_REMOTE_FETCH_TIMEOUT_S
+        ) as resp:
+            text = resp.read().decode("utf-8")
+        return text or None
+    except Exception:  # noqa: BLE001 — opportunistic refresh; any failure falls back to the bundle
+        return None
+
+
+def instructions_for(model: str) -> str:
+    """Return the Codex ``instructions`` prompt for ``model``.
+
+    Never raises and always returns a non-empty string. Tries the (cached)
+    opportunistic remote fetch first, then falls back to the bundled copy.
+    """
+    family = _model_family(model)
+    cached = _INSTRUCTIONS_CACHE.get(family)
+    if cached:
+        return cached
+
+    try:
+        remote = _fetch_remote_instructions(family)
+    except Exception:  # noqa: BLE001 — a misbehaving seam must still degrade to the bundle
+        remote = None
+    if isinstance(remote, str) and remote:
+        _INSTRUCTIONS_CACHE[family] = remote
+        return remote
+
+    bundled = _bundled_instructions()
+    _INSTRUCTIONS_CACHE[family] = bundled
+    return bundled

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -1,0 +1,188 @@
+"""Auth section of the vendored Codex/ChatGPT-backend handler (Task 4a).
+
+riftor talks to OpenAI's undocumented Codex/ChatGPT backend by reusing the token
+file written by the official ``codex login`` (``~/.codex/auth.json``). Unlike the
+read-only status peek in :mod:`riftor.codex_auth`, this module also *refreshes*
+the access token and writes it back — securely (0o600, tmp-file + os.replace).
+
+This file covers ONLY token read, account-id resolution, and refresh. Request
+building, SSE parsing, and the litellm ``CustomLLM`` class land in later
+sub-tasks; the public names here are what those depend on.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as _dt
+import json
+import os
+import time
+import urllib.request
+from pathlib import Path
+
+from riftor.codex_auth import _jwt_exp, codex_home
+
+# --- wire-protocol constants (undocumented endpoint — do not guess) ---------
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+AUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+_REFRESH_WINDOW_S = 300  # refresh when exp is within 5 minutes (or past)
+
+
+def _http_post_json(url: str, body: dict, timeout: float = 30.0) -> dict:
+    """POST ``body`` as JSON to ``url`` and return the parsed JSON response.
+
+    This is the single network seam in the module — tests monkeypatch *this*,
+    never the network itself.
+    """
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed https endpoint
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _auth_file() -> Path:
+    return codex_home() / "auth.json"
+
+
+def _read_auth() -> dict:
+    """Parse auth.json into a dict, or raise the upstream-mappable auth error."""
+    path = _auth_file()
+    if not path.exists():
+        raise RuntimeError("not logged in — run `codex login`")
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # noqa: BLE001 — a bad token file maps to an auth error, not a crash
+        raise RuntimeError("not logged in — run `codex login`") from exc
+
+
+def read_tokens() -> tuple[str, str]:
+    """Return ``(access_token, refresh_token)`` from auth.json.
+
+    Raises ``RuntimeError`` (so upstream ``classify_error`` maps it to an auth
+    error) when the file is missing or the tokens are absent.
+    """
+    data = _read_auth()
+    tokens = data.get("tokens") or {}
+    access = tokens.get("access_token")
+    refresh = tokens.get("refresh_token")
+    if not access or not refresh:
+        raise RuntimeError("not logged in — run `codex login`")
+    return access, refresh
+
+
+def _decode_jwt_payload(token: str) -> dict | None:
+    """Decode a JWT payload (URL-safe base64, padded). None if unparseable."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)  # restore base64 padding
+    try:
+        raw = base64.urlsafe_b64decode(payload.encode("ascii"))
+        claims = json.loads(raw)
+    except Exception:  # noqa: BLE001 — an unparseable JWT just means "unresolvable", never crash
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def account_id() -> str | None:
+    """The ChatGPT account id, or None if it cannot be resolved (never raises).
+
+    Prefers ``tokens.account_id`` when present and non-empty; otherwise decodes
+    it from the access-token JWT (``https://api.openai.com/auth`` ->
+    ``chatgpt_account_id``).
+    """
+    try:
+        data = _read_auth()
+    except RuntimeError:
+        return None
+    tokens = data.get("tokens") or {}
+    acc = tokens.get("account_id")
+    if isinstance(acc, str) and acc:
+        return acc
+    access = tokens.get("access_token")
+    if not isinstance(access, str) or not access:
+        return None
+    claims = _decode_jwt_payload(access)
+    if not claims:
+        return None
+    auth = claims.get("https://api.openai.com/auth")
+    if isinstance(auth, dict):
+        chatgpt = auth.get("chatgpt_account_id")
+        if isinstance(chatgpt, str) and chatgpt:
+            return chatgpt
+    return None
+
+
+def should_refresh(access_token: str) -> bool:
+    """True if the token has no readable ``exp`` or expires within the window."""
+    try:
+        exp = _jwt_exp(access_token)
+    except Exception:  # noqa: BLE001 — unparseable token => refresh to be safe
+        return True
+    if exp is None:
+        return True
+    return exp - time.time() <= _REFRESH_WINDOW_S
+
+
+def _write_auth_secure(data: dict) -> None:
+    """Write auth.json atomically with owner-only perms (tmp-file + os.replace)."""
+    path = _auth_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+    finally:
+        os.close(fd)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def refresh_tokens() -> str:
+    """Refresh the access token via the OAuth endpoint and persist it.
+
+    Reads the current refresh_token, POSTs to :data:`AUTH_TOKEN_URL`, writes the
+    new ``access_token``/``refresh_token``/``id_token`` back into auth.json
+    (falling back to the old values when a field is absent), updates
+    ``last_refresh``, and returns the new access token. Raises ``RuntimeError``
+    if the response has no ``access_token``.
+    """
+    data = _read_auth()
+    tokens = dict(data.get("tokens") or {})
+    refresh = tokens.get("refresh_token")
+    if not refresh:
+        raise RuntimeError("not logged in — run `codex login`")
+
+    resp = _http_post_json(
+        AUTH_TOKEN_URL,
+        {
+            "client_id": CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+        },
+    )
+
+    new_access = resp.get("access_token")
+    if not new_access:
+        raise RuntimeError("token refresh failed — no access_token in response")
+
+    tokens["access_token"] = new_access
+    tokens["refresh_token"] = resp.get("refresh_token") or tokens.get("refresh_token")
+    if resp.get("id_token"):
+        tokens["id_token"] = resp["id_token"]
+
+    data["tokens"] = tokens
+    data["last_refresh"] = (
+        _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    _write_auth_secure(data)
+    return new_access

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -12,15 +12,15 @@ sub-tasks; the public names here are what those depend on.
 
 from __future__ import annotations
 
-import base64
 import datetime as _dt
 import json
 import os
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
-from riftor.codex_auth import _jwt_exp, codex_home
+from riftor.codex_auth import _jwt_claims, _jwt_exp, codex_home
 
 # --- wire-protocol constants (undocumented endpoint — do not guess) ---------
 CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -75,21 +75,6 @@ def read_tokens() -> tuple[str, str]:
     return access, refresh
 
 
-def _decode_jwt_payload(token: str) -> dict | None:
-    """Decode a JWT payload (URL-safe base64, padded). None if unparseable."""
-    parts = token.split(".")
-    if len(parts) < 2:
-        return None
-    payload = parts[1]
-    payload += "=" * (-len(payload) % 4)  # restore base64 padding
-    try:
-        raw = base64.urlsafe_b64decode(payload.encode("ascii"))
-        claims = json.loads(raw)
-    except Exception:  # noqa: BLE001 — an unparseable JWT just means "unresolvable", never crash
-        return None
-    return claims if isinstance(claims, dict) else None
-
-
 def account_id() -> str | None:
     """The ChatGPT account id, or None if it cannot be resolved (never raises).
 
@@ -108,7 +93,10 @@ def account_id() -> str | None:
     access = tokens.get("access_token")
     if not isinstance(access, str) or not access:
         return None
-    claims = _decode_jwt_payload(access)
+    try:
+        claims = _jwt_claims(access)
+    except Exception:  # noqa: BLE001 — an unparseable JWT just means "unresolvable", never crash
+        return None
     if not claims:
         return None
     auth = claims.get("https://api.openai.com/auth")
@@ -137,14 +125,21 @@ def _write_auth_secure(data: dict) -> None:
     tmp = path.with_name(path.name + ".tmp")
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
-    finally:
-        os.close(fd)
-    try:
-        os.chmod(tmp, 0o600)
-    except OSError:
-        pass
-    os.replace(tmp, path)
+        try:
+            os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+        finally:
+            os.close(fd)
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001 — re-raised after cleanup; just removes the stale tmp first
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def refresh_tokens() -> str:
@@ -162,14 +157,19 @@ def refresh_tokens() -> str:
     if not refresh:
         raise RuntimeError("not logged in — run `codex login`")
 
-    resp = _http_post_json(
-        AUTH_TOKEN_URL,
-        {
-            "client_id": CLIENT_ID,
-            "grant_type": "refresh_token",
-            "refresh_token": refresh,
-        },
-    )
+    try:
+        resp = _http_post_json(
+            AUTH_TOKEN_URL,
+            {
+                "client_id": CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": refresh,
+            },
+        )
+    except (urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+        # A revoked/expired refresh token (HTTPError, a URLError subclass) or a
+        # non-JSON body becomes a clean auth error telling the user to re-login.
+        raise RuntimeError("token refresh failed — run `codex login`") from exc
 
     new_access = resp.get("access_token")
     if not new_access:

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -266,8 +266,9 @@ def _fetch_remote_instructions(family: str) -> str | None:
 def instructions_for(model: str) -> str:
     """Return the Codex ``instructions`` prompt for ``model``.
 
-    Never raises and always returns a non-empty string. Tries the (cached)
-    opportunistic remote fetch first, then falls back to the bundled copy.
+    Never raises on network/remote failure; always returns a non-empty string.
+    Tries the (cached) opportunistic remote fetch first, then falls back to the
+    bundled copy.
     """
     family = _model_family(model)
     cached = _INSTRUCTIONS_CACHE.get(family)
@@ -285,3 +286,149 @@ def instructions_for(model: str) -> str:
     bundled = _bundled_instructions()
     _INSTRUCTIONS_CACHE[family] = bundled
     return bundled
+
+
+# --- Responses request-body builder (Task 4c) ------------------------------
+#
+# Pure data transformation: Chat-Completions ``messages`` + ``tools`` -> the
+# undocumented Codex *Responses API* request body. No network, no I/O. See the
+# CLAUDE.md/task spec for the authoritative mapping.
+
+
+def _extract_text(content: object) -> str:
+    """Coerce a Chat-Completions ``content`` value into plain text.
+
+    ``content`` may be a string, ``None``, or a list of parts. For a list we
+    concatenate the text of ``{"type": "text"|"input_text", "text": ...}`` parts
+    (joined with ""), ignoring non-text parts. Anything else stringifies to "".
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in ("text", "input_text"):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _message_item(role: str, text: str) -> dict:
+    """A Responses ``message`` input item wrapping ``text`` for ``role``."""
+    return {
+        "type": "message",
+        "role": role,
+        "content": [{"type": "input_text", "text": text}],
+    }
+
+
+def _map_message(msg: dict) -> list[dict]:
+    """Map one Chat-Completions message to zero or more Responses input items.
+
+    System messages are handled by the caller (collected into a single leading
+    ``developer`` item), so they yield nothing here.
+    """
+    role = msg.get("role")
+    if role == "system":
+        return []  # handled by build_request_body as a leading developer item
+    if role == "tool":
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": msg.get("tool_call_id"),
+                "output": _extract_text(msg.get("content")),
+            }
+        ]
+    if role == "assistant":
+        items: list[dict] = []
+        text = _extract_text(msg.get("content"))
+        if text:
+            items.append(_message_item("assistant", text))
+        for call in msg.get("tool_calls") or []:
+            fn = call.get("function") or {}
+            items.append(
+                {
+                    "type": "function_call",
+                    "name": fn.get("name"),
+                    "arguments": fn.get("arguments"),
+                    "call_id": call.get("id"),
+                }
+            )
+        return items
+    # Default: a plain user (or other) message.
+    text = _extract_text(msg.get("content"))
+    if not text:
+        return []
+    return [_message_item("user" if role is None else role, text)]
+
+
+def _map_tool(tool: dict) -> dict:
+    """Flatten a Chat-Completions function tool to the Responses tool shape."""
+    fn = tool.get("function") or {}
+    out: dict = {
+        "type": "function",
+        "name": fn.get("name"),
+        "description": fn.get("description"),
+        "parameters": fn.get("parameters"),
+    }
+    if "strict" in fn:
+        out["strict"] = fn["strict"]
+    return out
+
+
+def build_request_body(
+    model: str,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    *,
+    instructions: str,
+    reasoning_effort: str = "medium",
+    verbosity: str = "medium",
+) -> dict:
+    """Build the Codex *Responses API* request body from Chat-Completions inputs.
+
+    Pure function — no network, no I/O. ``model`` is passed through as-is (the
+    caller has already stripped any provider prefix). ``instructions`` is the
+    canonical Codex system prompt and is placed verbatim in the top-level
+    ``instructions`` field (riftor's own RIFT system message is NOT placed there;
+    it rides along as a leading ``developer`` item in ``input`` instead).
+
+    Sampling/length params (``max_tokens``, ``max_output_tokens``,
+    ``max_completion_tokens``, ``temperature``, ``top_p``) are never emitted.
+    """
+    input_items: list[dict] = []
+
+    # riftor's RIFT system prompt(s) become a single leading developer item.
+    system_texts = [
+        _extract_text(m.get("content"))
+        for m in messages
+        if m.get("role") == "system"
+    ]
+    system_texts = [t for t in system_texts if t]
+    if system_texts:
+        input_items.append(_message_item("developer", "\n\n".join(system_texts)))
+
+    for msg in messages:
+        input_items.extend(_map_message(msg))
+
+    body: dict = {
+        "model": model,
+        "input": input_items,
+        "instructions": instructions,
+        "store": False,
+        "stream": True,
+        "include": ["reasoning.encrypted_content"],
+        "reasoning": {"effort": reasoning_effort, "summary": "auto"},
+        "text": {"verbosity": verbosity},
+    }
+
+    if tools:
+        body["tools"] = [_map_tool(t) for t in tools]
+
+    return body

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -18,6 +18,8 @@ import os
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
@@ -432,3 +434,174 @@ def build_request_body(
         body["tools"] = [_map_tool(t) for t in tools]
 
     return body
+
+
+# --- SSE response parser (Task 4d) -----------------------------------------
+#
+# Pure logic over already-decoded event dicts (and over raw SSE text lines).
+# No network — 4e feeds these from the live HTTP response. We translate the
+# undocumented Codex *Responses API* event stream into a litellm-agnostic
+# ``CodexChunk`` representation that 4e maps onto litellm's streaming chunks.
+
+_DONE_SENTINEL = "[DONE]"
+
+
+@dataclass
+class CodexChunk:
+    """A single streamed unit, litellm-agnostic.
+
+    ``tool_call`` (when set) has the shape
+    ``{"id", "name", "arguments_delta"}`` for a streaming arguments fragment.
+    The final chunk of a stream sets ``is_finished`` with a ``finish_reason``
+    and ``usage`` (``{"prompt_tokens", "completion_tokens", "total_tokens"}``).
+    """
+
+    text: str = ""
+    reasoning: str = ""
+    tool_call: dict | None = None
+    is_finished: bool = False
+    finish_reason: str | None = None
+    usage: dict | None = None
+
+
+def _usage_from_response(response: dict) -> dict:
+    """Map a Responses ``usage`` block to Chat-Completions usage shape.
+
+    ``input_tokens`` -> prompt_tokens, ``output_tokens`` -> completion_tokens,
+    ``total_tokens`` passed through (computed from the other two when absent).
+    Tolerant of a missing/odd ``usage`` via ``.get`` — never raises.
+    """
+    usage = response.get("usage") or {}
+    prompt = usage.get("input_tokens") or 0
+    completion = usage.get("output_tokens") or 0
+    total = usage.get("total_tokens")
+    if total is None:
+        total = prompt + completion
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    }
+
+
+def parse_events(events: Iterable[dict]) -> Iterator[CodexChunk]:
+    """Translate decoded Codex Responses-API events into ``CodexChunk``s.
+
+    Pure generator. Tracks function-call name/call_id announced on
+    ``response.output_item.added`` (keyed by item id) so later
+    ``function_call_arguments.delta`` fragments can be associated, and remembers
+    whether any function call was seen so the terminal chunk's ``finish_reason``
+    is ``"tool_calls"`` vs ``"stop"``. Yields exactly one final chunk on
+    ``response.completed``/``response.done``. Never raises on a missing or odd
+    field — every access uses ``.get``.
+    """
+    # item id -> {"id": call_id, "name": name}
+    call_meta: dict[str, dict] = {}
+    saw_function_call = False
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+
+        if etype == "response.output_text.delta":
+            yield CodexChunk(text=event.get("delta") or "")
+
+        elif etype in (
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ):
+            yield CodexChunk(reasoning=event.get("delta") or "")
+
+        elif etype == "response.output_item.added":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call":
+                # The added event's own id keys the deltas; deltas reference it
+                # via ``item_id``. The call_id (preferred) or that id identifies
+                # the call to the rest of the system.
+                item_id = item.get("id")
+                call_id = item.get("call_id") or item_id
+                if item_id is not None:
+                    call_meta[item_id] = {"id": call_id, "name": item.get("name")}
+
+        elif etype == "response.function_call_arguments.delta":
+            saw_function_call = True
+            ref = event.get("item_id") or event.get("call_id")
+            meta = call_meta.get(ref) if ref is not None else None
+            # Fall back to the referencing id as the call id when no added event
+            # supplied name/call_id; name stays None to be filled from output.
+            call_id = meta["id"] if meta else ref
+            name = meta["name"] if meta else None
+            yield CodexChunk(
+                tool_call={
+                    "id": call_id,
+                    "name": name,
+                    "arguments_delta": event.get("delta") or "",
+                }
+            )
+
+        elif etype in ("response.completed", "response.done"):
+            response = event.get("response") or {}
+            output = response.get("output") or []
+            output_has_call = any(
+                isinstance(item, dict) and item.get("type") == "function_call"
+                for item in output
+            )
+            finish_reason = (
+                "tool_calls" if (saw_function_call or output_has_call) else "stop"
+            )
+            yield CodexChunk(
+                is_finished=True,
+                finish_reason=finish_reason,
+                usage=_usage_from_response(response),
+            )
+            return
+
+        # Unknown event types yield nothing.
+
+
+def iter_sse_lines(lines: Iterable[str]) -> Iterator[dict]:
+    """Turn decoded SSE text lines into event dicts.
+
+    Accumulates ``data:`` payload lines until a blank line, ``json.loads`` the
+    joined payload, and yields the dict. ``data: [DONE]`` is a terminal sentinel
+    (stop). ``event:``/``id:``/comment (``:``) lines are ignored for the dict
+    payload — the ``type`` lives inside the JSON. Blank-data frames are skipped.
+    A single malformed data frame is skipped, never raised.
+    """
+    data_parts: list[str] = []
+
+    def _flush() -> Iterator[dict]:
+        nonlocal data_parts
+        if not data_parts:
+            return
+        payload = "\n".join(data_parts)
+        data_parts = []
+        if not payload.strip():
+            return
+        try:
+            obj = json.loads(payload)
+        except Exception:  # noqa: BLE001 — one bad data frame is skipped, never crashes the stream
+            return
+        if isinstance(obj, dict):
+            yield obj
+
+    for raw in lines:
+        line = raw.rstrip("\n").rstrip("\r")
+        if line == "":
+            # End of an event: flush the accumulated data payload.
+            yield from _flush()
+            continue
+        if line.startswith(":"):
+            continue  # SSE comment
+        if line.startswith("data:"):
+            value = line[len("data:") :]
+            if value.startswith(" "):
+                value = value[1:]
+            if value == _DONE_SENTINEL:
+                return  # terminal sentinel — stop
+            data_parts.append(value)
+        # event:/id:/other field lines carry no JSON payload — ignore.
+
+    # Flush any trailing event not terminated by a blank line.
+    yield from _flush()

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -455,7 +455,9 @@ class CodexChunk:
     """A single streamed unit, litellm-agnostic.
 
     ``tool_call`` (when set) has the shape
-    ``{"id", "name", "arguments_delta"}`` for a streaming arguments fragment.
+    ``{"id", "name", "arguments_delta", "index"}`` for a streaming arguments
+    fragment, where ``index`` is a stable 0-based index assigned per distinct
+    call in first-seen order (so parallel calls reassemble independently).
     The final chunk of a stream sets ``is_finished`` with a ``finish_reason``
     and ``usage`` (``{"prompt_tokens", "completion_tokens", "total_tokens"}``).
     """
@@ -499,9 +501,24 @@ def parse_events(events: Iterable[dict]) -> Iterator[CodexChunk]:
     ``response.completed``/``response.done``. Never raises on a missing or odd
     field — every access uses ``.get``.
     """
-    # item id -> {"id": call_id, "name": name}
+    # item id -> {"id": call_id, "name": name, "index": int}
     call_meta: dict[str, dict] = {}
     saw_function_call = False
+    next_index = 0
+
+    def _index_for(ref: str) -> int:
+        # Allocate a stable 0-based index per distinct call, in first-seen order.
+        nonlocal next_index
+        meta = call_meta.get(ref)
+        if meta is not None and "index" in meta:
+            return meta["index"]
+        idx = next_index
+        next_index += 1
+        if meta is None:
+            meta = {"id": ref, "name": None}
+            call_meta[ref] = meta
+        meta["index"] = idx
+        return idx
 
     for event in events:
         if not isinstance(event, dict):
@@ -527,6 +544,8 @@ def parse_events(events: Iterable[dict]) -> Iterator[CodexChunk]:
                 call_id = item.get("call_id") or item_id
                 if item_id is not None:
                     call_meta[item_id] = {"id": call_id, "name": item.get("name")}
+                    # Allocate the stable streaming index on first sight.
+                    _index_for(item_id)
 
         elif etype == "response.function_call_arguments.delta":
             saw_function_call = True
@@ -536,11 +555,15 @@ def parse_events(events: Iterable[dict]) -> Iterator[CodexChunk]:
             # supplied name/call_id; name stays None to be filled from output.
             call_id = meta["id"] if meta else ref
             name = meta["name"] if meta else None
+            # Allocate (or reuse) the stable per-call streaming index. Deltas for
+            # the same call share an index; a new call gets the next one.
+            index = _index_for(ref) if ref is not None else 0
             yield CodexChunk(
                 tool_call={
                     "id": call_id,
                     "name": name,
                     "arguments_delta": event.get("delta") or "",
+                    "index": index,
                 }
             )
 
@@ -622,10 +645,6 @@ def iter_sse_lines(lines: Iterable[str]) -> Iterator[dict]:
 
 # Undocumented Codex/ChatGPT-backend Responses endpoint (POST).
 RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
-
-# The arguments fragments of a single Codex function call all carry one stable
-# tool_use index so the consumer (provider.stream_turn) reassembles one call.
-_TOOL_USE_INDEX = 0
 
 
 def _litellm_types() -> Any:
@@ -720,7 +739,7 @@ def _chunk_to_streaming(chunk: CodexChunk) -> dict:
         tool_use = {
             "id": chunk.tool_call.get("id"),
             "type": "function",
-            "index": _TOOL_USE_INDEX,
+            "index": chunk.tool_call.get("index", 0),
             "function": {
                 "name": chunk.tool_call.get("name"),
                 "arguments": chunk.tool_call.get("arguments_delta") or "",

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -720,10 +720,36 @@ def _stream_responses(
             yield raw.decode("utf-8", errors="replace")
 
 
-def _bare_model(model: str) -> str:
-    """Strip a leading ``codex/`` provider prefix if present."""
+# litellm registry-matches the bare model name and will hijack any id it knows
+# (gpt-5.5, gpt-5.3-codex, ...) to its built-in OpenAI provider, bypassing this
+# custom handler. We prefix the bare name with an opaque marker so litellm cannot
+# match it and routes to us; the handler strips the marker before calling the API.
+_ROUTE_MARKER = "riftorcodex-"
+
+
+def to_litellm_model(model: str) -> str:
+    """Map a user/config codex model id to the id we hand to litellm.
+
+    `codex/gpt-5.5` -> `codex/riftorcodex-gpt-5.5` (registry-opaque, routes to us).
+    Non-codex ids pass through unchanged. Idempotent.
+    """
     prefix = "codex/"
-    return model[len(prefix) :] if model.startswith(prefix) else model
+    if not model.startswith(prefix):
+        return model
+    bare = model[len(prefix):]
+    if bare.startswith(_ROUTE_MARKER):
+        return model
+    return f"{prefix}{_ROUTE_MARKER}{bare}"
+
+
+def _bare_model(model: str) -> str:
+    """Strip the `codex/` prefix AND the internal route marker, yielding the real
+    model id to send to the Codex backend."""
+    prefix = "codex/"
+    bare = model[len(prefix):] if model.startswith(prefix) else model
+    if bare.startswith(_ROUTE_MARKER):
+        bare = bare[len(_ROUTE_MARKER):]
+    return bare
 
 
 def _chunk_to_streaming(chunk: CodexChunk) -> dict:

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -22,8 +22,12 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from riftor.codex_auth import _jwt_claims, _jwt_exp, codex_home
+
+if TYPE_CHECKING:
+    from litellm import ModelResponse
 
 # --- wire-protocol constants (undocumented endpoint — do not guess) ---------
 CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -605,3 +609,293 @@ def iter_sse_lines(lines: Iterable[str]) -> Iterator[dict]:
 
     # Flush any trailing event not terminated by a blank line.
     yield from _flush()
+
+
+# --- live HTTP handler / litellm CustomLLM (Task 4e) -----------------------
+#
+# Wires the auth (4a), prompt (4b), request builder (4c), and SSE parser (4d)
+# to the live, undocumented Codex *Responses API* endpoint, exposed as a
+# litellm ``CustomLLM`` plus a module-level singleton. ``_stream_responses`` is
+# the SINGLE inference network seam — tests monkeypatch *that*, never the
+# socket. The translation helpers below stay small and litellm-isolated so the
+# wiring is independently testable.
+
+# Undocumented Codex/ChatGPT-backend Responses endpoint (POST).
+RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+# The arguments fragments of a single Codex function call all carry one stable
+# tool_use index so the consumer (provider.stream_turn) reassembles one call.
+_TOOL_USE_INDEX = 0
+
+
+def _litellm_types() -> Any:
+    """Import litellm (via the shared lazy accessor) and return its types module.
+
+    Routing through ``provider._get_litellm`` keeps the fast-startup invariant:
+    litellm loads only once a Codex call is made, and the shared cache is set so
+    ``provider._litellm`` stays consistent. Returns the ``litellm.types.utils``
+    module, which carries ``Usage`` / ``Choices`` / ``Message``.
+    """
+    from riftor.agent.provider import _get_litellm
+
+    _get_litellm()  # ensures litellm is imported + configured + cached
+    import litellm.types.utils as _types
+
+    return _types
+
+
+def _custom_llm_base() -> type:
+    """Return litellm's ``CustomLLM`` base class (loaded lazily)."""
+    from riftor.agent.provider import _get_litellm
+
+    # getattr avoids pyright's reportPrivateImportUsage on the re-exported name.
+    return getattr(_get_litellm(), "CustomLLM")  # noqa: B009
+
+
+def _resolve_access_token() -> str:
+    """Return a usable access token, refreshing it first when near expiry.
+
+    Lets the clean "run `codex login`" ``RuntimeError`` from :func:`read_tokens`
+    propagate when the user isn't logged in.
+    """
+    access, _ = read_tokens()
+    if should_refresh(access):
+        access = refresh_tokens()
+    return access
+
+
+def _build_headers(access_token: str) -> dict:
+    """Build the request headers for the Codex Responses endpoint.
+
+    ``chatgpt-account-id`` is included only when :func:`account_id` resolves a
+    value (the endpoint tolerates its absence on personal accounts).
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "OpenAI-Beta": "responses=experimental",
+        "originator": "codex_cli_rs",
+        "Accept": "text/event-stream",
+        "Content-Type": "application/json",
+    }
+    acc = account_id()
+    if acc is not None:
+        headers["chatgpt-account-id"] = acc
+    return headers
+
+
+def _stream_responses(
+    payload: dict, headers: dict, timeout: float = 120.0
+) -> Iterator[str]:
+    """POST ``payload`` to the Responses endpoint and yield decoded body LINES.
+
+    The SINGLE inference network seam — tests monkeypatch *this* to feed canned
+    SSE lines. Uses stdlib ``urllib`` and streams the response line-by-line so
+    the SSE parser sees frames as they arrive.
+    """
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        RESPONSES_URL, data=data, headers=headers, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed https endpoint
+        for raw in resp:
+            yield raw.decode("utf-8", errors="replace")
+
+
+def _bare_model(model: str) -> str:
+    """Strip a leading ``codex/`` provider prefix if present."""
+    prefix = "codex/"
+    return model[len(prefix) :] if model.startswith(prefix) else model
+
+
+def _chunk_to_streaming(chunk: CodexChunk) -> dict:
+    """Translate a :class:`CodexChunk` into a litellm ``GenericStreamingChunk``.
+
+    Reasoning deltas are surfaced via ``provider_specific_fields`` so the UI can
+    show thinking, mirroring litellm's ``reasoning_content`` convention. The
+    terminal chunk carries ``is_finished``/``finish_reason`` and a litellm
+    ``Usage``.
+    """
+    tool_use = None
+    if chunk.tool_call is not None:
+        tool_use = {
+            "id": chunk.tool_call.get("id"),
+            "type": "function",
+            "index": _TOOL_USE_INDEX,
+            "function": {
+                "name": chunk.tool_call.get("name"),
+                "arguments": chunk.tool_call.get("arguments_delta") or "",
+            },
+        }
+
+    usage = None
+    if chunk.usage is not None:
+        usage = _litellm_types().Usage(
+            prompt_tokens=chunk.usage.get("prompt_tokens", 0),
+            completion_tokens=chunk.usage.get("completion_tokens", 0),
+            total_tokens=chunk.usage.get("total_tokens", 0),
+        )
+
+    provider_specific = None
+    if chunk.reasoning:
+        provider_specific = {"reasoning_content": chunk.reasoning}
+
+    return {
+        "text": chunk.text or "",
+        "tool_use": tool_use,
+        "is_finished": chunk.is_finished,
+        "finish_reason": chunk.finish_reason or "",
+        "usage": usage,
+        "index": 0,
+        "provider_specific_fields": provider_specific,
+    }
+
+
+def _model_response_from_chunks(
+    model: str, chunks: Iterable[CodexChunk]
+) -> "ModelResponse":
+    """Assemble a non-streaming ``ModelResponse`` from the full chunk stream.
+
+    Accumulates assistant text and per-id tool-call arguments (reasoning is
+    dropped from the message), reconciling each tool call's name from the first
+    non-None name seen for that id. The terminal chunk supplies finish_reason
+    and usage.
+    """
+    types = _litellm_types()
+    ModelResponse = types.ModelResponse
+    Choices = types.Choices
+    Message = types.Message
+    Usage = types.Usage
+
+    text_parts: list[str] = []
+    # call id -> {"name": str|None, "args": str}; ordered by first appearance.
+    calls: dict[str, dict] = {}
+    finish_reason = "stop"
+    usage: dict | None = None
+
+    for chunk in chunks:
+        if chunk.text:
+            text_parts.append(chunk.text)
+        if chunk.tool_call is not None:
+            call_id = chunk.tool_call.get("id")
+            if call_id is not None:
+                slot = calls.setdefault(call_id, {"name": None, "args": ""})
+                name = chunk.tool_call.get("name")
+                if name and not slot["name"]:
+                    slot["name"] = name
+                slot["args"] += chunk.tool_call.get("arguments_delta") or ""
+        if chunk.is_finished:
+            finish_reason = chunk.finish_reason or "stop"
+            usage = chunk.usage
+
+    tool_calls = [
+        {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": slot["name"], "arguments": slot["args"]},
+        }
+        for call_id, slot in calls.items()
+    ]
+
+    content = "".join(text_parts)
+    message = Message(
+        role="assistant",
+        content=content or None,
+        tool_calls=tool_calls or None,
+    )
+    choice = Choices(finish_reason=finish_reason, index=0, message=message)
+
+    usage = usage or {}
+    response_usage = Usage(
+        prompt_tokens=usage.get("prompt_tokens", 0),
+        completion_tokens=usage.get("completion_tokens", 0),
+        total_tokens=usage.get("total_tokens", 0),
+    )
+    return ModelResponse(
+        choices=[choice], usage=response_usage, model=_bare_model(model)
+    )
+
+
+def _build_payload(model: str, messages: list[dict], optional_params: dict) -> dict:
+    """Build the Responses request body from litellm's call inputs."""
+    tools = optional_params.get("tools")
+    reasoning_effort = optional_params.get("reasoning_effort") or "medium"
+    verbosity = optional_params.get("verbosity") or "medium"
+    bare = _bare_model(model)
+    return build_request_body(
+        bare,
+        messages,
+        tools=tools,
+        instructions=instructions_for(bare),
+        reasoning_effort=reasoning_effort,
+        verbosity=verbosity,
+    )
+
+
+def _iter_codex_chunks(model: str, messages: list[dict], optional_params: dict) -> Iterator[CodexChunk]:
+    """Resolve auth, fire the request, and yield parsed :class:`CodexChunk`s.
+
+    The shared spine of streaming and non-streaming: auth/headers/body, then
+    ``_stream_responses`` → ``iter_sse_lines`` → ``parse_events``.
+    """
+    access = _resolve_access_token()
+    headers = _build_headers(access)
+    payload = _build_payload(model, messages, optional_params)
+    lines = _stream_responses(payload, headers)
+    yield from parse_events(iter_sse_lines(lines))
+
+
+# The mixin holds all behavior; ``_build_codex_provider_class`` stitches it onto
+# litellm's ``CustomLLM`` base lazily (so importing this module never loads
+# litellm — the fast-startup invariant ``provider.py`` depends on).
+class _CodexProviderMixin:
+    """litellm ``CustomLLM`` handler for OpenAI's undocumented Codex backend."""
+
+    def streaming(self, model, messages, *args, **kwargs) -> Iterator[dict]:
+        optional_params = kwargs.get("optional_params") or {}
+        for chunk in _iter_codex_chunks(model, messages, optional_params):
+            yield _chunk_to_streaming(chunk)
+
+    async def astreaming(self, model, messages, *args, **kwargs):
+        # ``_stream_responses`` is sync (and monkeypatched in tests); driving the
+        # sync generator directly keeps this simple and correct. A real run can
+        # offload the blocking I/O via asyncio.to_thread later if needed.
+        for chunk in self.streaming(model, messages, *args, **kwargs):
+            yield chunk
+
+    def completion(self, model, messages, *args, **kwargs) -> "ModelResponse":
+        optional_params = kwargs.get("optional_params") or {}
+        chunks = _iter_codex_chunks(model, messages, optional_params)
+        return _model_response_from_chunks(model, chunks)
+
+    async def acompletion(self, model, messages, *args, **kwargs) -> "ModelResponse":
+        return self.completion(model, messages, *args, **kwargs)
+
+
+_CODEX_PROVIDER_CLASS: type | None = None
+_CODEX_PROVIDER_SINGLETON: "_CodexProviderMixin | None" = None
+
+
+def _build_codex_provider_class() -> type:
+    """Build (once) the concrete ``CodexProvider`` subclassing litellm CustomLLM."""
+    global _CODEX_PROVIDER_CLASS
+    if _CODEX_PROVIDER_CLASS is None:
+        _CODEX_PROVIDER_CLASS = type(
+            "CodexProvider", (_CodexProviderMixin, _custom_llm_base()), {}
+        )
+    return _CODEX_PROVIDER_CLASS
+
+
+def __getattr__(name: str):
+    """Lazily expose ``CodexProvider`` / ``codex_provider`` (PEP 562).
+
+    Resolving either triggers the (lazy) litellm import, so accessing the
+    handler is what loads litellm — never the bare module import.
+    """
+    if name == "CodexProvider":
+        return _build_codex_provider_class()
+    if name == "codex_provider":
+        global _CODEX_PROVIDER_SINGLETON
+        if _CODEX_PROVIDER_SINGLETON is None:
+            _CODEX_PROVIDER_SINGLETON = _build_codex_provider_class()()
+        return _CODEX_PROVIDER_SINGLETON
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -731,8 +731,8 @@ def _chunk_to_streaming(chunk: CodexChunk) -> dict:
 
     Reasoning deltas are surfaced via ``provider_specific_fields`` so the UI can
     show thinking, mirroring litellm's ``reasoning_content`` convention. The
-    terminal chunk carries ``is_finished``/``finish_reason`` and a litellm
-    ``Usage``.
+    terminal chunk carries ``is_finished``/``finish_reason`` and a ``usage``
+    mapping (a plain dict, which ``CustomStreamWrapper`` splats into ``Usage``).
     """
     tool_use = None
     if chunk.tool_call is not None:
@@ -748,11 +748,15 @@ def _chunk_to_streaming(chunk: CodexChunk) -> dict:
 
     usage = None
     if chunk.usage is not None:
-        usage = _litellm_types().Usage(
-            prompt_tokens=chunk.usage.get("prompt_tokens", 0),
-            completion_tokens=chunk.usage.get("completion_tokens", 0),
-            total_tokens=chunk.usage.get("total_tokens", 0),
-        )
+        # litellm's CustomStreamWrapper consumes this via ``Usage(**chunk["usage"])``,
+        # so it must be a plain mapping — passing a ``Usage`` object raises
+        # "argument after ** must be a mapping, not Usage" (wrapped as
+        # MidStreamFallbackError).
+        usage = {
+            "prompt_tokens": chunk.usage.get("prompt_tokens", 0),
+            "completion_tokens": chunk.usage.get("completion_tokens", 0),
+            "total_tokens": chunk.usage.get("total_tokens", 0),
+        }
 
     provider_specific = None
     if chunk.reasoning:

--- a/riftor/agent/prompts/codex/default.md
+++ b/riftor/agent/prompts/codex/default.md
@@ -1,0 +1,68 @@
+You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.
+
+## General
+
+- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+
+## Editing constraints
+
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Add succinct code comments that explain what is going on if code is not self-explanatory. You should not add comments like "Assigns the value to the variable", but a brief comment might be useful ahead of a complex code block that the user would otherwise have to spend time parsing out. Usage of these comments should be rare.
+- Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
+- You may be in a dirty git worktree.
+    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
+    * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
+    * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
+    * If the changes are in unrelated files, just ignore them and don't revert them.
+- Do not amend a commit unless explicitly requested to do so.
+- While you are working, you might notice unexpected changes that you didn't make. If this happens, STOP IMMEDIATELY and ask the user how they would like to proceed.
+- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested or approved by the user.
+
+## Plan tool
+
+When using the planning tool:
+- Skip using the planning tool for straightforward tasks (roughly the easiest 25%).
+- Do not make single-step plans.
+- When you made a plan, update it after having performed one of the sub-tasks that you shared on the plan.
+
+## Special user requests
+
+- If the user makes a simple request (such as asking for the time) which you can fulfill by running a terminal command (such as `date`), you should do so.
+- If the user asks for a "review", default to a code review mindset: prioritise identifying bugs, risks, behavioural regressions, and missing tests. Findings must be the primary focus of the response - keep summaries or overviews brief and only after enumerating the issues. Present findings first (ordered by severity with file/line references), follow with open questions or assumptions, and offer a change-summary only as a secondary detail. If no findings are discovered, state that explicitly and mention any residual risks or testing gaps.
+
+## Presenting your work and final message
+
+You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
+
+- Default: be very concise; friendly coding teammate tone.
+- Ask only when needed; suggest ideas; mirror the user's style.
+- For substantial work, summarize clearly; follow final‑answer formatting.
+- Skip heavy formatting for simple confirmations.
+- Don't dump large files you've written; reference paths only.
+- No "save/copy this file" - User is on the same machine.
+- Offer logical next steps (tests, commits, build) briefly; add verify steps if you couldn't do something.
+- For code changes:
+  * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
+  * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
+  * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
+- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+
+### Final answer structure and style guidelines
+
+- Plain text; CLI handles styling. Use structure only when it helps scanability.
+- Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.
+- Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.
+- Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string as often as possible.
+- Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
+- Tone: collaborative, concise, factual; present tense, active voice; self‑contained; no "above/below"; parallel wording.
+- Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.
+- Adaptation: code explanations → precise, structured with code refs; simple tasks → lead with outcome; big changes → logical walkthrough + rationale + next actions; casual one-offs → plain sentences, no headers/bullets.
+- File References: When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -54,6 +54,15 @@ def _register_codex_provider(litellm) -> None:
         return
     existing.append({"provider": "codex", "custom_handler": codex_provider})
     litellm.custom_provider_map = existing
+    # Setting custom_provider_map alone is NOT enough: litellm gates custom-handler
+    # dispatch on ``custom_llm_provider in litellm._custom_providers`` (main.py), a
+    # list that stays empty until ``custom_llm_setup()`` runs. It idempotently
+    # appends our provider to both ``litellm.provider_list`` and
+    # ``litellm._custom_providers`` so routing by model id reaches our handler.
+    try:
+        litellm.utils.custom_llm_setup()
+    except Exception:  # noqa: BLE001 — Codex optional at runtime; never break the loop
+        pass
 
 
 @dataclass
@@ -152,8 +161,17 @@ class Provider:
         self.max_retries = 4
 
     def _kwargs(self, messages: list[dict], tools: list[dict] | None = None) -> dict:
+        # Route codex/<real-model> through an opaque marker id so litellm dispatches
+        # to our custom handler instead of registry-matching the bare name to its
+        # built-in OpenAI provider. Imported lazily so importing provider.py never
+        # loads litellm/codex_provider (see test_importing_provider_does_not_load_litellm).
+        model = self.config.model
+        if model.startswith("codex/"):
+            from riftor.agent.codex_provider import to_litellm_model
+
+            model = to_litellm_model(model)
         kwargs: dict = {
-            "model": self.config.model,
+            "model": model,
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -33,8 +33,27 @@ def _get_litellm():
         litellm.telemetry = False
         litellm.drop_params = True
         litellm.suppress_debug_info = True
+        _register_codex_provider(litellm)
         _litellm = litellm
     return _litellm
+
+
+def _register_codex_provider(litellm) -> None:
+    """Register riftor's vendored `codex/` handler (reads ~/.codex/auth.json).
+
+    Guarded: if importing/instantiating the handler fails for any reason, Codex
+    simply won't work, but every other provider still does — riftor's
+    never-crash-on-an-optional-thing ethos.
+    """
+    try:
+        from riftor.agent.codex_provider import codex_provider
+    except Exception:  # noqa: BLE001 — Codex optional at runtime; never break the loop
+        return
+    existing = list(getattr(litellm, "custom_provider_map", None) or [])
+    if any(entry.get("provider") == "codex" for entry in existing):
+        return
+    existing.append({"provider": "codex", "custom_handler": codex_provider})
+    litellm.custom_provider_map = existing
 
 
 @dataclass

--- a/riftor/codex_auth.py
+++ b/riftor/codex_auth.py
@@ -33,8 +33,12 @@ def _auth_file() -> Path:
     return codex_home() / "auth.json"
 
 
-def _jwt_exp(token: str) -> int | None:
-    """Read the ``exp`` claim from a JWT payload (no signature check)."""
+def _jwt_claims(token: str) -> dict | None:
+    """Decode a JWT payload into its claims dict (no signature check).
+
+    Returns ``None`` when the token has fewer than 2 segments. Raises on
+    genuinely malformed base64/JSON — callers already guard this.
+    """
     parts = token.split(".")
     if len(parts) < 2:
         return None
@@ -42,6 +46,14 @@ def _jwt_exp(token: str) -> int | None:
     payload += "=" * (-len(payload) % 4)  # restore base64 padding
     raw = base64.urlsafe_b64decode(payload.encode("ascii"))
     claims = json.loads(raw)
+    return claims if isinstance(claims, dict) else None
+
+
+def _jwt_exp(token: str) -> int | None:
+    """Read the ``exp`` claim from a JWT payload (no signature check)."""
+    claims = _jwt_claims(token)
+    if claims is None:
+        return None
     exp = claims.get("exp")
     return int(exp) if isinstance(exp, (int, float)) else None
 

--- a/riftor/codex_auth.py
+++ b/riftor/codex_auth.py
@@ -1,0 +1,70 @@
+"""Read-only status for the Codex CLI's ~/.codex/auth.json token file.
+
+riftor never writes this file — the official ``codex login`` does. We only peek
+at it to tell the operator whether they're logged in (and roughly when the token
+expires) so /config and --doctor can guide them. Every failure degrades to a
+sensible status; this module never raises.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CodexAuthStatus:
+    logged_in: bool
+    expires_in_s: int | None
+    detail: str
+
+
+def codex_home() -> Path:
+    """``$CODEX_HOME`` if set, else ``~/.codex`` (matches the official CLI)."""
+    env = os.environ.get("CODEX_HOME")
+    return Path(env) if env else Path.home() / ".codex"
+
+
+def _auth_file() -> Path:
+    return codex_home() / "auth.json"
+
+
+def _jwt_exp(token: str) -> int | None:
+    """Read the ``exp`` claim from a JWT payload (no signature check)."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)  # restore base64 padding
+    raw = base64.urlsafe_b64decode(payload.encode("ascii"))
+    claims = json.loads(raw)
+    exp = claims.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+def auth_status() -> CodexAuthStatus:
+    """Best-effort login status. Never raises."""
+    path = _auth_file()
+    if not path.exists():
+        return CodexAuthStatus(False, None, "not logged in — run `codex login`")
+    try:
+        data = json.loads(path.read_text())
+        token = (data.get("tokens") or {}).get("access_token")
+    except Exception:  # noqa: BLE001 — a bad token file must never crash riftor
+        return CodexAuthStatus(False, None, "unreadable auth.json — run `codex login`")
+    if not token:
+        return CodexAuthStatus(False, None, "no token — run `codex login`")
+    try:
+        exp = _jwt_exp(token)
+    except Exception:  # noqa: BLE001 — unparseable JWT => token present, expiry unknown
+        return CodexAuthStatus(True, None, "token present")
+    if exp is None:
+        return CodexAuthStatus(True, None, "token present")
+    remaining = int(exp - time.time())
+    if remaining <= 0:
+        return CodexAuthStatus(False, 0, "token expired — run `codex login`")
+    return CodexAuthStatus(True, remaining, f"logged in ({remaining // 60}m left)")

--- a/riftor/codex_auth.py
+++ b/riftor/codex_auth.py
@@ -48,7 +48,10 @@ def _jwt_exp(token: str) -> int | None:
 
 def auth_status() -> CodexAuthStatus:
     """Best-effort login status. Never raises."""
-    path = _auth_file()
+    try:
+        path = _auth_file()
+    except Exception:  # noqa: BLE001 — Path.home() raises RuntimeError in homedir-less envs
+        return CodexAuthStatus(False, None, "cannot resolve auth path — run `codex login`")
     if not path.exists():
         return CodexAuthStatus(False, None, "not logged in — run `codex login`")
     try:

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -125,7 +125,7 @@ class Config(BaseModel):
         entry = self.providers.get(key_name)
         if entry and entry.api_key:
             return True
-        if self.model.startswith(("ollama/", "ollama_chat/")):
+        if self.model.startswith(("ollama/", "ollama_chat/", "codex/")):
             return True
         env = self.provider_env()
         if env and os.environ.get(env):
@@ -140,6 +140,9 @@ class Config(BaseModel):
         only) → (None, None). Model-keyed so a future multi-model feature can
         resolve each model's creds without touching this layer.
         """
+        if model.startswith("codex/"):
+            # Codex auth lives in ~/.codex/auth.json, read by the litellm handler.
+            return None, None
         # NOTE: slash-routed OpenRouter ids (e.g. "openai/gpt-5.5") are keyed to their
         # underlying provider ("openai"), not "openrouter". Resolved in the picker/store
         # layer (it prefixes/stores under the chosen provider); see Task 6/7.

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -36,6 +36,7 @@ _KNOWN_PROVIDERS = (
     "anthropic/", "openai/", "openrouter/", "ollama/", "ollama_chat/", "gemini/",
     "groq/", "mistral/", "cohere/", "azure/", "bedrock/", "vertex_ai/", "together_ai/",
     "deepseek/", "xai/", "perplexity/", "fireworks_ai/", "huggingface/", "replicate/",
+    "codex/",
 )
 
 # Valid reasoning-effort levels (litellm vocabulary). "none" => no reasoning request.

--- a/riftor/engagement/doctor.py
+++ b/riftor/engagement/doctor.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass
 
+from riftor.codex_auth import auth_status
+
 # Tools the methodology + system prompt reference, grouped by RIFT stage.
 # (binary, one-line purpose). Kept in sync with prompts/system.md.
 TOOLCHAIN: dict[str, list[tuple[str, str]]] = {
@@ -112,4 +114,8 @@ def render_plain(statuses: list[ToolStatus]) -> str:
     lines.append(f"{summary['present']}/{summary['total']} present.")
     if summary["missing"]:
         lines.append("missing (not fatal): " + ", ".join(summary["missing_names"]))
+    st = auth_status()
+    mark = "ok " if st.logged_in else "MISSING"
+    lines.append("Codex subscription:")
+    lines.append(f"  [{mark}] {'codex login':<10} {st.detail}")
     return "\n".join(lines)

--- a/riftor/providers.py
+++ b/riftor/providers.py
@@ -39,6 +39,8 @@ PROVIDERS: dict[str, ProviderMeta] = {
                         "openai", "https://api.x.ai/v1"),
     "mistral": ProviderMeta("mistral", "Mistral", "mistral/", "MISTRAL_API_KEY",
                             "openai", "https://api.mistral.ai/v1"),
+    "codex": ProviderMeta("codex", "Codex (ChatGPT)", "codex/", None,
+                          "codex", None),
     "ollama": ProviderMeta("ollama", "Ollama", "ollama_chat/", None,
                            "ollama", "http://localhost:11434"),
     "custom": ProviderMeta("custom", "Custom…", "", None, "openai", None),
@@ -56,6 +58,7 @@ PROVIDER_DEFAULTS: dict[str, list[str]] = {
     "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
     "xai": ["grok-4.3"],
     "mistral": ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
+    "codex": ["gpt-5.5-codex", "gpt-5.5", "gpt-5.4-codex"],
     "ollama": [],
     "custom": [],
 }
@@ -120,6 +123,10 @@ def fetch_models(provider_key: str, api_base: str | None, api_key: str | None) -
         return FetchResult(models=curated, source="curated")
 
     if meta.list_kind == "none":
+        return FetchResult(models=curated, source="curated")
+
+    if meta.list_kind == "codex":
+        # Codex backend has no public /models list; always use curated defaults.
         return FetchResult(models=curated, source="curated")
 
     base = (api_base or meta.default_base or "").rstrip("/")

--- a/riftor/providers.py
+++ b/riftor/providers.py
@@ -58,7 +58,7 @@ PROVIDER_DEFAULTS: dict[str, list[str]] = {
     "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
     "xai": ["grok-4.3"],
     "mistral": ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
-    "codex": ["gpt-5.5-codex", "gpt-5.5", "gpt-5.4-codex"],
+    "codex": ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"],
     "ollama": [],
     "custom": [],
 }

--- a/riftor/providers.py
+++ b/riftor/providers.py
@@ -18,7 +18,7 @@ class ProviderMeta:
     label: str
     prefix: str            # litellm prefix; "" for custom
     env: str | None        # env var holding the key, if any
-    list_kind: str         # "openai" | "ollama" | "none"
+    list_kind: str         # "openai" | "ollama" | "codex" | "none"
     default_base: str | None
 
 

--- a/riftor/tools/subagent.py
+++ b/riftor/tools/subagent.py
@@ -100,7 +100,7 @@ class DispatchChaklaTool(Tool):
         # We gate on api_key only: the reported failure mode is a missing/mismatched
         # key. A keyless custom endpoint (api_base but no key) is the rare exception
         # and is refused here; set any placeholder key or use the blank-reuse path.
-        is_local = worker_model.startswith(("ollama/", "ollama_chat/"))
+        is_local = worker_model.startswith(("ollama/", "ollama_chat/", "codex/"))
         api_key, _api_base = cfg.creds_for(worker_model)
         if not is_local and api_key is None:
             return ToolResult(

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 # Model-window estimates (tokens) for the context gauge, by provider prefix.
 _CONTEXT_WINDOWS = {
     "anthropic/": 200_000, "openai/": 128_000, "openrouter/": 128_000,
+    "codex/": 128_000,
     "gemini/": 1_000_000, "groq/": 128_000, "ollama": 8_192,
 }
 _DEFAULT_WINDOW = 128_000

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -19,6 +19,7 @@ from riftor.providers import (
     fetch_models,
     provider_key_for_model,
 )
+from riftor.codex_auth import auth_status
 from riftor.config import REASONING_EFFORTS
 from riftor.tui.theme import THEMES
 
@@ -124,6 +125,8 @@ class ConfigScreen(ModalScreen[dict | None]):
                             value=base_val, placeholder="provider default", id="cfg-base"))
                         yield _row("API key", Input(
                             password=True, placeholder="leave blank to keep", id="cfg-key"))
+                        yield _row("Codex login", Label(
+                            self._codex_status_text(), id="cfg-codex-status"))
                         with Horizontal(classes="field-row"):
                             yield Label("", classes="field-label")
                             yield Button("Fetch models", id="cfg-fetch", variant="primary")
@@ -181,6 +184,25 @@ class ConfigScreen(ModalScreen[dict | None]):
         # Model is the default-visible section (the only panel composed without
         # the `hidden` class); focus its first field.
         self.query_one("#cfg-provider", Select).focus()
+        # Codex has no key/base/model-list — reflect that if it's the saved provider.
+        self._set_codex_mode(self._provider == "codex")
+
+    def _codex_status_text(self) -> str:
+        st = auth_status()
+        mark = "✓" if st.logged_in else "⚠"
+        return f"{mark} {st.detail}"
+
+    def _set_codex_mode(self, on: bool) -> None:
+        """Codex has no API key/base/model-list: hide those rows, show status."""
+        for wid in ("cfg-key", "cfg-base", "cfg-fetch"):
+            row = self.query_one(f"#{wid}").parent
+            if row is not None:
+                row.set_class(on, "hidden")
+        status_row = self.query_one("#cfg-codex-status").parent
+        if status_row is not None:
+            status_row.set_class(not on, "hidden")
+        if on:
+            self.query_one("#cfg-codex-status", Label).update(self._codex_status_text())
 
     def show_section(self, key: str) -> None:
         """Show the named section panel, hide the rest. All panels stay mounted
@@ -215,6 +237,7 @@ class ConfigScreen(ModalScreen[dict | None]):
             return
         if event.select.id == "cfg-provider" and isinstance(event.value, str):
             self._provider = event.value
+            self._set_codex_mode(event.value == "codex")
             meta = PROVIDERS[event.value]
             self.query_one("#cfg-base", Input).value = meta.default_base or ""
             if self._provider_initialized:

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -125,8 +125,9 @@ class ConfigScreen(ModalScreen[dict | None]):
                             value=base_val, placeholder="provider default", id="cfg-base"))
                         yield _row("API key", Input(
                             password=True, placeholder="leave blank to keep", id="cfg-key"))
-                        yield _row("Codex login", Label(
-                            self._codex_status_text(), id="cfg-codex-status"))
+                        _codex_row = _row("Codex login", Label("", id="cfg-codex-status"))
+                        _codex_row.add_class("hidden")
+                        yield _codex_row
                         with Horizontal(classes="field-row"):
                             yield Label("", classes="field-label")
                             yield Button("Fetch models", id="cfg-fetch", variant="primary")

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -170,6 +170,9 @@ ConfirmScreen, ConfigScreen {
 .config-section-panel.hidden {
     display: none;
 }
+.field-row.hidden {
+    display: none;
+}
 
 .config-section {
     width: 1fr;

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -1,0 +1,60 @@
+"""Codex auth-status helper: reads ~/.codex/auth.json, never raises."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import riftor.codex_auth as ca
+
+
+def _make_jwt(exp: int) -> str:
+    """A minimal unsigned JWT with the given exp claim (header.payload.sig)."""
+    def seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return f"{seg({'alg': 'none'})}.{seg({'exp': exp})}.sig"
+
+
+def _write_auth(tmp_path, access_token: str) -> None:
+    (tmp_path / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": access_token}})
+    )
+
+
+def test_missing_file_is_not_logged_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    status = ca.auth_status()
+    assert status.logged_in is False
+    assert "codex login" in status.detail
+
+
+def test_valid_future_token_is_logged_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_auth(tmp_path, _make_jwt(int(time.time()) + 3600))
+    status = ca.auth_status()
+    assert status.logged_in is True
+    assert status.expires_in_s is not None
+    assert 0 < status.expires_in_s <= 3600
+
+
+def test_garbage_token_degrades_without_raising(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_auth(tmp_path, "not-a-jwt")
+    status = ca.auth_status()           # must NOT raise
+    assert status.logged_in is True     # token present, just unparseable
+    assert status.expires_in_s is None
+
+
+def test_malformed_json_degrades_without_raising(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text("{ this is not json")
+    status = ca.auth_status()           # must NOT raise
+    assert status.logged_in is False
+
+
+def test_codex_home_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    from pathlib import Path
+    assert ca.codex_home() == Path.home() / ".codex"

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -58,3 +58,12 @@ def test_codex_home_defaults_to_home(monkeypatch):
     monkeypatch.delenv("CODEX_HOME", raising=False)
     from pathlib import Path
     assert ca.codex_home() == Path.home() / ".codex"
+
+
+def test_expired_token_is_not_logged_in(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    _write_auth(tmp_path, _make_jwt(int(time.time()) - 1))
+    status = ca.auth_status()
+    assert status.logged_in is False
+    assert status.expires_in_s == 0
+    assert "expired" in status.detail

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -67,3 +67,11 @@ def test_expired_token_is_not_logged_in(tmp_path, monkeypatch):
     assert status.logged_in is False
     assert status.expires_in_s == 0
     assert "expired" in status.detail
+
+
+def test_doctor_plain_includes_codex_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))  # no auth.json => not logged in
+    from riftor.engagement.doctor import check_toolchain, render_plain
+    out = render_plain(check_toolchain())
+    assert "Codex" in out
+    assert "codex login" in out

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -855,8 +855,125 @@ def test_streaming_tool_call_reply(tmp_path, monkeypatch):
     assert "bash" in names
     args = "".join(c["tool_use"]["function"]["arguments"] or "" for c in tool_chunks)
     assert args == '{"cmd":"ls"}'
-    # tool_use index is stable so the consumer reassembles one call.
-    assert all(c["tool_use"]["index"] == tool_chunks[0]["tool_use"]["index"] for c in tool_chunks)
+    # A single call streams under one stable index (0) so the consumer
+    # reassembles exactly one call.
+    assert all(c["tool_use"]["index"] == 0 for c in tool_chunks)
+
+    final = chunks[-1]
+    assert final["is_finished"] is True
+    assert final["finish_reason"] == "tool_calls"
+
+
+def test_streaming_two_parallel_tool_calls_distinct_index(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    # Two parallel function calls announced up-front.
+    lines += _sse(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": "a",
+                "call_id": "call_a",
+                "id": "item_a",
+            },
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": "b",
+                "call_id": "call_b",
+                "id": "item_b",
+            },
+        }
+    )
+    # Argument fragments interleaved between the two calls.
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_a",
+            "delta": '{"x"',
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_b",
+            "delta": '{"y"',
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_a",
+            "delta": ":1}",
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_b",
+            "delta": ":2}",
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "a",
+                        "arguments": '{"x":1}',
+                        "call_id": "call_a",
+                    },
+                    {
+                        "type": "function_call",
+                        "name": "b",
+                        "arguments": '{"y":2}',
+                        "call_id": "call_b",
+                    },
+                ],
+                "usage": {"input_tokens": 9, "output_tokens": 5},
+            },
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider, "_stream_responses", lambda payload, headers, timeout=120.0: iter(lines)
+    )
+
+    chunks = list(
+        codex_provider.codex_provider.streaming(
+            "gpt-5.5-codex", [{"role": "user", "content": "do two things"}]
+        )
+    )
+
+    tool_chunks = [c for c in chunks if c["tool_use"]]
+    # Group streamed fragments by their tool_use index.
+    by_index: dict[int, list[dict]] = {}
+    for c in tool_chunks:
+        by_index.setdefault(c["tool_use"]["index"], []).append(c)
+
+    # Two distinct calls -> two distinct indices, 0 and 1 in first-seen order.
+    assert set(by_index) == {0, 1}
+
+    # Index 0 belongs to call_a, index 1 to call_b, and arguments accumulate
+    # INDEPENDENTLY per index (no concatenation across calls).
+    def _args(idx: int) -> str:
+        return "".join(c["tool_use"]["function"]["arguments"] or "" for c in by_index[idx])
+
+    def _id(idx: int) -> str:
+        return next(c["tool_use"]["id"] for c in by_index[idx])
+
+    assert _id(0) == "call_a"
+    assert _id(1) == "call_b"
+    assert _args(0) == '{"x":1}'
+    assert _args(1) == '{"y":2}'
 
     final = chunks[-1]
     assert final["is_finished"] is True

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -11,6 +11,7 @@ import base64
 import json
 import stat
 import time
+import urllib.error
 
 import pytest
 
@@ -173,3 +174,29 @@ def test_refresh_tokens_missing_access_token_raises(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError):
         codex_provider.refresh_tokens()
+
+
+def test_refresh_http_error_becomes_auth_error(tmp_path, monkeypatch):
+    _write_auth(tmp_path, {"access_token": "old-at", "refresh_token": "old-rt"})
+
+    def fake_post(url, body, timeout=30.0):
+        raise urllib.error.HTTPError(url, 401, "unauthorized", hdrs=None, fp=None)
+
+    monkeypatch.setattr(codex_provider, "_http_post_json", fake_post)
+
+    with pytest.raises(RuntimeError) as ei:
+        codex_provider.refresh_tokens()
+    assert "codex login" in str(ei.value)
+
+
+def test_refresh_non_json_becomes_auth_error(tmp_path, monkeypatch):
+    _write_auth(tmp_path, {"access_token": "old-at", "refresh_token": "old-rt"})
+
+    def fake_post(url, body, timeout=30.0):
+        raise json.JSONDecodeError("x", "", 0)
+
+    monkeypatch.setattr(codex_provider, "_http_post_json", fake_post)
+
+    with pytest.raises(RuntimeError) as ei:
+        codex_provider.refresh_tokens()
+    assert "codex login" in str(ei.value)

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -1,0 +1,175 @@
+"""Offline tests for the Codex provider auth section (Task 4a).
+
+Every network/filesystem seam is monkeypatched: no real network, no real
+``~/.codex``. We point ``CODEX_HOME`` at ``tmp_path`` and patch the single
+``_http_post_json`` network seam.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import stat
+import time
+
+import pytest
+
+from riftor.agent import codex_provider
+
+
+def _make_jwt(claims: dict) -> str:
+    def seg(obj: dict) -> str:
+        return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'none'})}.{seg(claims)}.sig"
+
+
+def _write_auth(tmp_path, tokens: dict, **extra) -> None:
+    data = {"tokens": tokens, **extra}
+    (tmp_path / "auth.json").write_text(json.dumps(data))
+
+
+@pytest.fixture(autouse=True)
+def _codex_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    return tmp_path
+
+
+# --- read_tokens -----------------------------------------------------------
+
+
+def test_read_tokens_returns_pair(tmp_path):
+    _write_auth(tmp_path, {"access_token": "at-1", "refresh_token": "rt-1"})
+    assert codex_provider.read_tokens() == ("at-1", "rt-1")
+
+
+def test_read_tokens_missing_file_raises(tmp_path):
+    with pytest.raises(RuntimeError) as ei:
+        codex_provider.read_tokens()
+    assert "codex login" in str(ei.value)
+
+
+def test_read_tokens_absent_tokens_raises(tmp_path):
+    _write_auth(tmp_path, {})  # tokens present but no access/refresh
+    with pytest.raises(RuntimeError) as ei:
+        codex_provider.read_tokens()
+    assert "codex login" in str(ei.value)
+
+
+# --- account_id ------------------------------------------------------------
+
+
+def test_account_id_prefers_tokens_field(tmp_path):
+    _write_auth(
+        tmp_path,
+        {"access_token": "at", "refresh_token": "rt", "account_id": "acc-from-field"},
+    )
+    assert codex_provider.account_id() == "acc-from-field"
+
+
+def test_account_id_decoded_from_jwt_when_absent(tmp_path):
+    at = _make_jwt(
+        {
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acc-123"},
+            "exp": int(time.time()) + 3600,
+        }
+    )
+    _write_auth(tmp_path, {"access_token": at, "refresh_token": "rt"})
+    assert codex_provider.account_id() == "acc-123"
+
+
+def test_account_id_none_when_unresolvable(tmp_path):
+    _write_auth(tmp_path, {"access_token": "not-a-jwt", "refresh_token": "rt"})
+    assert codex_provider.account_id() is None
+
+
+# --- should_refresh --------------------------------------------------------
+
+
+def test_should_refresh_within_window():
+    at = _make_jwt({"exp": int(time.time()) + 60})
+    assert codex_provider.should_refresh(at) is True
+
+
+def test_should_refresh_no_exp():
+    at = _make_jwt({"foo": "bar"})
+    assert codex_provider.should_refresh(at) is True
+
+
+def test_should_refresh_far_future():
+    at = _make_jwt({"exp": int(time.time()) + 3600})
+    assert codex_provider.should_refresh(at) is False
+
+
+# --- refresh_tokens --------------------------------------------------------
+
+
+def test_refresh_tokens_writes_back(tmp_path, monkeypatch):
+    _write_auth(
+        tmp_path,
+        {"access_token": "old-at", "refresh_token": "old-rt", "account_id": "acc-x"},
+        last_refresh="2020-01-01T00:00:00Z",
+    )
+
+    captured: dict = {}
+
+    def fake_post(url, body, timeout=30.0):
+        captured["url"] = url
+        captured["body"] = body
+        return {"access_token": "new-at", "refresh_token": "new-rt"}
+
+    monkeypatch.setattr(codex_provider, "_http_post_json", fake_post)
+
+    result = codex_provider.refresh_tokens()
+    assert result == "new-at"
+
+    on_disk = json.loads((tmp_path / "auth.json").read_text())
+    assert on_disk["tokens"]["access_token"] == "new-at"
+    assert on_disk["tokens"]["refresh_token"] == "new-rt"
+    # Preserved other keys
+    assert on_disk["tokens"]["account_id"] == "acc-x"
+    # last_refresh updated to something other than the stale value
+    assert on_disk["last_refresh"] != "2020-01-01T00:00:00Z"
+    assert on_disk["last_refresh"]
+
+    # File mode is owner-only.
+    mode = stat.S_IMODE((tmp_path / "auth.json").stat().st_mode)
+    assert mode == 0o600
+
+    # Wire protocol body is exact.
+    assert captured["url"] == codex_provider.AUTH_TOKEN_URL
+    assert captured["body"] == {
+        "client_id": codex_provider.CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": "old-rt",
+    }
+
+
+def test_refresh_tokens_falls_back_to_old_values(tmp_path, monkeypatch):
+    _write_auth(
+        tmp_path,
+        {"access_token": "old-at", "refresh_token": "old-rt", "id_token": "old-id"},
+    )
+
+    def fake_post(url, body, timeout=30.0):
+        return {"access_token": "new-at"}  # no refresh_token / id_token
+
+    monkeypatch.setattr(codex_provider, "_http_post_json", fake_post)
+
+    assert codex_provider.refresh_tokens() == "new-at"
+    on_disk = json.loads((tmp_path / "auth.json").read_text())
+    assert on_disk["tokens"]["access_token"] == "new-at"
+    assert on_disk["tokens"]["refresh_token"] == "old-rt"  # preserved
+    assert on_disk["tokens"]["id_token"] == "old-id"  # preserved
+
+
+def test_refresh_tokens_missing_access_token_raises(tmp_path, monkeypatch):
+    _write_auth(tmp_path, {"access_token": "old-at", "refresh_token": "old-rt"})
+
+    def fake_post(url, body, timeout=30.0):
+        return {"refresh_token": "new-rt"}  # no access_token
+
+    monkeypatch.setattr(codex_provider, "_http_post_json", fake_post)
+
+    with pytest.raises(RuntimeError):
+        codex_provider.refresh_tokens()

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -200,3 +200,54 @@ def test_refresh_non_json_becomes_auth_error(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError) as ei:
         codex_provider.refresh_tokens()
     assert "codex login" in str(ei.value)
+
+
+# --- instructions prompt (Task 4b) -----------------------------------------
+
+
+def test_bundled_instructions_loads():
+    text = codex_provider._bundled_instructions()
+    assert text
+    assert text.startswith("You are Codex")
+
+
+def test_instructions_falls_back_to_bundle_offline(monkeypatch):
+    codex_provider._INSTRUCTIONS_CACHE.clear()
+    monkeypatch.setattr(codex_provider, "_fetch_remote_instructions", lambda family: None)
+    text = codex_provider.instructions_for("gpt-5.5-codex")
+    assert text
+    assert text.startswith("You are Codex")
+
+    # And a variant where the remote seam raises — still falls back, never crashes.
+    codex_provider._INSTRUCTIONS_CACHE.clear()
+
+    def boom(family):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(codex_provider, "_fetch_remote_instructions", boom)
+    text2 = codex_provider.instructions_for("gpt-5.5-codex")
+    assert text2
+    assert text2.startswith("You are Codex")
+
+
+def test_instructions_uses_remote_when_available(monkeypatch):
+    codex_provider._INSTRUCTIONS_CACHE.clear()
+    monkeypatch.setattr(
+        codex_provider, "_fetch_remote_instructions", lambda family: "REMOTE PROMPT TEXT"
+    )
+    assert codex_provider.instructions_for("gpt-5.5-codex") == "REMOTE PROMPT TEXT"
+
+
+def test_instructions_caches(monkeypatch):
+    codex_provider._INSTRUCTIONS_CACHE.clear()
+    calls = {"n": 0}
+
+    def counting(family):
+        calls["n"] += 1
+        return "X"
+
+    monkeypatch.setattr(codex_provider, "_fetch_remote_instructions", counting)
+    first = codex_provider.instructions_for("gpt-5.5-codex")
+    second = codex_provider.instructions_for("gpt-5.5-codex")
+    assert first == second == "X"
+    assert calls["n"] == 1

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -793,6 +793,63 @@ async def test_astreaming_text_reply(tmp_path, monkeypatch):
     assert collected[-1]["is_finished"] is True
 
 
+def test_streaming_through_litellm_custom_stream_wrapper(tmp_path, monkeypatch):
+    """End-to-end: drive our handler's chunks through litellm's real
+    ``CustomStreamWrapper`` (as riftor does via ``lit.completion(..., stream=True)``).
+
+    This is the integration gap that unit tests on the chunk dict miss: the
+    terminal chunk's ``usage`` must be a plain mapping, because
+    ``CustomStreamWrapper`` does ``Usage(**chunk["usage"])``. A litellm ``Usage``
+    object there raises ``argument after ** must be a mapping, not Usage``
+    (surfaced as a ``MidStreamFallbackError``).
+    """
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    lines += _sse({"type": "response.output_text.delta", "delta": "Hel"})
+    lines += _sse({"type": "response.output_text.delta", "delta": "lo"})
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [],
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+            },
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider,
+        "_stream_responses",
+        lambda payload, headers, timeout=120.0: iter(lines),
+    )
+
+    from riftor.agent.provider import _get_litellm
+
+    lit = _get_litellm()
+    resp = lit.completion(
+        model="codex/gpt-5.5-codex",
+        custom_llm_provider="codex",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+
+    # Iterating the stream exercises CustomStreamWrapper end-to-end.
+    # Before the fix this raises (Usage not a mapping / MidStreamFallbackError).
+    chunks = list(resp)
+
+    text = "".join(
+        (c.choices[0].delta.content or "") for c in chunks if c.choices
+    )
+    assert text == "Hello"
+
+    # If litellm surfaces usage on the final chunk, the token counts round-trip.
+    usage = getattr(chunks[-1], "usage", None)
+    if usage is not None:
+        assert int(usage.prompt_tokens) == 5
+        assert int(usage.completion_tokens) == 3
+
+
 def test_streaming_tool_call_reply(tmp_path, monkeypatch):
     _future_auth(tmp_path)
 

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -707,6 +707,93 @@ def _sse(event: dict) -> list[str]:
 def test_bare_model_strips_prefix():
     assert codex_provider._bare_model("codex/gpt-5.5-codex") == "gpt-5.5-codex"
     assert codex_provider._bare_model("gpt-5.5-codex") == "gpt-5.5-codex"
+    # The internal route marker is stripped too, so the REAL model id reaches the
+    # Codex backend (litellm sees the marked id; the handler sees the real one).
+    assert codex_provider._bare_model("codex/riftorcodex-gpt-5.5") == "gpt-5.5"
+    assert codex_provider._bare_model("riftorcodex-gpt-5.5-codex") == "gpt-5.5-codex"
+
+
+def test_to_litellm_model_adds_marker():
+    # `codex/<real>` becomes a registry-opaque id so litellm routes to our handler
+    # instead of hijacking the bare name to its built-in OpenAI provider.
+    assert (
+        codex_provider.to_litellm_model("codex/gpt-5.5")
+        == "codex/riftorcodex-gpt-5.5"
+    )
+    assert (
+        codex_provider.to_litellm_model("codex/gpt-5.3-codex")
+        == "codex/riftorcodex-gpt-5.3-codex"
+    )
+
+
+def test_to_litellm_model_idempotent():
+    once = codex_provider.to_litellm_model("codex/gpt-5.5")
+    assert codex_provider.to_litellm_model(once) == once
+
+
+def test_to_litellm_model_passes_through_non_codex():
+    assert (
+        codex_provider.to_litellm_model("anthropic/claude-opus-4-8")
+        == "anthropic/claude-opus-4-8"
+    )
+    assert codex_provider.to_litellm_model("gpt-5.5") == "gpt-5.5"
+
+
+# --- end-to-end litellm routing (the gap that let the bug through) ---------
+
+
+@pytest.mark.parametrize("real", ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"])
+def test_real_codex_model_routes_to_our_handler(tmp_path, monkeypatch, real):
+    """Drive a REAL codex model name through litellm's actual dispatch.
+
+    litellm registry-matches the bare model name, so for known names (gpt-5.5,
+    gpt-5.3-codex, ...) it would otherwise hijack the call to its built-in OpenAI
+    provider and fail with a credentials error. We send litellm the marked,
+    registry-opaque id (exactly as riftor's ``_kwargs`` does) and assert the call
+    reaches our custom handler AND the backend receives the REAL (un-marked) name.
+    """
+    _future_auth(tmp_path)
+
+    recorded: dict = {}
+
+    lines: list[str] = []
+    lines += _sse({"type": "response.output_text.delta", "delta": "Hel"})
+    lines += _sse({"type": "response.output_text.delta", "delta": "lo"})
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [],
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+            },
+        }
+    )
+
+    def fake_stream(payload, headers, timeout=120.0):
+        recorded["model"] = payload["model"]
+        return iter(lines)
+
+    monkeypatch.setattr(codex_provider, "_stream_responses", fake_stream)
+
+    from riftor.agent.codex_provider import to_litellm_model
+    from riftor.agent.provider import _get_litellm
+
+    lit = _get_litellm()
+    litellm_model = to_litellm_model(f"codex/{real}")
+    # NOTE: no explicit custom_llm_provider — we rely on litellm routing from the
+    # model id alone, which is exactly what triggers the bug for known names.
+    resp = lit.completion(
+        model=litellm_model,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+    chunks = list(resp)
+
+    # Our handler was reached (no "Missing credentials"/CodexException) and the
+    # backend got the REAL model id, not the marked one.
+    assert recorded["model"] == real
+    text = "".join((c.choices[0].delta.content or "") for c in chunks if c.choices)
+    assert text == "Hello"
 
 
 def test_streaming_text_reply(tmp_path, monkeypatch):

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -486,3 +486,200 @@ def test_build_request_body_empty_assistant_text_skipped():
         instructions="ci",
     )
     assert body["input"] == []
+
+
+# --- parse_events (Task 4d) ------------------------------------------------
+
+
+def test_parse_events_text_deltas():
+    events = [
+        {"type": "response.output_text.delta", "delta": "Hel"},
+        {"type": "response.output_text.delta", "delta": "lo"},
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    assert len(chunks) == 2
+    assert chunks[0].text == "Hel"
+    assert chunks[0].reasoning == ""
+    assert chunks[0].is_finished is False
+    assert chunks[1].text == "lo"
+
+
+def test_parse_events_reasoning_delta():
+    for etype in (
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_text.delta",
+    ):
+        chunks = list(
+            codex_provider.parse_events([{"type": etype, "delta": "thinking"}])
+        )
+        assert len(chunks) == 1
+        assert chunks[0].reasoning == "thinking"
+        assert chunks[0].text == ""
+
+
+def test_parse_events_function_call_sequence():
+    events = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": "bash",
+                "call_id": "call_1",
+                "id": "item_1",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"cmd"',
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": ':"ls"}',
+        },
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    assert len(chunks) == 2
+    fragments = "".join(c.tool_call["arguments_delta"] for c in chunks)
+    assert fragments == '{"cmd":"ls"}'
+    for c in chunks:
+        assert c.tool_call["id"] == "call_1"
+        assert c.tool_call["name"] == "bash"
+
+
+def test_parse_events_completed_with_usage_tool_calls():
+    events = [
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "bash",
+                        "arguments": "{}",
+                        "call_id": "call_1",
+                    }
+                ],
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+            },
+        }
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    assert len(chunks) == 1
+    final = chunks[0]
+    assert final.is_finished is True
+    assert final.finish_reason == "tool_calls"
+    assert final.usage == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+
+
+def test_parse_events_completed_text_only_is_stop():
+    events = [
+        {"type": "response.output_text.delta", "delta": "hi"},
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "hi"}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 1,
+                    "total_tokens": 4,
+                },
+            },
+        },
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    final = chunks[-1]
+    assert final.is_finished is True
+    assert final.finish_reason == "stop"
+    assert final.usage["total_tokens"] == 4
+
+
+def test_parse_events_done_accepted_like_completed():
+    events = [
+        {
+            "type": "response.done",
+            "response": {"output": [], "usage": {"input_tokens": 1, "output_tokens": 2}},
+        }
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    assert len(chunks) == 1
+    assert chunks[0].is_finished is True
+    assert chunks[0].finish_reason == "stop"
+    assert chunks[0].usage["total_tokens"] == 3
+
+
+def test_parse_events_unknown_type_yields_nothing():
+    chunks = list(
+        codex_provider.parse_events([{"type": "response.something.weird", "x": 1}])
+    )
+    assert chunks == []
+
+
+def test_parse_events_missing_fields_never_raises():
+    # Odd/empty events must be tolerated via .get, not crash.
+    events = [
+        {},
+        {"type": "response.output_text.delta"},  # no delta
+        {"type": "response.function_call_arguments.delta"},  # no item_id/delta
+    ]
+    chunks = list(codex_provider.parse_events(events))
+    # Text delta with no "delta" coerces to empty string; tool-call delta still
+    # emits a (best-effort) chunk. Nothing raises.
+    assert all(isinstance(c, codex_provider.CodexChunk) for c in chunks)
+
+
+# --- iter_sse_lines (Task 4d) ----------------------------------------------
+
+
+def test_iter_sse_lines_basic_and_done():
+    lines = [
+        'data: {"type":"response.output_text.delta","delta":"hi"}',
+        "",
+        "data: [DONE]",
+    ]
+    events = list(codex_provider.iter_sse_lines(lines))
+    assert events == [{"type": "response.output_text.delta", "delta": "hi"}]
+
+
+def test_iter_sse_lines_skips_malformed_frame():
+    lines = [
+        "data: {not json",
+        "",
+        'data: {"type":"response.output_text.delta","delta":"ok"}',
+        "",
+    ]
+    events = list(codex_provider.iter_sse_lines(lines))
+    assert events == [{"type": "response.output_text.delta", "delta": "ok"}]
+
+
+def test_iter_sse_lines_ignores_event_and_comment_lines():
+    lines = [
+        ": this is a comment",
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"x"}',
+        "",
+    ]
+    events = list(codex_provider.iter_sse_lines(lines))
+    assert events == [{"type": "response.output_text.delta", "delta": "x"}]
+
+
+def test_iter_sse_lines_skips_blank_data_frame():
+    lines = [
+        "data: ",
+        "",
+        'data: {"type":"response.output_text.delta","delta":"y"}',
+        "",
+    ]
+    events = list(codex_provider.iter_sse_lines(lines))
+    assert events == [{"type": "response.output_text.delta", "delta": "y"}]

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -683,3 +683,285 @@ def test_iter_sse_lines_skips_blank_data_frame():
     ]
     events = list(codex_provider.iter_sse_lines(lines))
     assert events == [{"type": "response.output_text.delta", "delta": "y"}]
+
+
+# --- CustomLLM handler (Task 4e) -------------------------------------------
+
+
+def _future_auth(tmp_path) -> str:
+    """Write an auth.json with a far-future access token (no refresh fires)."""
+    at = _make_jwt(
+        {
+            "https://api.openai.com/auth": {"chatgpt_account_id": "acc-xyz"},
+            "exp": int(time.time()) + 3600,
+        }
+    )
+    _write_auth(tmp_path, {"access_token": at, "refresh_token": "rt-1"})
+    return at
+
+
+def _sse(event: dict) -> list[str]:
+    return [f"data: {json.dumps(event)}", ""]
+
+
+def test_bare_model_strips_prefix():
+    assert codex_provider._bare_model("codex/gpt-5.5-codex") == "gpt-5.5-codex"
+    assert codex_provider._bare_model("gpt-5.5-codex") == "gpt-5.5-codex"
+
+
+def test_streaming_text_reply(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+    captured: dict = {}
+
+    lines: list[str] = []
+    lines += _sse({"type": "response.output_text.delta", "delta": "Hel"})
+    lines += _sse({"type": "response.output_text.delta", "delta": "lo"})
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Hello"}],
+                    }
+                ],
+                "usage": {"input_tokens": 11, "output_tokens": 2, "total_tokens": 13},
+            },
+        }
+    )
+
+    def fake_stream(payload, headers, timeout=120.0):
+        captured["payload"] = payload
+        captured["headers"] = headers
+        return iter(lines)
+
+    monkeypatch.setattr(codex_provider, "_stream_responses", fake_stream)
+
+    chunks = list(
+        codex_provider.codex_provider.streaming(
+            "codex/gpt-5.5-codex", [{"role": "user", "content": "hi"}]
+        )
+    )
+
+    text = "".join(c["text"] or "" for c in chunks)
+    assert text == "Hello"
+
+    final = chunks[-1]
+    assert final["is_finished"] is True
+    usage = final["usage"]
+    assert usage is not None
+    assert int(usage["prompt_tokens"]) == 11
+    assert int(usage["completion_tokens"]) == 2
+
+    # The request body carried the bundled instructions prompt.
+    assert captured["payload"]["instructions"]
+    # Headers carry auth + the responses beta header.
+    assert captured["headers"]["Authorization"].startswith("Bearer ")
+    assert captured["headers"]["OpenAI-Beta"] == "responses=experimental"
+    # Account id resolved from the JWT becomes the chatgpt-account-id header.
+    assert captured["headers"]["chatgpt-account-id"] == "acc-xyz"
+    # Model prefix stripped before going on the wire.
+    assert captured["payload"]["model"] == "gpt-5.5-codex"
+
+
+async def test_astreaming_text_reply(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    lines += _sse({"type": "response.output_text.delta", "delta": "foo"})
+    lines += _sse({"type": "response.output_text.delta", "delta": "bar"})
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {"usage": {"input_tokens": 4, "output_tokens": 2}},
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider, "_stream_responses", lambda payload, headers, timeout=120.0: iter(lines)
+    )
+
+    collected = []
+    async for c in codex_provider.codex_provider.astreaming(
+        "gpt-5.5-codex", [{"role": "user", "content": "hi"}]
+    ):
+        collected.append(c)
+
+    assert "".join(c["text"] or "" for c in collected) == "foobar"
+    assert collected[-1]["is_finished"] is True
+
+
+def test_streaming_tool_call_reply(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    lines += _sse(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": "bash",
+                "call_id": "call_1",
+                "id": "item_1",
+            },
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"cmd"',
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": ':"ls"}',
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "bash",
+                        "arguments": '{"cmd":"ls"}',
+                        "call_id": "call_1",
+                    }
+                ],
+                "usage": {"input_tokens": 9, "output_tokens": 5},
+            },
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider, "_stream_responses", lambda payload, headers, timeout=120.0: iter(lines)
+    )
+
+    chunks = list(
+        codex_provider.codex_provider.streaming(
+            "gpt-5.5-codex", [{"role": "user", "content": "list files"}]
+        )
+    )
+
+    tool_chunks = [c for c in chunks if c["tool_use"]]
+    assert tool_chunks
+    names = [c["tool_use"]["function"]["name"] for c in tool_chunks if c["tool_use"]["function"]["name"]]
+    assert "bash" in names
+    args = "".join(c["tool_use"]["function"]["arguments"] or "" for c in tool_chunks)
+    assert args == '{"cmd":"ls"}'
+    # tool_use index is stable so the consumer reassembles one call.
+    assert all(c["tool_use"]["index"] == tool_chunks[0]["tool_use"]["index"] for c in tool_chunks)
+
+    final = chunks[-1]
+    assert final["is_finished"] is True
+    assert final["finish_reason"] == "tool_calls"
+
+
+def test_completion_non_stream_text(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    lines += _sse({"type": "response.output_text.delta", "delta": "Hel"})
+    lines += _sse({"type": "response.output_text.delta", "delta": "lo!"})
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {"usage": {"input_tokens": 6, "output_tokens": 3}},
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider, "_stream_responses", lambda payload, headers, timeout=120.0: iter(lines)
+    )
+
+    resp = codex_provider.codex_provider.completion(
+        "gpt-5.5-codex", [{"role": "user", "content": "hi"}]
+    )
+    assert resp.choices[0].message.content == "Hello!"
+    assert int(resp.usage.prompt_tokens) == 6
+    assert int(resp.usage.completion_tokens) == 3
+
+
+def test_completion_non_stream_tool_calls(tmp_path, monkeypatch):
+    _future_auth(tmp_path)
+
+    lines: list[str] = []
+    lines += _sse(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": "bash",
+                "call_id": "call_1",
+                "id": "item_1",
+            },
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_1",
+            "delta": '{"cmd":"ls"}',
+        }
+    )
+    lines += _sse(
+        {
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "bash",
+                        "arguments": '{"cmd":"ls"}',
+                        "call_id": "call_1",
+                    }
+                ],
+                "usage": {"input_tokens": 9, "output_tokens": 5},
+            },
+        }
+    )
+
+    monkeypatch.setattr(
+        codex_provider, "_stream_responses", lambda payload, headers, timeout=120.0: iter(lines)
+    )
+
+    resp = codex_provider.codex_provider.completion(
+        "gpt-5.5-codex", [{"role": "user", "content": "list"}]
+    )
+    calls = resp.choices[0].message.tool_calls
+    assert calls
+    assert calls[0].function.name == "bash"
+    assert calls[0].function.arguments == '{"cmd":"ls"}'
+    assert calls[0].id == "call_1"
+    assert resp.choices[0].finish_reason == "tool_calls"
+
+
+def test_streaming_auth_required_raises(tmp_path, monkeypatch):
+    # Empty CODEX_HOME -> no auth.json -> RuntimeError on iteration.
+    with pytest.raises(RuntimeError) as ei:
+        list(
+            codex_provider.codex_provider.streaming(
+                "gpt-5.5-codex", [{"role": "user", "content": "hi"}]
+            )
+        )
+    assert "codex login" in str(ei.value)
+
+
+def test_build_headers_omits_account_id_when_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(codex_provider, "account_id", lambda: None)
+    headers = codex_provider._build_headers("tok-1")
+    assert headers["Authorization"] == "Bearer tok-1"
+    assert "chatgpt-account-id" not in headers
+
+
+def test_resolve_access_token_refreshes_when_stale(tmp_path, monkeypatch):
+    _write_auth(tmp_path, {"access_token": "stale", "refresh_token": "rt-1"})
+    monkeypatch.setattr(codex_provider, "should_refresh", lambda at: True)
+    monkeypatch.setattr(codex_provider, "refresh_tokens", lambda: "fresh-token")
+    assert codex_provider._resolve_access_token() == "fresh-token"

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -251,3 +251,238 @@ def test_instructions_caches(monkeypatch):
     second = codex_provider.instructions_for("gpt-5.5-codex")
     assert first == second == "X"
     assert calls["n"] == 1
+
+
+# --- build_request_body (Task 4c) ------------------------------------------
+
+
+def test_build_request_body_system_becomes_developer_item():
+    body = codex_provider.build_request_body(
+        "gpt-5.5-codex",
+        [{"role": "system", "content": "RIFT system prompt"}],
+        instructions="canonical codex instructions",
+    )
+    # The RIFT system text rides along as the first developer item in input.
+    first = body["input"][0]
+    assert first["type"] == "message"
+    assert first["role"] == "developer"
+    assert first["content"][0]["type"] == "input_text"
+    assert first["content"][0]["text"] == "RIFT system prompt"
+    # instructions stays exactly what was passed in (not the system text).
+    assert body["instructions"] == "canonical codex instructions"
+
+
+def test_build_request_body_multiple_system_messages_concatenated():
+    body = codex_provider.build_request_body(
+        "m",
+        [
+            {"role": "system", "content": "first"},
+            {"role": "system", "content": "second"},
+        ],
+        instructions="ci",
+    )
+    first = body["input"][0]
+    assert first["role"] == "developer"
+    assert first["content"][0]["text"] == "first\n\nsecond"
+
+
+def test_build_request_body_user_message():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": "hello"}],
+        instructions="ci",
+    )
+    item = body["input"][0]
+    assert item == {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "hello"}],
+    }
+
+
+def test_build_request_body_assistant_tool_calls():
+    body = codex_provider.build_request_body(
+        "m",
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "bash", "arguments": '{"cmd":"ls"}'},
+                    }
+                ],
+            }
+        ],
+        instructions="ci",
+    )
+    item = body["input"][0]
+    assert item == {
+        "type": "function_call",
+        "name": "bash",
+        "arguments": '{"cmd":"ls"}',
+        "call_id": "call_1",
+    }
+
+
+def test_build_request_body_assistant_text_and_tool_calls():
+    body = codex_provider.build_request_body(
+        "m",
+        [
+            {
+                "role": "assistant",
+                "content": "thinking out loud",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "function": {"name": "grep", "arguments": "{}"},
+                    }
+                ],
+            }
+        ],
+        instructions="ci",
+    )
+    # Text message comes before the function_call item.
+    assert body["input"][0] == {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "input_text", "text": "thinking out loud"}],
+    }
+    assert body["input"][1]["type"] == "function_call"
+    assert body["input"][1]["call_id"] == "call_2"
+
+
+def test_build_request_body_tool_message():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "tool", "tool_call_id": "call_1", "content": "output text"}],
+        instructions="ci",
+    )
+    assert body["input"][0] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "output text",
+    }
+
+
+def test_build_request_body_top_level_fields():
+    body = codex_provider.build_request_body(
+        "gpt-5.5-codex",
+        [{"role": "user", "content": "hi"}],
+        instructions="ci",
+        reasoning_effort="high",
+        verbosity="low",
+    )
+    assert body["model"] == "gpt-5.5-codex"
+    assert body["store"] is False
+    assert body["stream"] is True
+    assert body["include"] == ["reasoning.encrypted_content"]
+    assert body["reasoning"]["summary"] == "auto"
+    assert body["reasoning"]["effort"] == "high"
+    assert body["text"]["verbosity"] == "low"
+
+
+def test_build_request_body_strips_sampling_params():
+    # Even if sampling params sneak in via message dicts, they must not appear.
+    body = codex_provider.build_request_body(
+        "m",
+        [
+            {
+                "role": "user",
+                "content": "hi",
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "max_tokens": 100,
+            }
+        ],
+        instructions="ci",
+    )
+    for key in (
+        "max_tokens",
+        "max_output_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+    ):
+        assert key not in body
+
+
+def test_build_request_body_flattens_tools():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        instructions="ci",
+    )
+    tool = body["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["name"] == "bash"
+    assert tool["description"] == "d"
+    assert tool["parameters"] == {"type": "object"}
+    assert "function" not in tool
+
+
+def test_build_request_body_tool_strict_preserved():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                },
+            }
+        ],
+        instructions="ci",
+    )
+    assert body["tools"][0]["strict"] is True
+
+
+def test_build_request_body_no_tools_omits_key():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": "hi"}],
+        instructions="ci",
+    )
+    assert "tools" not in body
+
+
+def test_build_request_body_content_as_list():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        instructions="ci",
+    )
+    assert body["input"][0]["content"][0]["text"] == "hi"
+
+
+def test_build_request_body_content_as_list_input_text_variant():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "user", "content": [{"type": "input_text", "text": "yo"}]}],
+        instructions="ci",
+    )
+    assert body["input"][0]["content"][0]["text"] == "yo"
+
+
+def test_build_request_body_empty_assistant_text_skipped():
+    body = codex_provider.build_request_body(
+        "m",
+        [{"role": "assistant", "content": ""}],
+        instructions="ci",
+    )
+    assert body["input"] == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,11 +218,16 @@ def test_codex_creds_are_none(monkeypatch):
     assert cfg.creds_for("codex/gpt-5.5-codex") == (None, None)
 
 
-def test_codex_has_credentials_like_ollama(monkeypatch):
+def test_codex_has_credentials_like_ollama():
     # Treated like ollama: never block the UI on a key. Real login validity is
     # surfaced as status, not a hard gate.
     cfg = Config(model="codex/gpt-5.5-codex")
     assert cfg.has_credentials()
+
+
+def test_codex_model_warning_is_none():
+    # codex/ is a known provider prefix; no spurious "unknown prefix" warning.
+    assert Config(model="codex/gpt-5.5-codex").model_warning() is None
 
 
 def test_codex_provider_env_is_none():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,6 +211,24 @@ def test_display_settings_default_and_roundtrip(tmp_path, monkeypatch):
     assert loaded.reasoning_effort == "high"
 
 
+def test_codex_creds_are_none(monkeypatch):
+    # Codex supplies no api_key/api_base from riftor; the litellm handler reads
+    # ~/.codex/auth.json itself. A stale global key must never leak to it.
+    cfg = Config(model="codex/gpt-5.5-codex", api_key="leftover-global")
+    assert cfg.creds_for("codex/gpt-5.5-codex") == (None, None)
+
+
+def test_codex_has_credentials_like_ollama(monkeypatch):
+    # Treated like ollama: never block the UI on a key. Real login validity is
+    # surfaced as status, not a hard gate.
+    cfg = Config(model="codex/gpt-5.5-codex")
+    assert cfg.has_credentials()
+
+
+def test_codex_provider_env_is_none():
+    assert Config(model="codex/gpt-5.5-codex").provider_env() is None
+
+
 def test_creds_for_openrouter_routed_id_is_miskeyed_known_limitation(monkeypatch):
     # KNOWN LIMITATION (deferred to picker tasks): a slash-routed OpenRouter id like
     # "openai/gpt-5.5" is classified by prefix as the "openai" provider, so creds stored

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -51,8 +51,9 @@ async def test_config_modal_renders_all_fields():
             # aligned label column: one .field-label per field row. WORKERS now has
             # 3 picker rows + 2 label rows (was 1 plain input + 2 labels) => +2.
             # +3 field rows for the DISPLAY section => 15 + 3 = 18, plus the
-            # GENERATION "Tool call steps" row => 19.
-            assert len(list(screen.query(".field-label"))) == 19
+            # GENERATION "Tool call steps" row => 19, plus the MODEL "Codex login"
+            # status row => 20.
+            assert len(list(screen.query(".field-label"))) == 20
             await pilot.press("escape")
             await pilot.pause()
 
@@ -265,6 +266,78 @@ async def test_worker_provider_switch_does_not_clobber_main_base():
         # the worker provider got ITS OWN default base, and reused the shared key
         assert app.config.providers["deepseek"].api_base == PROVIDERS["deepseek"].default_base
         assert app.config.providers["deepseek"].api_key == "sk-openai"
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_hides_key_base_fetch_shows_login(monkeypatch):
+    # Picking the Codex provider hides API-key/Base-URL/Fetch (Codex reads
+    # ~/.codex/auth.json — no key/base/model-list) and reveals the login status.
+    # Switching back to another provider restores the standard rows.
+    import riftor.tui.config_screen as cs
+    from riftor.codex_auth import CodexAuthStatus
+
+    monkeypatch.setattr(
+        cs, "auth_status",
+        lambda: CodexAuthStatus(logged_in=True, expires_in_s=600, detail="logged in (10m left)"))
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="anthropic/claude-opus-4-8")
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            app.query_one("#prompt", Input).value = "/config"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, ConfigScreen)
+
+            def row_hidden(wid: str) -> bool:
+                return screen.query_one(wid).parent.has_class("hidden")
+
+            # Non-codex provider: standard rows visible, status row hidden.
+            assert not row_hidden("#cfg-key")
+            assert not row_hidden("#cfg-base")
+            assert not row_hidden("#cfg-fetch")
+            assert row_hidden("#cfg-codex-status")
+
+            # Switch to Codex: key/base/fetch hidden, login status shown.
+            screen.query_one("#cfg-provider", Select).value = "codex"
+            await pilot.pause()
+            assert row_hidden("#cfg-key")
+            assert row_hidden("#cfg-base")
+            assert row_hidden("#cfg-fetch")
+            assert not row_hidden("#cfg-codex-status")
+            status_text = screen._codex_status_text()
+            assert "✓" in status_text and "logged in" in status_text
+
+            # Switch back: the standard rows return and the status hides.
+            screen.query_one("#cfg-provider", Select).value = "anthropic"
+            await pilot.pause()
+            assert not row_hidden("#cfg-key")
+            assert not row_hidden("#cfg-base")
+            assert not row_hidden("#cfg-fetch")
+            assert row_hidden("#cfg-codex-status")
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_codex_status_text_marks_logged_out(monkeypatch):
+    import riftor.tui.config_screen as cs
+    from riftor.codex_auth import CodexAuthStatus
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config(model="anthropic/claude-opus-4-8")
+        screen = ConfigScreen(cfg)
+        monkeypatch.setattr(
+            cs, "auth_status",
+            lambda: CodexAuthStatus(logged_in=False, expires_in_s=None,
+                                    detail="not logged in — run `codex login`"))
+        text = screen._codex_status_text()
+        assert text.startswith("⚠") and "not logged in" in text
+        monkeypatch.setattr(
+            cs, "auth_status",
+            lambda: CodexAuthStatus(logged_in=True, expires_in_s=60, detail="token present"))
+        assert screen._codex_status_text().startswith("✓")
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -293,11 +293,21 @@ async def test_codex_provider_hides_key_base_fetch_shows_login(monkeypatch):
             def row_hidden(wid: str) -> bool:
                 return screen.query_one(wid).parent.has_class("hidden")
 
+            def row_visible(wid: str) -> bool:
+                # Textual sets widget.display=False when `display: none` applies
+                # via CSS. This is the REAL visibility, so a missing
+                # `.field-row.hidden` rule would make a "hidden" row still True.
+                return screen.query_one(wid).parent.display
+
             # Non-codex provider: standard rows visible, status row hidden.
             assert not row_hidden("#cfg-key")
             assert not row_hidden("#cfg-base")
             assert not row_hidden("#cfg-fetch")
             assert row_hidden("#cfg-codex-status")
+            assert row_visible("#cfg-key")
+            assert row_visible("#cfg-base")
+            assert row_visible("#cfg-fetch")
+            assert not row_visible("#cfg-codex-status")
 
             # Switch to Codex: key/base/fetch hidden, login status shown.
             screen.query_one("#cfg-provider", Select).value = "codex"
@@ -306,6 +316,11 @@ async def test_codex_provider_hides_key_base_fetch_shows_login(monkeypatch):
             assert row_hidden("#cfg-base")
             assert row_hidden("#cfg-fetch")
             assert not row_hidden("#cfg-codex-status")
+            # Real computed visibility: the CSS rule must actually take effect.
+            assert not row_visible("#cfg-key")
+            assert not row_visible("#cfg-base")
+            assert not row_visible("#cfg-fetch")
+            assert row_visible("#cfg-codex-status")
             status_text = screen._codex_status_text()
             assert "✓" in status_text and "logged in" in status_text
 
@@ -316,6 +331,10 @@ async def test_codex_provider_hides_key_base_fetch_shows_login(monkeypatch):
             assert not row_hidden("#cfg-base")
             assert not row_hidden("#cfg-fetch")
             assert row_hidden("#cfg-codex-status")
+            assert row_visible("#cfg-key")
+            assert row_visible("#cfg-base")
+            assert row_visible("#cfg-fetch")
+            assert not row_visible("#cfg-codex-status")
             await pilot.press("escape")
             await pilot.pause()
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -93,6 +93,38 @@ def test_kwargs_uses_provider_table_creds(monkeypatch):
     assert kw["api_base"] == "https://table/"
 
 
+def test_get_litellm_registers_codex():
+    """_get_litellm() must register the codex custom handler into litellm."""
+    # Run registration fresh so the codex entry is guaranteed to be present.
+    saved = prov._litellm
+    try:
+        prov._litellm = None
+        lit = prov._get_litellm()
+        entries = list(getattr(lit, "custom_provider_map", None) or [])
+        providers = [e.get("provider") for e in entries]
+        assert "codex" in providers, f"'codex' not in custom_provider_map providers: {providers}"
+        codex_entry = next(e for e in entries if e.get("provider") == "codex")
+        assert codex_entry.get("custom_handler") is not None
+    finally:
+        prov._litellm = saved
+
+
+def test_get_litellm_registration_is_idempotent():
+    """Calling _get_litellm() multiple times must not duplicate the codex entry."""
+    saved = prov._litellm
+    try:
+        prov._litellm = None
+        lit = prov._get_litellm()
+        # Second call: _litellm is already cached, so registration won't re-run,
+        # but the guard must also prevent duplication if somehow called again.
+        prov._register_codex_provider(lit)  # call the guard directly a second time
+        entries = list(getattr(lit, "custom_provider_map", None) or [])
+        codex_count = sum(1 for e in entries if e.get("provider") == "codex")
+        assert codex_count == 1, f"Expected 1 codex entry, got {codex_count}"
+    finally:
+        prov._litellm = saved
+
+
 @pytest.mark.asyncio
 async def test_stream_turn_yields_thinking_and_excludes_it_from_message(monkeypatch):
     # Fake litellm streaming chunks: reasoning_content deltas, then content.

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -93,6 +93,20 @@ def test_kwargs_uses_provider_table_creds(monkeypatch):
     assert kw["api_base"] == "https://table/"
 
 
+def test_kwargs_marks_codex_model_for_litellm(monkeypatch):
+    monkeypatch.delenv("RIFTOR_DEMO_RESPONSE", raising=False)
+    cfg = Config(model="codex/gpt-5.5")
+    kw = prov.Provider(cfg)._kwargs([{"role": "user", "content": "hi"}])
+    assert kw["model"] == "codex/riftorcodex-gpt-5.5"
+
+
+def test_kwargs_leaves_non_codex_model_unchanged(monkeypatch):
+    monkeypatch.delenv("RIFTOR_DEMO_RESPONSE", raising=False)
+    cfg = Config(model="anthropic/claude-opus-4-8", api_key="sk-demo")
+    kw = prov.Provider(cfg)._kwargs([{"role": "user", "content": "hi"}])
+    assert kw["model"] == "anthropic/claude-opus-4-8"
+
+
 def test_get_litellm_registers_codex():
     """_get_litellm() must register the codex custom handler into litellm."""
     # Run registration fresh so the codex entry is guaranteed to be present.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -96,3 +96,31 @@ def test_fetch_curated_result_is_a_copy_not_the_module_list():
     res = pv.fetch_models("anthropic", None, None)
     assert res.models == pv.PROVIDER_DEFAULTS["anthropic"]
     assert res.models is not pv.PROVIDER_DEFAULTS["anthropic"]  # defensive copy
+
+
+def test_codex_provider_registered():
+    assert "codex" in pv.PROVIDERS
+    meta = pv.PROVIDERS["codex"]
+    assert meta.prefix == "codex/"
+    assert meta.env is None          # no API key env var
+    assert meta.list_kind == "codex"
+    assert meta.default_base is None
+    assert "codex" in pv.PROVIDER_DEFAULTS
+
+
+def test_codex_provider_key_and_prefix():
+    assert pv.provider_key_for_model("codex/gpt-5.5-codex") == "codex"
+    assert pv.apply_prefix("codex", "gpt-5.5-codex") == "codex/gpt-5.5-codex"
+    # an id that already carries the prefix passes through unchanged
+    assert pv.apply_prefix("codex", "codex/gpt-5.5") == "codex/gpt-5.5"
+
+
+def test_fetch_codex_returns_curated_without_network(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("must not hit the network for list_kind=codex")
+    monkeypatch.setattr(pv.urllib.request, "urlopen", boom)
+    monkeypatch.setattr(pv, "_http_get_json", boom)
+    res = pv.fetch_models("codex", None, None)
+    assert res.source == "curated"
+    assert res.error is None
+    assert res.models == pv.PROVIDER_DEFAULTS["codex"]

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -445,6 +445,20 @@ def test_dispatch_ollama_worker_needs_no_key(tmp_workdir, engagement, monkeypatc
     assert "no credentials for worker model" not in res.content
 
 
+def test_dispatch_codex_worker_needs_no_key(tmp_workdir, engagement, monkeypatch):
+    # codex/ worker auth lives in ~/.codex/auth.json; creds_for() returns (None, None)
+    # by design. The credential gate must treat codex/ as keyless, not refuse it.
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "ok")
+    cfg = Config(model="anthropic/claude-sonnet-4-6", chakla_model="codex/gpt-5.5-codex")
+    cfg.providers["anthropic"] = ProviderCreds(api_key="sk-anth-xxx")
+    ctx = tools_mod.ToolContext(
+        workdir=tmp_workdir, engagement=engagement, config=cfg,
+        permissions=Permissions(), audit=AuditLog(),
+    )
+    res = asyncio.run(DispatchChaklaTool().execute({"tasks": ["x"], "tools": []}, ctx))
+    assert "no credentials for worker model" not in res.content
+
+
 def test_toolcontext_progress_defaults_to_none(tmp_workdir, engagement):
     ctx = ToolContext(workdir=tmp_workdir, engagement=engagement)
     assert ctx.progress is None

--- a/uv.lock
+++ b/uv.lock
@@ -1610,7 +1610,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary

Adds a first-class **Codex (ChatGPT subscription)** provider so riftor users can run inference through their ChatGPT Plus/Pro/Team subscription instead of an API key. riftor reuses the token file written by OpenAI's official `codex login` (`~/.codex/auth.json`) and **vendors its own litellm `CustomLLM` handler** that bridges Chat Completions ↔ the undocumented Codex **Responses** backend.

- New `codex/` provider in the registry + `/config` picker (`Codex (ChatGPT)`), with a live login-status line; no API key/Base-URL/Fetch shown for Codex.
- Vendored handler `riftor/agent/codex_provider.py`: reads/refreshes the token (`auth.openai.com/oauth/token`, proactive ≤5 min before expiry, atomic `0o600` write-back), resolves `chatgpt-account-id` (token field or JWT claim), builds the Responses request (canonical Codex prompt in `instructions`; riftor's RIFT prompt as a `developer` message), parses the SSE stream back to Chat-Completions chunks. Registered into litellm via `custom_provider_map` inside the existing lazy-litellm seam — startup stays fast and the lazy-import invariant holds.
- Canonical Codex `instructions` prompt **bundled** (pinned to `openai/codex` `rust-v0.137.0`) with **opportunistic online refresh** (offline-safe fallback).
- `--doctor` reports Codex login status; status-bar context-window estimate (128k); docs in `docs/configuration.md`.
- **No new dependency** — the originally-planned `litellm-codex-oauth-provider` package is unpublished/git-only, so the handler is vendored instead (see the design spec).

## Test Plan

- [x] `make check` green — ruff, pyright (0 errors), 254 offline tests, smoke.
- [x] New offline unit tests: provider registry/creds, `codex_auth` status, the vendored handler (auth/refresh, account-id, request build, SSE parse, CustomLLM streaming/non-streaming, parallel-tool-call indices), `/config` Codex mode (incl. real visibility, not just DOM class), `--doctor` line, `subagent` keyless Codex worker.
- [x] `dev/smoke.py` drives a `codex/` model turn offline (no real `~/.codex` needed).
- [ ] **Manual live verification (requires a human with a ChatGPT subscription):** run `codex login`, then `uv run riftor --model codex/gpt-5.5-codex -p "say hi"` — confirm a real response and a token refresh. This is the only path that exercises the undocumented endpoint; CI cannot.

## Notes / risks

- The Codex backend (`chatgpt.com/backend-api/codex/responses`) is **undocumented and may change without notice**; the bundled `instructions` prompt self-heals online but drifts offline.
- Design + plan: `docs/superpowers/specs/2026-06-08-codex-chatgpt-login-design.md`, `docs/superpowers/plans/2026-06-08-codex-chatgpt-login.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)