### PR TITLE
Add Playwright browser capability (headed/headless)

### DIFF
--- a/completions/_riftor
+++ b/completions/_riftor
@@ -12,6 +12,7 @@ _riftor() {
     '--api-key[override the API key for this run]:key:' \
     '--workdir[engagement working directory]:dir:_files -/' \
     '--scope-file[load scope targets from a file]:file:_files' \
+    '--browser-headed[run the Playwright browser headed for this run]' \
     '(-p --prompt)'{-p,--prompt}'[run one task non-interactively]:prompt:' \
     '--headless[non-interactive mode]' \
     '(-h --help)'{-h,--help}'[show help]'

--- a/completions/riftor.bash
+++ b/completions/riftor.bash
@@ -5,7 +5,7 @@ _riftor() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--version --config --model --chakla-model --api-key --workdir --scope-file --prompt --headless --help"
+    opts="--version --config --model --chakla-model --api-key --workdir --scope-file --browser-headed --prompt --headless --help"
 
     case "$prev" in
         --workdir|--scope-file)

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -622,6 +622,32 @@ async def test_engagement() -> None:
     print("ENGAGEMENT OK")
 
 
+async def _browser_smoke() -> None:
+    """Lazy-launch → navigate (local fixture) → teardown. Skips if no Chromium."""
+    import importlib.util
+    from pathlib import Path
+
+    if importlib.util.find_spec("playwright") is None:
+        print("smoke: browser skipped (no playwright)")
+        return
+    cache = Path.home() / ".cache" / "ms-playwright"
+    if not (cache.exists() and any(cache.glob("chromium-*"))):
+        print("smoke: browser skipped (no Chromium binary)")
+        return
+    import tempfile
+    from riftor.config import Config
+    from riftor.tools import ToolContext
+    from riftor import tools
+
+    fixture = Path(__file__).parent.parent / "tests" / "fixtures" / "login.html"
+    with tempfile.TemporaryDirectory() as d:
+        ctx = ToolContext(workdir=Path(d), config=Config(browser_headless=True))
+        r = await tools.get("browser_navigate").execute({"url": fixture.as_uri()}, ctx)
+        assert not r.is_error and "Sign in" in r.content, r.content
+        await ctx.browser.close()
+    print("smoke: browser ok")
+
+
 if __name__ == "__main__":
     asyncio.run(main())
     asyncio.run(test_tools())
@@ -633,3 +659,4 @@ if __name__ == "__main__":
     test_cvss()
     test_report()
     test_session()
+    asyncio.run(_browser_smoke())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,8 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |
 | `result_preview_lines` | int | `25` | Lines of a tool result shown before `…/show <id>`. |
 | `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |
+| `browser_headless` | bool | `true` | Run the Playwright browser headless (good for servers/SSH). Set `false` to launch it visibly. |
+| `browser_persistent_profile` | bool | `false` | Reuse a profile at `.riftor/browser-profile/` (persists cookies/sessions). Default is incognito — a fresh context per launch. |
 | `chakla_model` | string | `anthropic/claude-haiku-4-5-20251001` | The cheap worker model used by dispatched Chakla subagents. |
 | `chakla_max_workers` | int | `5` | Max number of Chakla workers per dispatch batch. |
 | `chakla_timeout_s` | int | `300` | Per-worker wall-clock timeout in seconds. |
@@ -93,6 +95,35 @@ invocation and are not persisted to config.toml):
 | `--model MODEL` | `model` | Override the main-agent model. |
 | `--chakla-model MODEL` | `chakla_model` | Override the Chakla worker model. |
 | `--api-key KEY` | `api_key` | Override the API key. |
+| `--browser-headed` | `browser_headless` | Run the browser visibly for this run only (does not persist). |
+
+## Browser
+
+riftor can drive a real Chromium browser (via Playwright) for SPA recon and
+authenticated flows. The agent navigates pages, reads them as accessibility
+snapshots, clicks/types, screenshots, and inspects console + network traffic.
+
+Two `[riftor]` fields control how the browser launches:
+
+- `browser_headless` (default `true`) — headless is the default so it works on
+  servers and over SSH. Toggle it in `/config` (Display section), or run a single
+  visible session with the `--browser-headed` flag.
+- `browser_persistent_profile` (default `false`) — incognito by default, so a
+  pentest does not retain a client's session cookies between runs. Enable it (also
+  in the `/config` Display section) to persist a profile at `.riftor/browser-profile/`.
+
+Manage the browser at runtime with `/browser`: it prints status, `/browser headed`
+and `/browser headless` switch the mode (persisted to config), and `/browser close`
+tears the browser down.
+
+The browser launches lazily on first use, and Chromium binaries auto-install the
+first time a browser tool runs (`playwright install chromium`, ~150 MB, once).
+`riftor --doctor` and `/doctor` report browser readiness.
+
+Screenshots are saved to `.riftor/screenshots/`. They render inline in the terminal
+if the optional extra is installed (`pip install 'riftor[browser-ui]'`) on Python
+≥3.12 and the terminal supports Kitty or Sixel graphics; otherwise riftor shows the
+saved file path.
 
 ## Providers & models
 

--- a/docs/riftor.1
+++ b/docs/riftor.1
@@ -38,10 +38,15 @@ Run a single task non-interactively and exit (headless one-shot).
 .TP
 .B \-\-headless
 Non-interactive mode; reads the prompt from \fB\-\-prompt\fR or stdin.
+.TP
+.B \-\-browser\-headed
+Run the Playwright browser visibly for this run only (not persisted; default is headless).
 .SH IN-APP COMMANDS
 Type \fB/help\fR inside riftor for the full list, including \fB/scope\fR,
 \fB/stage\fR, \fB/findings\fR, \fB/report\fR, \fB/permissions\fR, \fB/cost\fR,
-\fB/retry\fR, \fB/continue\fR, \fB/compact\fR, \fB/timeline\fR and \fB/export\fR.
+\fB/retry\fR, \fB/continue\fR, \fB/compact\fR, \fB/timeline\fR, \fB/browser\fR and \fB/export\fR.
+\fB/browser\fR shows browser status; \fB/browser headed\fR / \fB/browser headless\fR
+switch the mode (persisted) and \fB/browser close\fR tears it down.
 .SH FILES
 .TP
 .I ~/.config/riftor/config.toml
@@ -72,6 +77,12 @@ Display name for the orchestrator agent (default: \fIBaaj\fR).
 .TP
 .B label_worker
 Display name for worker subagents (default: \fIChakla\fR).
+.TP
+.B browser_headless
+Run the Playwright browser headless (default: \fItrue\fR).
+.TP
+.B browser_persistent_profile
+Persist a browser profile at \fI.riftor/browser-profile/\fR; default is incognito (default: \fIfalse\fR).
 .SH ENVIRONMENT
 .TP
 .B ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY

--- a/docs/superpowers/plans/2026-06-09-playwright-browser.md
+++ b/docs/superpowers/plans/2026-06-09-playwright-browser.md
@@ -1,0 +1,1439 @@
+# Playwright Browser Capability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give riftor's agent a headed/headless Playwright browser — navigate, ref-tagged accessibility snapshot, click, type, screenshot, eval, console/network capture — wired into riftor's existing scope/permission/audit guardrails.
+
+**Architecture:** Embed the Python `playwright` package as native `Tool` subclasses (no MCP). A lazily-launched, session-scoped `BrowserManager` lives on `ToolContext` (mirroring `ctx.engagement`). The model perceives pages as a compact ref-tagged accessibility tree; screenshots save to `.riftor/screenshots/` and render inline via the optional `textual-image` extra with a path fallback. Profile is incognito by default, persistent opt-in via `/config`.
+
+**Tech Stack:** Python 3.11+, asyncio, `playwright` (async API), Textual, optional `textual-image[textual]`, pytest (`asyncio_mode=auto`, offline).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-09-playwright-browser-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `riftor/tools/browser.py` | `BrowserManager` + ref-snapshot helper + 8 browser `Tool` subclasses | Create |
+| `riftor/tools/base.py` | Add `browser: BrowserManager \| None` field to `ToolContext` | Modify |
+| `riftor/tools/__init__.py` | Register the 8 browser tools in `ALL_TOOLS` | Modify |
+| `riftor/config.py` | `browser_headless`, `browser_persistent_profile` fields + TOML | Modify |
+| `riftor/engagement/doctor.py` | Browser readiness row (package + binary) | Modify |
+| `riftor/__main__.py` | `--browser-headed` flag (per-run override) | Modify |
+| `riftor/tui/app.py` | Build `BrowserManager`, `/browser` command, teardown, first-run hint | Modify |
+| `riftor/headless.py` | Browser teardown in `finally` | Modify |
+| `pyproject.toml` | `playwright` core dep + `browser-ui` extra | Modify |
+| `completions/riftor.bash`, `completions/_riftor` | `--browser-headed` flag | Modify |
+| `tests/test_browser.py` | Mocked-unit + skip-guarded integration tests | Create |
+| `tests/fixtures/login.html` | Local static HTML fixture for integration tests | Create |
+| `dev/smoke.py` | Add skip-guarded browser smoke pass | Modify |
+
+**Naming contract (used across tasks — keep exact):**
+- `BrowserManager.page() -> Page` (async), `.close()` (async, idempotent), `.launched: bool`, `.snapshot_text() -> str`, `.resolve_ref(ref: str)` returns a Playwright `Locator` or raises `KeyError`.
+- Tool names: `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_screenshot`, `browser_eval`, `browser_console_messages`, `browser_network_requests`.
+- Config fields: `browser_headless: bool = True`, `browser_persistent_profile: bool = False`.
+
+---
+
+## Task 1: Add `playwright` dependency and the `browser-ui` extra
+
+**Files:**
+- Modify: `pyproject.toml:18-22` (dependencies), `pyproject.toml:24-32` (optional-dependencies)
+
+- [ ] **Step 1: Add `playwright` to core dependencies**
+
+In `pyproject.toml`, change the `dependencies` list to:
+
+```toml
+dependencies = [
+    "textual>=0.79",
+    "litellm>=1.55",
+    "pydantic>=2.6",
+    "playwright>=1.44",
+]
+```
+
+- [ ] **Step 2: Add the optional `browser-ui` extra**
+
+In `[project.optional-dependencies]`, add (alongside the existing `dev` block):
+
+```toml
+browser-ui = [
+    "textual-image[textual]>=0.13; python_version >= '3.12'",
+]
+```
+
+(The `python_version` marker keeps it from attempting install on 3.11, where `textual-image` is unsupported.)
+
+- [ ] **Step 3: Sync and regenerate the lockfile**
+
+Run: `uv sync --extra dev && uv run playwright install chromium`
+Expected: dependencies resolve; `uv.lock` updates; Chromium downloads (~150 MB).
+
+- [ ] **Step 4: Verify playwright imports**
+
+Run: `uv run python -c "from playwright.async_api import async_playwright; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build: add playwright core dep + optional browser-ui extra"
+```
+
+---
+
+## Task 2: Add `browser` field to `ToolContext`
+
+**Files:**
+- Modify: `riftor/tools/base.py:34-55` (`ToolContext` dataclass), `riftor/tools/base.py:10-13` (TYPE_CHECKING imports)
+- Test: `tests/test_browser.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_browser.py`:
+
+```python
+"""Browser tool behavior: context wiring, lifecycle, snapshot, scope, screenshots."""
+
+from __future__ import annotations
+
+import pytest
+
+from riftor.tools import ToolContext
+
+
+def test_toolcontext_has_browser_field_default_none():
+    ctx = ToolContext()
+    assert ctx.browser is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_browser.py::test_toolcontext_has_browser_field_default_none -v`
+Expected: FAIL — `AttributeError: 'ToolContext' object has no attribute 'browser'`
+
+- [ ] **Step 3: Add the field**
+
+In `riftor/tools/base.py`, under the TYPE_CHECKING block (lines 10-13) add:
+
+```python
+if TYPE_CHECKING:
+    from riftor.config import Config
+    from riftor.engagement import Engagement
+    from riftor.safety.audit import AuditLog
+    from riftor.safety.permissions import Permissions
+    from riftor.tools.browser import BrowserManager
+```
+
+In the `ToolContext` dataclass (after the `progress` field, ~line 55) add:
+
+```python
+    #: Lazily-launched, session-scoped browser. The first long-lived resource in
+    #: riftor (every other tool is stateless per call). None until a browser_*
+    #: tool launches it. Mirrors how ``engagement`` persists across calls.
+    browser: "BrowserManager | None" = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_browser.py::test_toolcontext_has_browser_field_default_none -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riftor/tools/base.py tests/test_browser.py
+git commit -m "feat: add browser field to ToolContext"
+```
+
+---
+
+## Task 3: `BrowserManager` — lazy launch + idempotent teardown
+
+**Files:**
+- Create: `riftor/tools/browser.py`
+- Test: `tests/test_browser.py`
+
+- [ ] **Step 1: Write the failing tests (mocked, no real browser)**
+
+Append to `tests/test_browser.py`:
+
+```python
+class _FakePage:
+    def __init__(self):
+        self.closed = False
+        self.url = "about:blank"
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeContext:
+    def __init__(self):
+        self.pages_created = 0
+        self.closed = False
+
+    async def new_page(self):
+        self.pages_created += 1
+        return _FakePage()
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_manager_lazy_no_launch_until_page(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    launches = {"n": 0}
+
+    async def fake_launch(self):
+        launches["n"] += 1
+        return _FakeContext(), _FakePage()
+
+    monkeypatch.setattr(bmod.BrowserManager, "_launch", fake_launch)
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    assert not mgr.launched
+    assert launches["n"] == 0
+    page = await mgr.page()
+    assert mgr.launched
+    assert launches["n"] == 1
+    # second call reuses, no relaunch
+    await mgr.page()
+    assert launches["n"] == 1
+    await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_manager_close_idempotent(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    ctx_obj = _FakeContext()
+
+    async def fake_launch(self):
+        return ctx_obj, _FakePage()
+
+    monkeypatch.setattr(bmod.BrowserManager, "_launch", fake_launch)
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    await mgr.page()
+    await mgr.close()
+    assert ctx_obj.closed
+    await mgr.close()  # second close must not raise
+    assert not mgr.launched
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_browser.py -k manager -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'riftor.tools.browser'`
+
+- [ ] **Step 3: Create `riftor/tools/browser.py` with the manager skeleton**
+
+```python
+"""Playwright browser: a lazily-launched, session-scoped BrowserManager plus the
+browser_* tools. The manager is riftor's first long-lived resource — every other
+tool is stateless per call. It lives on ToolContext (like ctx.engagement) and is
+torn down on app exit / session switch / explicit /browser close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.async_api import Locator, Page
+
+
+class BrowserError(Exception):
+    """Browser couldn't launch (binaries missing, install failed, etc.)."""
+
+
+class BrowserManager:
+    """Owns one Chromium context+page for the session. Lazy: nothing launches
+    until ``page()`` is first awaited."""
+
+    def __init__(self, workdir: Path, *, headless: bool, persistent: bool) -> None:
+        self._workdir = workdir
+        self._headless = headless
+        self._persistent = persistent
+        self._pw = None  # async_playwright context manager instance
+        self._context = None  # BrowserContext
+        self._page: "Page | None" = None
+        self._refs: dict[str, "Locator"] = {}
+        self.console_log: list[str] = []
+        self.network_log: list[str] = []
+
+    @property
+    def launched(self) -> bool:
+        return self._page is not None
+
+    async def _launch(self) -> tuple[object, "Page"]:
+        """Start Playwright + Chromium. Returns (context, page). Auto-installs
+        Chromium binaries on first use; raises BrowserError on failure."""
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:  # pragma: no cover - playwright is a core dep
+            raise BrowserError(f"playwright not installed: {exc}") from exc
+
+        self._pw = await async_playwright().start()
+        profile = self._workdir / ".riftor" / "browser-profile"
+        try:
+            context, page = await self._do_launch(profile)
+        except Exception as exc:  # noqa: BLE001 — likely missing browser binaries
+            if not await self._try_install():
+                raise BrowserError(
+                    "Chromium not available and auto-install failed. "
+                    "Run: playwright install chromium"
+                ) from exc
+            context, page = await self._do_launch(profile)
+        return context, page
+
+    async def _do_launch(self, profile: Path) -> tuple[object, "Page"]:
+        if self._persistent:
+            profile.mkdir(parents=True, exist_ok=True)
+            context = await self._pw.chromium.launch_persistent_context(
+                str(profile), headless=self._headless
+            )
+            page = context.pages[0] if context.pages else await context.new_page()
+        else:
+            browser = await self._pw.chromium.launch(headless=self._headless)
+            context = await browser.new_context()
+            page = await context.new_page()
+        return context, page
+
+    async def _try_install(self) -> bool:
+        """Run `playwright install chromium`. Returns True on success."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-m", "playwright", "install", "chromium",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+            )
+            await proc.communicate()
+            return proc.returncode == 0
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def page(self) -> "Page":
+        if self._page is None:
+            self._context, self._page = await self._launch()
+            self._attach_listeners(self._page)
+        return self._page
+
+    def _attach_listeners(self, page: "Page") -> None:
+        page.on("console", lambda m: self.console_log.append(f"[{m.type}] {m.text}"))
+        page.on(
+            "requestfinished",
+            lambda r: self.network_log.append(f"{r.method} {r.url}"),
+        )
+
+    async def close(self) -> None:
+        """Idempotent teardown."""
+        try:
+            if self._context is not None:
+                await self._context.close()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            if self._pw is not None:
+                await self._pw.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        self._context = None
+        self._page = None
+        self._pw = None
+        self._refs.clear()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_browser.py -k manager -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riftor/tools/browser.py tests/test_browser.py
+git commit -m "feat: BrowserManager lazy launch + idempotent teardown"
+```
+
+---
+
+## Task 4: Ref-tagged accessibility snapshot
+
+**Files:**
+- Modify: `riftor/tools/browser.py` (add `snapshot_text`, `resolve_ref`)
+- Test: `tests/test_browser.py`
+
+- [ ] **Step 1: Write the failing test (mocked page tree)**
+
+Append to `tests/test_browser.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_snapshot_text_tags_interactive_nodes(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    tree = {
+        "role": "WebArea",
+        "name": "",
+        "children": [
+            {"role": "heading", "name": "Sign in", "level": 1},
+            {"role": "textbox", "name": "Username"},
+            {"role": "button", "name": "Submit"},
+        ],
+    }
+
+    class _AxPage:
+        class accessibility:
+            @staticmethod
+            async def snapshot(interesting_only=False):
+                return tree
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    mgr._page = _AxPage()  # inject a fake page
+    text = await mgr.snapshot_text()
+    assert "heading \"Sign in\"" in text
+    assert "textbox \"Username\" [ref=e" in text
+    assert "button \"Submit\" [ref=e" in text
+    # non-interactive heading gets no ref
+    assert "heading \"Sign in\" [ref=" not in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_browser.py::test_snapshot_text_tags_interactive_nodes -v`
+Expected: FAIL — `AttributeError: 'BrowserManager' object has no attribute 'snapshot_text'`
+
+- [ ] **Step 3: Implement snapshot + ref resolution**
+
+Add to `BrowserManager` in `riftor/tools/browser.py`:
+
+```python
+    # roles the model can act on → these get a [ref=eN] tag
+    _INTERACTIVE = {
+        "button", "link", "textbox", "checkbox", "radio", "combobox",
+        "menuitem", "tab", "switch", "searchbox", "slider",
+    }
+
+    async def snapshot_text(self) -> str:
+        """Compact, ref-tagged accessibility tree of the current page. Interactive
+        nodes get a stable [ref=eN] id used by click/type. Refs reset each call."""
+        page = await self.page()
+        tree = await page.accessibility.snapshot(interesting_only=False)
+        self._refs.clear()
+        self._ref_targets: dict[str, dict] = {}
+        lines: list[str] = []
+        counter = {"n": 0}
+
+        def walk(node: dict, depth: int) -> None:
+            role = node.get("role", "")
+            if role in ("WebArea", "RootWebArea", "", "generic", "none"):
+                for child in node.get("children", []) or []:
+                    walk(child, depth)
+                return
+            name = node.get("name", "") or ""
+            indent = "  " * depth
+            label = f'{role} "{name}"' if name else role
+            if node.get("level"):
+                label += f" [level={node['level']}]"
+            if role in self._INTERACTIVE:
+                counter["n"] += 1
+                ref = f"e{counter['n']}"
+                self._ref_targets[ref] = node
+                label += f" [ref={ref}]"
+            lines.append(f"{indent}- {label}")
+            for child in node.get("children", []) or []:
+                walk(child, depth + 1)
+
+        if tree:
+            walk(tree, 0)
+        return "\n".join(lines) if lines else "(empty page)"
+
+    def resolve_ref(self, ref: str) -> "Locator":
+        """Map a ref id from the last snapshot to a Playwright locator. The
+        accessibility node carries role+name; we locate by ARIA role+name."""
+        node = getattr(self, "_ref_targets", {}).get(ref)
+        if node is None:
+            raise KeyError(ref)
+        role = node.get("role", "")
+        name = node.get("name", "") or ""
+        page = self._page
+        assert page is not None
+        if name:
+            return page.get_by_role(role, name=name).first
+        return page.get_by_role(role).first
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_browser.py::test_snapshot_text_tags_interactive_nodes -v`
+Expected: PASS
+
+- [ ] **Step 5: Add stale-ref test and verify**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_resolve_unknown_ref_raises(tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    with pytest.raises(KeyError):
+        mgr.resolve_ref("e99")
+```
+
+Run: `uv run pytest tests/test_browser.py -k "snapshot or ref" -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add riftor/tools/browser.py tests/test_browser.py
+git commit -m "feat: ref-tagged accessibility snapshot + ref resolution"
+```
+
+---
+
+## Task 5: The 8 browser tools
+
+**Files:**
+- Modify: `riftor/tools/browser.py` (add tool classes), `riftor/tools/__init__.py:1-78` (register)
+- Test: `tests/test_browser.py`
+
+- [ ] **Step 1: Write failing registration + flag tests**
+
+Append to `tests/test_browser.py`:
+
+```python
+def test_browser_tools_registered_with_correct_flags():
+    from riftor import tools
+
+    names = {t.name for t in tools.all_tools()}
+    expected = {
+        "browser_navigate", "browser_snapshot", "browser_click", "browser_type",
+        "browser_screenshot", "browser_eval", "browser_console_messages",
+        "browser_network_requests",
+    }
+    assert expected <= names
+
+    nav = tools.get("browser_navigate")
+    assert nav.scope_sensitive is True
+    assert nav.requires_permission is False
+
+    ev = tools.get("browser_eval")
+    assert ev.scope_sensitive is True
+    assert ev.requires_permission is True
+    assert ev.danger is True
+
+    # action-on-loaded-page tools are NOT independently scope-sensitive
+    for n in ("browser_click", "browser_type", "browser_snapshot", "browser_screenshot"):
+        assert tools.get(n).scope_sensitive is False
+
+
+@pytest.mark.asyncio
+async def test_navigate_without_browser_errors_cleanly(toolctx):
+    from riftor import tools
+
+    # toolctx.browser is None and config is None → tool must error, not crash
+    r = await tools.get("browser_navigate").execute({"url": "https://example.com"}, toolctx)
+    assert r.is_error
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_browser.py -k "registered or without_browser" -v`
+Expected: FAIL — `browser_navigate` not found / returns None.
+
+- [ ] **Step 3: Implement the tools**
+
+Add to `riftor/tools/browser.py` (after `BrowserManager`):
+
+```python
+from riftor.tools.base import Tool, ToolContext, ToolResult, resolve_path
+
+
+def _ensure_manager(ctx: ToolContext) -> "BrowserManager | None":
+    """Get-or-create the session BrowserManager from ctx. Returns None if there's
+    no config to derive settings from (bare test contexts)."""
+    if ctx.browser is not None:
+        return ctx.browser
+    if ctx.config is None:
+        return None
+    mgr = BrowserManager(
+        ctx.workdir,
+        headless=getattr(ctx.config, "browser_headless", True),
+        persistent=getattr(ctx.config, "browser_persistent_profile", False),
+    )
+    ctx.browser = mgr
+    return mgr
+
+
+class _BrowserTool(Tool):
+    """Shared error handling for browser tools."""
+
+    async def _manager(self, ctx: ToolContext) -> "BrowserManager":
+        mgr = _ensure_manager(ctx)
+        if mgr is None:
+            raise BrowserError("no active browser context (config unavailable)")
+        return mgr
+
+
+class BrowserNavigateTool(_BrowserTool):
+    name = "browser_navigate"
+    description = "Navigate the browser to a URL. Returns load status and a ref-tagged accessibility snapshot of the resulting page."
+    scope_sensitive = True
+    parameters = {
+        "type": "object",
+        "properties": {"url": {"type": "string", "description": "Absolute URL to load."}},
+        "required": ["url"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return str(args.get("url", ""))[:300]
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        url = str(args.get("url", "")).strip()
+        if not url:
+            return ToolResult("error: empty url", is_error=True)
+        try:
+            mgr = await self._manager(ctx)
+            page = await mgr.page()
+            resp = await page.goto(url, wait_until="domcontentloaded")
+            status = resp.status if resp else "?"
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"navigated → {page.url} [{status}]\n\n{snap}").truncated(
+                ctx.max_result_chars
+            )
+        except BrowserError as exc:
+            return ToolResult(f"error: {exc}", is_error=True)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: navigation failed: {exc}", is_error=True)
+
+
+class BrowserSnapshotTool(_BrowserTool):
+    name = "browser_snapshot"
+    description = "Return a ref-tagged accessibility snapshot of the current page."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        try:
+            mgr = await self._manager(ctx)
+            if not mgr.launched:
+                return ToolResult("error: no page loaded; use browser_navigate first", is_error=True)
+            return ToolResult(await mgr.snapshot_text()).truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: {exc}", is_error=True)
+
+
+class BrowserClickTool(_BrowserTool):
+    name = "browser_click"
+    description = "Click an element by its [ref=eN] id from the latest snapshot. Returns the new page snapshot."
+    parameters = {
+        "type": "object",
+        "properties": {"ref": {"type": "string", "description": "Element ref, e.g. e9."}},
+        "required": ["ref"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return f"ref={args.get('ref', '')}"
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        ref = str(args.get("ref", "")).strip()
+        try:
+            mgr = await self._manager(ctx)
+            try:
+                locator = mgr.resolve_ref(ref)
+            except KeyError:
+                return ToolResult(f"error: unknown ref '{ref}' — snapshot may be stale", is_error=True)
+            await locator.click()
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"clicked {ref}\n\n{snap}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: click failed: {exc}", is_error=True)
+
+
+class BrowserTypeTool(_BrowserTool):
+    name = "browser_type"
+    description = "Type text into an element by its [ref=eN] id. Set submit=true to press Enter after. Returns the new page snapshot."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "ref": {"type": "string"},
+            "text": {"type": "string"},
+            "submit": {"type": "boolean", "description": "Press Enter after typing."},
+        },
+        "required": ["ref", "text"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return f"ref={args.get('ref', '')} text={str(args.get('text', ''))[:40]!r}"
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        ref = str(args.get("ref", "")).strip()
+        text = str(args.get("text", ""))
+        try:
+            mgr = await self._manager(ctx)
+            try:
+                locator = mgr.resolve_ref(ref)
+            except KeyError:
+                return ToolResult(f"error: unknown ref '{ref}' — snapshot may be stale", is_error=True)
+            await locator.fill(text)
+            if args.get("submit"):
+                await locator.press("Enter")
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"typed into {ref}\n\n{snap}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: type failed: {exc}", is_error=True)
+
+
+class BrowserScreenshotTool(_BrowserTool):
+    name = "browser_screenshot"
+    description = "Save a PNG screenshot of the current page to .riftor/screenshots/ and return its path."
+    parameters = {
+        "type": "object",
+        "properties": {"full_page": {"type": "boolean", "description": "Capture full scrollable page."}},
+    }
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        try:
+            mgr = await self._manager(ctx)
+            if not mgr.launched:
+                return ToolResult("error: no page loaded; use browser_navigate first", is_error=True)
+            page = await mgr.page()
+            shots = ctx.workdir / ".riftor" / "screenshots"
+            shots.mkdir(parents=True, exist_ok=True)
+            n = len(list(shots.glob("*.png"))) + 1
+            path = shots / f"{n:03d}.png"
+            await page.screenshot(path=str(path), full_page=bool(args.get("full_page")))
+            size = path.stat().st_size
+            return ToolResult(f"screenshot saved → {path} ({size} bytes)\npage: {page.url}")
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: screenshot failed: {exc}", is_error=True)
+
+
+class BrowserEvalTool(_BrowserTool):
+    name = "browser_eval"
+    description = "Execute arbitrary JavaScript in the current page and return its result. Powerful and dangerous — like running shell code in the browser."
+    scope_sensitive = True
+    requires_permission = True
+    danger = True
+    parameters = {
+        "type": "object",
+        "properties": {"js": {"type": "string", "description": "JavaScript expression to evaluate."}},
+        "required": ["js"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return str(args.get("js", ""))[:300]
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        js = str(args.get("js", ""))
+        try:
+            mgr = await self._manager(ctx)
+            page = await mgr.page()
+            value = await page.evaluate(js)
+            return ToolResult(f"{value!r}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: eval failed: {exc}", is_error=True)
+
+
+class BrowserConsoleMessagesTool(_BrowserTool):
+    name = "browser_console_messages"
+    description = "Return console messages captured from the current page (errors, warnings, logged values)."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        mgr = _ensure_manager(ctx)
+        if mgr is None or not mgr.launched:
+            return ToolResult("(no browser activity)")
+        log = mgr.console_log[-200:]
+        return ToolResult("\n".join(log) if log else "(no console messages)").truncated(
+            ctx.max_result_chars
+        )
+
+
+class BrowserNetworkRequestsTool(_BrowserTool):
+    name = "browser_network_requests"
+    description = "Return the network requests (method + URL) captured from the current page."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        mgr = _ensure_manager(ctx)
+        if mgr is None or not mgr.launched:
+            return ToolResult("(no browser activity)")
+        log = mgr.network_log[-200:]
+        return ToolResult("\n".join(log) if log else "(no requests captured)").truncated(
+            ctx.max_result_chars
+        )
+```
+
+- [ ] **Step 4: Register the tools in `ALL_TOOLS`**
+
+In `riftor/tools/__init__.py`, add imports after the `from riftor.tools.subagent import DispatchChaklaTool` line (line 33):
+
+```python
+from riftor.tools.browser import (
+    BrowserClickTool,
+    BrowserConsoleMessagesTool,
+    BrowserEvalTool,
+    BrowserNavigateTool,
+    BrowserNetworkRequestsTool,
+    BrowserScreenshotTool,
+    BrowserSnapshotTool,
+    BrowserTypeTool,
+)
+```
+
+In the `ALL_TOOLS` list, insert the read-ish browser tools after `WebFetchTool()` (line 41) and put `BrowserEvalTool()` near the mutating tools. Final list ordering — insert these:
+
+After `WebFetchTool(),`:
+```python
+    BrowserNavigateTool(),
+    BrowserSnapshotTool(),
+    BrowserClickTool(),
+    BrowserTypeTool(),
+    BrowserScreenshotTool(),
+    BrowserConsoleMessagesTool(),
+    BrowserNetworkRequestsTool(),
+```
+And after `BashTool(),` (the last mutating tool, line 60):
+```python
+    BrowserEvalTool(),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_browser.py -k "registered or without_browser" -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Run full suite + lint + typecheck**
+
+Run: `uv run pytest tests/test_browser.py -v && uv run ruff check riftor && uv run pyright riftor/tools/browser.py`
+Expected: all PASS / no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add riftor/tools/browser.py riftor/tools/__init__.py tests/test_browser.py
+git commit -m "feat: add 8 browser tools wired into the registry"
+```
+
+---
+
+## Task 6: Config fields for headed/headless + profile
+
+**Files:**
+- Modify: `riftor/config.py:66-72` (fields), `riftor/config.py:223-241` (`_to_toml`)
+- Test: `tests/test_browser.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_browser.py`:
+
+```python
+def test_config_browser_defaults_and_toml():
+    from riftor.config import Config
+
+    cfg = Config()
+    assert cfg.browser_headless is True
+    assert cfg.browser_persistent_profile is False
+    toml = cfg._to_toml()
+    assert "browser_headless = true" in toml
+    assert "browser_persistent_profile = false" in toml
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_browser.py::test_config_browser_defaults_and_toml -v`
+Expected: FAIL — `AttributeError` / fields missing from TOML.
+
+- [ ] **Step 3: Add the fields**
+
+In `riftor/config.py`, after the `rate_limit_per_min` field (line 72) add:
+
+```python
+    # Browser (Playwright). Incognito by default — a pentest tool must not silently
+    # persist a client's session cookies. Persistent profile is opt-in via /config.
+    browser_headless: bool = True
+    browser_persistent_profile: bool = False
+```
+
+In `_to_toml()`, in the `lines += [...]` block after `f"rate_limit_per_min = {self.rate_limit_per_min}",` (line 234) add:
+
+```python
+            f"browser_headless = {str(self.browser_headless).lower()}",
+            f"browser_persistent_profile = {str(self.browser_persistent_profile).lower()}",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_browser.py::test_config_browser_defaults_and_toml -v`
+Expected: PASS
+
+- [ ] **Step 5: Run config tests for regressions**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS (round-trip load/save still works).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add riftor/config.py tests/test_browser.py
+git commit -m "feat: browser_headless + browser_persistent_profile config"
+```
+
+---
+
+## Task 7: Doctor browser readiness row
+
+**Files:**
+- Modify: `riftor/engagement/doctor.py` (add a browser check + render in both functions)
+- Test: `tests/test_doctor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_doctor.py`:
+
+```python
+def test_browser_status_in_plain_report():
+    from riftor.engagement import doctor
+
+    text = doctor.render_plain(doctor.check_toolchain())
+    assert "browser" in text.lower()
+    assert "playwright" in text.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_doctor.py::test_browser_status_in_plain_report -v`
+Expected: FAIL — no "browser" string in the report.
+
+- [ ] **Step 3: Add a browser-readiness helper + render it**
+
+In `riftor/engagement/doctor.py`, after `summarize(...)` (line 72) add:
+
+```python
+def browser_status() -> tuple[bool, bool, str]:
+    """Return (package_ok, binary_ok, detail) for the Playwright browser."""
+    try:
+        import importlib.util
+
+        pkg_ok = importlib.util.find_spec("playwright") is not None
+    except Exception:  # noqa: BLE001
+        pkg_ok = False
+    binary_ok = False
+    if pkg_ok:
+        from pathlib import Path
+
+        # Playwright caches browsers under ~/.cache/ms-playwright (Linux/macOS).
+        cache = Path.home() / ".cache" / "ms-playwright"
+        binary_ok = cache.exists() and any(cache.glob("chromium-*"))
+    if not pkg_ok:
+        detail = "playwright package not installed"
+    elif not binary_ok:
+        detail = "Chromium not installed — run: playwright install chromium"
+    else:
+        detail = "ready (chromium installed)"
+    return pkg_ok, binary_ok, detail
+```
+
+In `render_plain(...)` before the final `return "\n".join(lines)` (after the Codex block, ~line 121) add:
+
+```python
+    pkg_ok, binary_ok, detail = browser_status()
+    mark = "ok " if (pkg_ok and binary_ok) else "MISSING"
+    lines.append("Browser (Playwright):")
+    lines.append(f"  [{mark}] {'browser':<10} {detail}")
+```
+
+In `render_markdown(...)` before its `summary = summarize(...)` line (line 94) add:
+
+```python
+    pkg_ok, binary_ok, detail = browser_status()
+    bmark = "✓" if (pkg_ok and binary_ok) else "✗"
+    lines.append("_Browser_")
+    lines.append(f"- {bmark} `browser` (Playwright) — {detail}")
+    lines.append("")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_doctor.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riftor/engagement/doctor.py tests/test_doctor.py
+git commit -m "feat: doctor reports Playwright browser readiness"
+```
+
+---
+
+## Task 8: `--browser-headed` CLI flag (per-run override)
+
+**Files:**
+- Modify: `riftor/__main__.py:30-44` (argparse), `riftor/__main__.py:60-67` (apply override)
+- Modify: `completions/riftor.bash`, `completions/_riftor`
+
+- [ ] **Step 1: Add the argparse flag**
+
+In `riftor/__main__.py`, after the `--scope-file` argument (line 32) add:
+
+```python
+    parser.add_argument(
+        "--browser-headed", dest="browser_headed", action="store_true",
+        help="run the Playwright browser headed (visible) for this run",
+    )
+```
+
+- [ ] **Step 2: Apply the override (per-run, not persisted)**
+
+After `if args.api_key: cfg.api_key = args.api_key` (line ~67) add:
+
+```python
+    if args.browser_headed:
+        cfg.browser_headless = False  # this run only; not written to config.toml
+```
+
+- [ ] **Step 3: Update shell completions**
+
+In `completions/riftor.bash`, add `--browser-headed` to the flag list (find the line listing `--scope-file` and add it alongside).
+In `completions/_riftor`, add a line in the `_arguments` block:
+
+```
+'--browser-headed[run the Playwright browser headed for this run]'
+```
+
+- [ ] **Step 4: Verify the flag parses**
+
+Run: `uv run riftor --browser-headed --doctor`
+Expected: doctor output prints (flag accepted, no error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riftor/__main__.py completions/riftor.bash completions/_riftor
+git commit -m "feat: --browser-headed per-run flag + completions"
+```
+
+---
+
+## Task 9: TUI lifecycle — `/browser` command, teardown, first-run hint
+
+**Files:**
+- Modify: `riftor/tui/app.py:53-59` (`_COMMANDS`), `:61-95` (HELP), `:466-506` (handler dict), add `_browser_cmd`, add `on_unmount`, add first-run hint in `_run_tool`
+- Test: covered by smoke (Task 11); logic kept thin.
+
+- [ ] **Step 1: Add `/browser` to the command list and help**
+
+In `_COMMANDS` (line 58), add `"/browser"` to the list (before `"/exit"`).
+In `HELP`, under `_Settings & sessions_` add a line:
+
+```
+- `/browser [headed|headless|close]` — browser status / mode / teardown
+```
+
+- [ ] **Step 2: Register the handler**
+
+In the `handlers` dict in `_command` (after `"/doctor": self._doctor_cmd,`, line 501) add:
+
+```python
+            "/browser": lambda: self._browser_cmd(arg),
+```
+
+- [ ] **Step 3: Implement `_browser_cmd` and `on_unmount`**
+
+Add a method near `_doctor_cmd` (line 960):
+
+```python
+    def _browser_cmd(self, arg: str) -> None:
+        sub = (arg or "").strip().lower()
+        mgr = self.toolctx.browser
+        if sub in ("headed", "headless"):
+            self.config.browser_headless = sub == "headless"
+            self.config.save()
+            self._note(f"browser mode → {sub} (applies on next launch)")
+            return
+        if sub == "close":
+            if mgr is not None and mgr.launched:
+                self.run_worker(mgr.close(), exclusive=False)
+                self._note("browser closed")
+            else:
+                self._note("no browser running")
+            return
+        mode = "headless" if self.config.browser_headless else "headed"
+        profile = "persistent" if self.config.browser_persistent_profile else "incognito"
+        state = "running" if (mgr and mgr.launched) else "not launched"
+        self._note(f"browser: {state} · {mode} · {profile} (toggle in /config)")
+```
+
+Add an `on_unmount` method (near `on_mount`, line 222) — if one exists, add the teardown into it instead:
+
+```python
+    async def on_unmount(self) -> None:
+        mgr = self.toolctx.browser
+        if mgr is not None and mgr.launched:
+            try:
+                await mgr.close()
+            except Exception:  # noqa: BLE001
+                pass
+```
+
+- [ ] **Step 4: Add the one-time first-run incognito hint**
+
+In `_run_tool` (line 1314), right after `tool = tools.get(call.name)` resolves and before execution — add a guarded note. Add an instance flag in `__init__` (after `self._autoscroll = True`, line 186):
+
+```python
+        self._browser_hint_shown = False
+```
+
+Then in `_run_tool`, just before `result = await tool.execute(...)` (line 1383):
+
+```python
+        if call.name.startswith("browser_") and not self._browser_hint_shown:
+            self._browser_hint_shown = True
+            if not self.config.browser_persistent_profile:
+                self._note(
+                    "browser running in incognito (nothing saved) · enable persistent "
+                    "profile in /config to keep cookies/logins across runs"
+                )
+```
+
+- [ ] **Step 5: Verify the app boots and the command exists**
+
+Run: `uv run python -c "from riftor.tui.app import RiftorApp, _COMMANDS; assert '/browser' in _COMMANDS; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 6: Lint + typecheck**
+
+Run: `uv run ruff check riftor && uv run pyright riftor`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add riftor/tui/app.py
+git commit -m "feat: /browser command, teardown on unmount, first-run incognito hint"
+```
+
+---
+
+## Task 10: Headless teardown
+
+**Files:**
+- Modify: `riftor/headless.py:104-132` (wrap loop in try/finally to close the browser)
+
+- [ ] **Step 1: Wrap the step loop so the browser always closes**
+
+In `riftor/headless.py`, in `_run`, change the `for _ in range(max_steps):` loop (lines 104-130) to be inside a `try/finally`:
+
+```python
+    context.add_user(prompt)
+    max_steps = 10**9 if yolo else cfg.max_steps
+    try:
+        for _ in range(max_steps):
+            context.repair()
+            text_parts: list[str] = []
+            turn = None
+            try:
+                async for event, payload in provider.stream_turn(context.messages, schemas):
+                    if event == "thinking":
+                        if cfg.show_thinking:
+                            sys.stderr.write(str(payload))
+                            sys.stderr.flush()
+                    elif event == "text":
+                        sys.stdout.write(str(payload))
+                        sys.stdout.flush()
+                        text_parts.append(str(payload))
+                    elif event == "done":
+                        turn = payload  # type: ignore[assignment]
+            except ProviderError as exc:
+                print(f"\nriftor: provider error [{exc.kind}] — {exc}", file=sys.stderr)
+                return 1
+            if turn is None:
+                break
+            context.add_message(turn.assistant_message)
+            if not turn.tool_calls:
+                break
+            for call in turn.tool_calls:
+                await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
+    finally:
+        if toolctx.browser is not None and toolctx.browser.launched:
+            try:
+                await toolctx.browser.close()
+            except Exception:  # noqa: BLE001
+                pass
+    print()  # trailing newline
+    return 0
+```
+
+(Note: the `return 1` on ProviderError still runs the `finally` — the browser closes either way.)
+
+- [ ] **Step 2: Verify headless still runs offline**
+
+Run: `RIFTOR_DEMO_RESPONSE="done" uv run riftor -p "say hi" --workdir /tmp/riftor-hl-test`
+Expected: prints the demo response, exits 0, no leaked process.
+
+- [ ] **Step 3: Lint**
+
+Run: `uv run ruff check riftor/headless.py`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add riftor/headless.py
+git commit -m "feat: tear down browser at end of headless run"
+```
+
+---
+
+## Task 11: Real-browser integration tests + smoke (skip-guarded)
+
+**Files:**
+- Create: `tests/fixtures/login.html`
+- Modify: `tests/test_browser.py` (integration tests), `dev/smoke.py`
+
+- [ ] **Step 1: Create the local static fixture**
+
+Create `tests/fixtures/login.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>Login Fixture</title></head>
+<body>
+  <header><a href="#home">Home</a></header>
+  <main>
+    <h1>Sign in</h1>
+    <form>
+      <label>Username <input type="text" aria-label="Username"></label>
+      <label>Password <input type="password" aria-label="Password"></label>
+      <button type="button" onclick="document.title='clicked'">Submit</button>
+    </form>
+  </main>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write skip-guarded integration tests**
+
+Append to `tests/test_browser.py`:
+
+```python
+import importlib.util
+from pathlib import Path
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "login.html"
+
+
+def _browser_available() -> bool:
+    if importlib.util.find_spec("playwright") is None:
+        return False
+    cache = Path.home() / ".cache" / "ms-playwright"
+    return cache.exists() and any(cache.glob("chromium-*"))
+
+
+requires_browser = pytest.mark.skipif(
+    not _browser_available(), reason="playwright/Chromium not installed"
+)
+
+
+@requires_browser
+@pytest.mark.asyncio
+async def test_real_navigate_snapshot_click(tmp_workdir):
+    from riftor.config import Config
+    from riftor.tools import ToolContext
+    from riftor import tools
+
+    ctx = ToolContext(workdir=tmp_workdir, config=Config(browser_headless=True))
+    url = _FIXTURE.as_uri()
+    r = await tools.get("browser_navigate").execute({"url": url}, ctx)
+    assert not r.is_error
+    assert "Sign in" in r.content
+    assert "[ref=e" in r.content  # interactive elements got refs
+    # find a ref for the Submit button from the snapshot text
+    import re
+    refs = re.findall(r"button \"Submit\" \[ref=(e\d+)\]", r.content)
+    assert refs, r.content
+    rc = await tools.get("browser_click").execute({"ref": refs[0]}, ctx)
+    assert not rc.is_error
+    # screenshot writes a file
+    rs = await tools.get("browser_screenshot").execute({}, ctx)
+    assert not rs.is_error
+    assert (tmp_workdir / ".riftor" / "screenshots" / "001.png").exists()
+    await ctx.browser.close()
+```
+
+- [ ] **Step 3: Run integration test (passes if browser present, skips otherwise)**
+
+Run: `uv run pytest tests/test_browser.py::test_real_navigate_snapshot_click -v`
+Expected: PASS (browser installed in Task 1) — or SKIP on a machine without Chromium.
+
+- [ ] **Step 4: Add a skip-guarded smoke pass**
+
+`dev/smoke.py` defines several top-level functions and runs them from a
+`if __name__ == "__main__":` block (e.g. `asyncio.run(main())`,
+`asyncio.run(test_tools())`, ...). Add a new standalone async function and call
+it from that block. Add this function near the other test functions:
+
+```python
+async def _browser_smoke() -> None:
+    """Lazy-launch → navigate (local fixture) → teardown. Skips if no Chromium."""
+    import importlib.util
+    from pathlib import Path
+
+    if importlib.util.find_spec("playwright") is None:
+        print("smoke: browser skipped (no playwright)")
+        return
+    cache = Path.home() / ".cache" / "ms-playwright"
+    if not (cache.exists() and any(cache.glob("chromium-*"))):
+        print("smoke: browser skipped (no Chromium binary)")
+        return
+    import tempfile
+    from riftor.config import Config
+    from riftor.tools import ToolContext
+    from riftor import tools
+
+    fixture = Path(__file__).parent.parent / "tests" / "fixtures" / "login.html"
+    with tempfile.TemporaryDirectory() as d:
+        ctx = ToolContext(workdir=Path(d), config=Config(browser_headless=True))
+        r = await tools.get("browser_navigate").execute({"url": fixture.as_uri()}, ctx)
+        assert not r.is_error and "Sign in" in r.content, r.content
+        await ctx.browser.close()
+    print("smoke: browser ok")
+```
+
+Then add `asyncio.run(_browser_smoke())` as the last line inside the
+`if __name__ == "__main__":` block (after `test_session()`).
+
+- [ ] **Step 5: Run the smoke test**
+
+Run: `uv run python dev/smoke.py`
+Expected: existing smoke output + `smoke: browser ok` (or a skip line).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/login.html tests/test_browser.py dev/smoke.py
+git commit -m "test: real-browser integration tests + smoke (skip-guarded)"
+```
+
+---
+
+## Task 12: Inline screenshot rendering in the TUI (optional `textual-image`)
+
+**Files:**
+- Modify: `riftor/tui/app.py` — top-of-file soft import; render screenshot results inline in `_run_tool` after `browser_screenshot`.
+
+- [ ] **Step 1: Add the soft import at module top**
+
+Near the top of `riftor/tui/app.py` (with the other imports), add:
+
+```python
+# Optional inline image rendering. textual-image needs Python >= 3.12 and a
+# graphics-capable terminal (Kitty/Sixel); import at module top per its detection
+# requirement. A failed import simply means we show the screenshot path instead.
+try:
+    from textual_image.widget import Image as _InlineImage  # type: ignore
+except Exception:  # noqa: BLE001 — never let a missing optional dep break startup
+    _InlineImage = None
+```
+
+- [ ] **Step 2: Render the screenshot inline after a successful `browser_screenshot`**
+
+In `_run_tool`, after `await self._show_tool_result(result.content, is_error=result.is_error)` (line 1399), add:
+
+```python
+        if (
+            call.name == "browser_screenshot"
+            and not result.is_error
+            and _InlineImage is not None
+        ):
+            # parse "screenshot saved → <path> (...)" from the result content
+            import re
+
+            m = re.search(r"saved → (\S+\.png)", result.content)
+            if m:
+                from pathlib import Path as _P
+
+                shot = _P(m.group(1))
+                if shot.exists():
+                    try:
+                        await self._mount(_InlineImage(str(shot)))
+                    except Exception:  # noqa: BLE001 — fall back to the path line already shown
+                        pass
+```
+
+(The path line is always shown by `_show_tool_result`; inline rendering is purely additive, so the path fallback is automatic when `_InlineImage` is None or rendering fails — including inside tmux.)
+
+- [ ] **Step 3: Verify startup is unaffected on 3.11 (import is None) and 3.12**
+
+Run: `uv run python -c "from riftor.tui import app; print('inline:', app._InlineImage is not None)"`
+Expected: `ok` — prints `inline: True` or `inline: False` depending on environment; either way no crash.
+
+- [ ] **Step 4: Lint + typecheck + full suite**
+
+Run: `uv run ruff check riftor && uv run pyright riftor && uv run pytest`
+Expected: all PASS / no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add riftor/tui/app.py
+git commit -m "feat: render browser screenshots inline when terminal supports it"
+```
+
+---
+
+## Task 13: Docs + system prompt awareness
+
+**Files:**
+- Modify: `docs/configuration.md` (browser config options), `docs/riftor.1` (man page: `--browser-headed`, `/browser`), `riftor/agent/prompts/system.md` (tell the model the browser tools exist)
+
+- [ ] **Step 1: Document the config options**
+
+In `docs/configuration.md`, add a "Browser" subsection documenting `browser_headless` (default true) and `browser_persistent_profile` (default false, incognito), plus the `/browser` command and `--browser-headed` flag. Note Chromium auto-installs on first use and that inline rendering needs `pip install 'riftor[browser-ui]'` on Python ≥ 3.12.
+
+- [ ] **Step 2: Update the man page**
+
+In `docs/riftor.1`, add `--browser-headed` to the OPTIONS section and `/browser` to any command listing, mirroring the style of existing entries.
+
+- [ ] **Step 3: Make the model aware of the browser tools**
+
+In `riftor/agent/prompts/system.md`, add a short paragraph (in the tools/methodology area) noting the agent can drive a browser via `browser_navigate`/`browser_snapshot`/`browser_click`/`browser_type` for SPA recon and authenticated flows, acts on elements by their `[ref=eN]` ids from the latest snapshot, and that `browser_eval` runs arbitrary JS and is gated like `bash`.
+
+- [ ] **Step 4: Verify the prompt still loads**
+
+Run: `uv run python -c "from riftor.agent.context import Context; c=Context(lore=False); print('system prompt ok', len(c.messages))"`
+Expected: prints `system prompt ok ...` with no error.
+
+- [ ] **Step 5: Run all CI gates**
+
+Run: `make check`
+Expected: lint → typecheck → test → smoke all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/configuration.md docs/riftor.1 riftor/agent/prompts/system.md
+git commit -m "docs: document browser tools, config, flag; make the model aware"
+```
+
+---
+
+## Self-Review notes (resolved)
+
+- **Spec coverage:** every spec decision maps to a task — embed (T3/T5), snapshot-primary (T4), inline+path screenshot (T11/T12), lean 6+2 tools with correct flags (T5), lazy session-scoped manager on ToolContext (T2/T3), incognito-default + first-run hint (T6/T9), headed/headless via config+flag+slash (T6/T8/T9), core dep + auto-install + doctor (T1/T3/T7), action+snapshot result (T5), mocked+skip-guarded tests (T3-T6, T11).
+- **Type consistency:** `BrowserManager.page()/.close()/.launched/.snapshot_text()/.resolve_ref()`, tool names, and config field names are identical across all tasks.
+- **No placeholders:** every code step shows the actual code; commands include expected output.
+- **Known runtime detail deferred to implementation:** `page.accessibility.snapshot()` is deprecated-but-functional (Task 4 uses it; if a worker finds it removed in the installed Playwright, switch to an ARIA-locator walk producing the same `- role "name" [ref=eN]` format — the contract, asserted by tests, does not change).

--- a/docs/superpowers/plans/2026-06-09-playwright-browser.md
+++ b/docs/superpowers/plans/2026-06-09-playwright-browser.md
@@ -1267,6 +1267,11 @@ async def test_real_navigate_snapshot_click(tmp_workdir):
     assert refs, r.content
     rc = await tools.get("browser_click").execute({"ref": refs[0]}, ctx)
     assert not rc.is_error
+    # HARDENING (from Task 4 review): the click must actually ACTUATE — not just
+    # return without error — to catch any AX-role vs ARIA-role mismatch in
+    # resolve_ref. The fixture's Submit button sets document.title='clicked'.
+    rt = await tools.get("browser_eval").execute({"js": "document.title"}, ctx)
+    assert "clicked" in rt.content
     # screenshot writes a file
     rs = await tools.get("browser_screenshot").execute({}, ctx)
     assert not rs.is_error

--- a/docs/superpowers/specs/2026-06-09-playwright-browser-design.md
+++ b/docs/superpowers/specs/2026-06-09-playwright-browser-design.md
@@ -1,0 +1,281 @@
+# Playwright Browser Capability for riftor — Design
+
+**Date:** 2026-06-09
+**Status:** Approved design, pending implementation plan
+**Author:** brainstorm session (amanverasia + Claude)
+
+## Goal
+
+Give riftor's agent the ability to drive a real browser — navigate, read page
+structure, click, type, screenshot, and inspect console/network traffic — for
+SPA-aware recon, authenticated scanning, and form-driven testing that plain
+`WebFetchTool`/`httpx` cannot do. Support both **headed** (watch the browser) and
+**headless** (default, server/SSH-friendly) operation.
+
+## Decisions (locked during brainstorming)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Architecture | **Embed the Python `playwright` package** as native riftor `Tool` subclasses. NOT the Node `@playwright/mcp` subprocess. |
+| 2 | Model perception | **Snapshot-primary, screenshot fallback.** Model reasons over a compact ref-tagged accessibility tree (`click ref=e9`); screenshots are an explicit fallback tool. |
+| 3 | TUI screenshot display | **Inline-first, path fallback.** Render inline via `textual-image` (Kitty/Sixel) when the terminal supports it; otherwise show a clickable path. The *tool always writes the PNG to disk* regardless. |
+| 4 | Tool set | **Lean 6 + 2:** navigate, snapshot, click, type, screenshot, eval, console_messages, network_requests. |
+| 5 | Lifecycle | **Lazy launch, session-scoped, `BrowserManager` on `ToolContext`** (mirrors `ctx.engagement`). Teardown on app exit / `/browser close` / session end. |
+| 6 | Profile | **Incognito by default; persistent is opt-in** via `/config` (`browser_persistent_profile`). One-time hint on first launch. |
+| 7 | Headed/headless | **Headless by default**, override via `--browser-headed` flag, `/browser headed` slash command, and config screen. |
+| 8 | Install | **`playwright` is a core dependency; auto-install Chromium** on first browser use, degrading gracefully to an actionable error. `--doctor`/`/doctor` gain a browser row. |
+| 9 | Action result | Action tools return **status + fresh ref-tagged snapshot** (Playwright-MCP pattern), filtered to interactive nodes, capped by `ToolResult.truncated()`. |
+| 10 | Testing | **Mocked units + skip-guarded real-browser integration tests** against local static HTML fixtures (offline). |
+
+## Why embed, not MCP
+
+riftor's entire safety story — `scope_sensitive` URL probing, the
+`requires_permission` operator prompt, the audit log, the YOLO bypass — is
+enforced **per-call, in-process** (`tui/app.py`, `headless.py`). The MCP route
+runs the browser in a separate Node process, forcing us to re-implement that
+gating at a process-boundary bridge. Embedding makes a browser action a plain
+`Tool` subclass that inherits the exact same treatment as `BashTool` for free,
+with no Node runtime and no subprocess to supervise. The cost — we maintain the
+accessibility-snapshot/ref scheme ourselves — is bounded and well-understood.
+
+## Architecture
+
+### New module: `riftor/tools/browser.py`
+
+Holds the `BrowserManager` and all browser `Tool` subclasses.
+
+#### `BrowserManager` — the first long-lived resource
+
+Every existing tool is stateless per call (fresh subprocess, fresh HTTP). The
+browser is different: one Chromium process must persist across many tool calls.
+It lives on `ToolContext`, exactly as `ctx.engagement` (the SQLite connection)
+already does.
+
+```python
+class BrowserManager:
+    def __init__(self, workdir: Path, *, headless: bool, persistent: bool): ...
+    async def page(self) -> "Page":
+        """Lazily launch Chromium on first call; return the shared Page."""
+    async def close(self) -> None:
+        """Idempotent teardown."""
+    @property
+    def launched(self) -> bool: ...
+```
+
+- **Lazy:** no Chromium launched until the first `browser_*` tool call. Mirrors
+  riftor's lazy `litellm` import — heavy weight (~150–300 MB binaries, a process)
+  is not paid for sessions that never touch the browser.
+- **Lazy binary install:** on first launch, if Chromium binaries are missing,
+  run `playwright install chromium` (with a TUI notice: "downloading Chromium
+  (~150 MB), one time…"). On failure (no network, sandbox, perms) return an
+  actionable error — never crash. (Honors the "bad config never crashes" rule.)
+- **Persistent vs incognito:** `persistent=True` →
+  `chromium.launch_persistent_context(.riftor/browser-profile/)`;
+  `persistent=False` (default) → `chromium.launch()` + ephemeral `new_context()`.
+- **Headed/headless:** `headless` passed to `launch(...)`.
+- **Single shared page** reused across calls so the model can
+  navigate → snapshot → click → snapshot on the same page.
+- No module-level globals (clean for tests + multiple app instances).
+
+`ToolContext` gains one optional field:
+
+```python
+# tools/base.py — ToolContext
+browser: "BrowserManager | None" = None  # lazily set by the app on first browser use
+```
+
+The app constructs the manager from config and assigns `ctx.browser` (or the
+manager is created lazily inside the tool via a small accessor that reads
+`ctx.config`). Decision deferred to the plan; either keeps tests building a bare
+`ToolContext`.
+
+### The ref-tagged accessibility snapshot
+
+A helper builds a compact, deterministic text tree of the current page where each
+interactive element carries a stable `ref` id the model uses to act:
+
+```
+- banner
+  - link "Home" [ref=e3]
+  - link "Login" [ref=e4]
+- main
+  - heading "Sign in" [level=1]
+  - textbox "Username" [ref=e7]
+  - textbox "Password" [ref=e8]
+  - button "Submit" [ref=e9]
+```
+
+- Built from Playwright's ARIA/accessibility data. `page.accessibility.snapshot()`
+  is deprecated-but-functional; the plan will choose between using it and walking
+  ARIA roles via locators. Either way the output format above is the contract.
+- **Filtered to interactive/interesting nodes** to keep token cost low and stay
+  within riftor's context-window budget.
+- **ref → element resolution:** the manager keeps a per-snapshot map from `ref`
+  id to a Playwright locator/handle so `click`/`type` can resolve `ref=e9`.
+  Refs are regenerated on each snapshot; a stale ref returns a clear error.
+
+### Tool set (registered in `ALL_TOOLS`, `tools/__init__.py`)
+
+Order follows the safe→mutating convention; browser tools slot among the core
+tools (read-only-ish first, `eval` last near `BashTool`).
+
+| Tool | Flags | Behavior |
+|------|-------|----------|
+| `browser_navigate(url)` | `scope_sensitive` | Go to URL. Returns status (final URL, HTTP status) **+ fresh snapshot**. |
+| `browser_snapshot()` | — | Return the current page's ref-tagged snapshot. |
+| `browser_click(ref)` | — | Click element by ref. Returns status **+ fresh snapshot**. |
+| `browser_type(ref, text, submit?)` | — | Type into element; optional Enter. Returns status **+ fresh snapshot**. |
+| `browser_screenshot(full_page?)` | — | Save PNG to `.riftor/screenshots/`, return path + dims. |
+| `browser_eval(js)` | `scope_sensitive`, `requires_permission`, `danger` | Run arbitrary JS in the page (the browser's `BashTool`). |
+| `browser_console_messages()` | — | Return captured console log (errors, CSP, leaked tokens). |
+| `browser_network_requests()` | — | Return captured XHR/fetch log (hidden endpoints, auth headers). |
+
+- `navigate` and `eval` are **scope-sensitive** — their URL/JS args are probed
+  against engagement scope by the existing enforcement path. The other action
+  tools operate on the already-loaded page (the `navigate` was the gate), so they
+  are not independently scope-sensitive.
+- `eval` is **dangerous + requires permission** — arbitrary JS execution. The
+  operator approves it exactly like `bash`. In headless mode it auto-denies
+  unless an explicit allow rule exists.
+- `console_messages`/`network_requests` read buffers the manager accumulates via
+  Playwright `page.on("console")` / `page.on("request"/"response")` listeners
+  attached at page creation.
+
+### Result content
+
+Action tools (`navigate`/`click`/`type`) return a short status line **plus** the
+new ref-tagged snapshot, so the model always holds current page state without a
+separate round-trip — the proven Playwright-MCP shape. Size is controlled by
+filtering the snapshot to interactive nodes and applying the existing
+`ToolResult.truncated(ctx.max_result_chars)` cap. `browser_snapshot` remains for
+an explicit re-read.
+
+### Screenshot display in the TUI
+
+The `browser_screenshot` **tool** always writes the PNG to
+`.riftor/screenshots/NNN-<slug>.png` and returns a text result (path, dimensions,
+page URL). This makes screenshots first-class engagement artifacts (a later
+enhancement can let the report generator embed them, alongside `.riftor/reports/`).
+
+The **TUI rendering** is a separate, optional layer:
+
+- **Inline-first:** if `textual-image` is importable and the terminal supports a
+  true graphics protocol (Kitty TGP / Sixel — auto-detected by `textual-image`),
+  mount an `Image` widget so the operator sees the screenshot in-app.
+- **Path fallback:** otherwise (Python 3.11 where `textual-image` can't install;
+  no graphics protocol; inside tmux without passthrough) render a polished
+  fallback — an OSC-8 clickable hyperlink to the PNG plus the absolute path. No
+  noisy half-block approximation (useless for reading text in a screenshot).
+- **Optional dependency:** `textual-image` requires Python ≥ 3.12 but riftor
+  targets 3.11+. It is therefore an **optional extra** (`riftor[browser-ui]` or
+  similar) imported behind `try/except ImportError` — a failed import silently
+  selects the path fallback (honors "bad config never crashes"). Import at module
+  top, before `App.run()`, per `textual-image`'s detection requirement.
+
+### Profile: incognito default, persistent opt-in
+
+- Config gains `browser_persistent_profile: bool = False`.
+- **Incognito (default):** ephemeral context, nothing written to disk. A pentest
+  tool must not silently persist a client's authenticated session cookies.
+- **Persistent (opt-in via `/config`):** `launch_persistent_context` against
+  `.riftor/browser-profile/`; cookies/logins survive across runs.
+- **First-run hint:** the first time a browser tool launches in a session, the TUI
+  prints a one-time note: *"Browser running in incognito (nothing saved). Enable
+  persistent profile in /config to keep cookies/logins across runs."*
+
+### Config additions (`config.py`)
+
+```python
+browser_headless: bool = True
+browser_persistent_profile: bool = False
+```
+
+Both added to `_to_toml()`, surfaced in the config screen
+(`tui/config_screen.py`), and validated leniently (clamp, never raise) per
+existing convention. CLI: `--browser-headed` flag in `__main__.py` sets
+`browser_headless=False` for **this run only** (an in-memory override on the
+loaded `Config`, not written back to `config.toml` — matches how `--model`/
+`--api-key` override without persisting). Update bash/zsh completions in
+`completions/`.
+
+### Slash command: `/browser`
+
+Add `/browser` to `_COMMANDS` and the help text:
+
+- `/browser` — show status (launched?, headed/headless, incognito/persistent,
+  current URL).
+- `/browser headed` / `/browser headless` — toggle mode (takes effect on next
+  launch, or relaunch if already running).
+- `/browser close` — explicit teardown.
+
+### Doctor integration (`engagement/doctor.py`)
+
+Add a browser row to the toolchain report (both `render_markdown` and
+`render_plain`): whether the `playwright` package imports and whether Chromium
+binaries are installed, with the exact `playwright install chromium` command when
+missing. Surfaced by `riftor --doctor` and `/doctor`, and folded into the
+one-line `_toolchain_heads_up()`.
+
+### Lifecycle wiring (`tui/app.py`, `headless.py`)
+
+- **TUI:** create/attach `BrowserManager` from config; tear it down in an
+  `on_unmount` (add if absent) and on `/new`/session switch. Per-step session
+  checkpointing is unaffected (the browser is runtime-only, not serialized).
+- **Headless:** same lazy manager; **always `close()` at end of run** in a
+  `finally`. `browser_eval` (dangerous) auto-denies without an allow rule;
+  out-of-scope `browser_navigate` is hard-blocked (no operator) — both inherited
+  from the existing headless gating, no new code.
+
+## Dependencies
+
+- **Core:** add `playwright>=1.4x` to `pyproject.toml` dependencies.
+- **Optional extra:** `textual-image[textual]` under an extra (e.g.
+  `[project.optional-dependencies] browser-ui = ["textual-image[textual]"]`),
+  imported softly.
+- `uv.lock` regenerated (committed, per convention).
+- Browser binaries are NOT a pip dependency — installed at runtime via
+  `playwright install chromium` (auto, on first use).
+
+## Testing
+
+CI runs **fully offline** on Python 3.11 + 3.12 with no extra binaries — the
+browser work must not break that.
+
+- **Mocked unit tests** (no real browser, always run): scope-sensitivity flags
+  and probing, the first-run incognito notice, lifecycle (lazy launch / idempotent
+  close), result formatting (status + snapshot, truncation), the auto-install
+  error path, ref→element resolution and stale-ref errors. Mock the
+  `BrowserManager`/`Page`.
+- **Real-browser integration tests** (skip-guarded): drive Playwright against tiny
+  **local static HTML fixtures** (`file://` or a localhost `http.server`) — fully
+  offline and deterministic. `pytest.skip(...)` when the `playwright` import fails
+  or Chromium binaries are absent, exactly as recon-tool tests skip on missing
+  PATH binaries. Covers navigate → snapshot → click → type → screenshot.
+- **Smoke test** (`dev/smoke.py`): one headless lazy-launch → navigate (local
+  fixture) → teardown pass, skip-guarded the same way.
+
+This is belt-and-suspenders by design: mocks catch our logic bugs fast and keep
+CI green binary-free; the real-browser tests catch Playwright-API drift where the
+actual value of a browser lives.
+
+## Out of scope (deferable)
+
+- Extra tools: back/forward, hover, select_option, wait_for, tabs, file_upload,
+  pdf, storage-state save/restore. Add when a concrete workflow needs them.
+- Report generator embedding screenshots into HTML/SARIF.
+- Multi-tab/multi-page orchestration.
+- Vision-primary perception (we are snapshot-primary).
+- Concurrent browsers for Chakla subagents (workers default to `bash` only).
+
+## Risks & mitigations
+
+- **Hallucinated findings.** Browser agents notoriously fake exploitation. The
+  existing `/review` self-critique and the requirement that findings carry
+  evidence apply; treat any browser-derived "vuln" as needing PoC validation.
+- **Binary install weight/failure.** Mitigated by lazy install + graceful error +
+  doctor visibility.
+- **tmux graphics fragility.** Mitigated by the polished path fallback firing
+  whenever inline rendering isn't confidently available.
+- **First long-lived resource.** Teardown must be reliable (app exit, session
+  switch, headless `finally`) to avoid leaked Chromium processes — explicitly
+  covered in lifecycle tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "textual>=0.79",
     "litellm>=1.55",
     "pydantic>=2.6",
+    "playwright>=1.44",
 ]
 
 [project.optional-dependencies]
@@ -29,6 +30,9 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pyright>=1.1.380",
+]
+browser-ui = [
+    "textual-image[textual]>=0.13; python_version >= '3.12'",
 ]
 
 [project.urls]

--- a/riftor/__main__.py
+++ b/riftor/__main__.py
@@ -31,6 +31,10 @@ def main() -> None:
     parser.add_argument("--workdir", help="engagement working directory (default: cwd)")
     parser.add_argument("--scope-file", dest="scope_file", help="load scope targets from a file")
     parser.add_argument(
+        "--browser-headed", dest="browser_headed", action="store_true",
+        help="run the Playwright browser headed (visible) for this run",
+    )
+    parser.add_argument(
         "-p", "--prompt",
         help="run a single task non-interactively and exit (headless one-shot)",
     )
@@ -65,6 +69,8 @@ def main() -> None:
         cfg.chakla_model = args.chakla_model
     if args.api_key:
         cfg.api_key = args.api_key
+    if args.browser_headed:
+        cfg.browser_headless = False  # this run only; not written to config.toml
 
     workdir = Path(args.workdir).expanduser() if args.workdir else Path.cwd()
 

--- a/riftor/agent/prompts/system.md
+++ b/riftor/agent/prompts/system.md
@@ -46,6 +46,17 @@ Act through tools — don't just describe, do it. Shell tools run real binaries
   tags/notes) or remove a duplicate/false positive, by its id.
 - `generate_report` — write the report (md/html/json/sarif/all).
 
+## Driving a browser
+For SPA recon, JS-heavy apps, and authenticated flows, drive a real browser
+instead of guessing from raw HTML. `browser_navigate` loads a URL; read the page
+as a ref-tagged accessibility snapshot with `browser_snapshot` and act on elements
+by their `[ref=eN]` ids via `browser_click` and `browser_type` (navigate/click/type
+return the new snapshot automatically). `browser_screenshot` captures the page;
+`browser_console_messages` and `browser_network_requests` surface console + network
+activity — useful for spotting leaked tokens and hidden API endpoints. `browser_eval`
+runs arbitrary JavaScript in the page, but it is **dangerous and gated like `bash`**
+(and scope-enforced, like `browser_navigate`) — use it deliberately.
+
 ## Your additional tools
 - `load_skill` — load a methodology skill if one is available for the domain
   (e.g. recon, exploitation, payloads, reporting). Skills are optional, operator-

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -70,6 +70,10 @@ class Config(BaseModel):
     result_preview_lines: int = 25
     # Politeness / safety toward targets and APIs
     rate_limit_per_min: int = 0  # 0 = unlimited
+    # Browser (Playwright). Incognito by default — a pentest tool must not silently
+    # persist a client's session cookies. Persistent profile is opt-in via /config.
+    browser_headless: bool = True
+    browser_persistent_profile: bool = False
     # Tracks whether we've shown the first-run onboarding.
     onboarded: bool = False
     # Per-provider credentials, keyed by provider key (see riftor.providers.PROVIDERS).
@@ -232,6 +236,8 @@ class Config(BaseModel):
             f"max_result_chars = {self.max_result_chars}",
             f"result_preview_lines = {self.result_preview_lines}",
             f"rate_limit_per_min = {self.rate_limit_per_min}",
+            f"browser_headless = {str(self.browser_headless).lower()}",
+            f"browser_persistent_profile = {str(self.browser_persistent_profile).lower()}",
             f"onboarded = {str(self.onboarded).lower()}",
             f'chakla_model = "{self.chakla_model}"',
             f"chakla_max_workers = {self.chakla_max_workers}",

--- a/riftor/engagement/doctor.py
+++ b/riftor/engagement/doctor.py
@@ -72,6 +72,30 @@ def summarize(statuses: list[ToolStatus]) -> dict:
     }
 
 
+def browser_status() -> tuple[bool, bool, str]:
+    """Return (package_ok, binary_ok, detail) for the Playwright browser."""
+    try:
+        import importlib.util
+
+        pkg_ok = importlib.util.find_spec("playwright") is not None
+    except Exception:  # noqa: BLE001
+        pkg_ok = False
+    binary_ok = False
+    if pkg_ok:
+        from pathlib import Path
+
+        # Playwright caches browsers under ~/.cache/ms-playwright (Linux/macOS).
+        cache = Path.home() / ".cache" / "ms-playwright"
+        binary_ok = cache.exists() and any(cache.glob("chromium-*"))
+    if not pkg_ok:
+        detail = "playwright package not installed"
+    elif not binary_ok:
+        detail = "Chromium not installed — run: playwright install chromium"
+    else:
+        detail = "ready (chromium installed)"
+    return pkg_ok, binary_ok, detail
+
+
 def render_markdown(statuses: list[ToolStatus]) -> str:
     """A grouped, human-readable report for the TUI / CLI."""
     by_stage: dict[str, list[ToolStatus]] = {}
@@ -90,6 +114,12 @@ def render_markdown(statuses: list[ToolStatus]) -> str:
             where = f" `{s.path}`" if s.present else " — *not on PATH*"
             lines.append(f"- {mark} `{s.name}` — {s.purpose}{where}")
         lines.append("")
+
+    pkg_ok, binary_ok, detail = browser_status()
+    bmark = "✓" if (pkg_ok and binary_ok) else "✗"
+    lines.append("_Browser_")
+    lines.append(f"- {bmark} `browser` (Playwright) — {detail}")
+    lines.append("")
 
     summary = summarize(statuses)
     lines.append(
@@ -118,4 +148,8 @@ def render_plain(statuses: list[ToolStatus]) -> str:
     mark = "ok " if st.logged_in else "MISSING"
     lines.append("Codex subscription:")
     lines.append(f"  [{mark}] {'codex login':<10} {st.detail}")
+    pkg_ok, binary_ok, detail = browser_status()
+    mark = "ok " if (pkg_ok and binary_ok) else "MISSING"
+    lines.append("Browser (Playwright):")
+    lines.append(f"  [{mark}] {'browser':<10} {detail}")
     return "\n".join(lines)

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -101,33 +101,40 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
 
     context.add_user(prompt)
     max_steps = 10**9 if yolo else cfg.max_steps
-    for _ in range(max_steps):
-        context.repair()
-        text_parts: list[str] = []
-        turn = None
-        try:
-            async for event, payload in provider.stream_turn(context.messages, schemas):
-                if event == "thinking":
-                    if cfg.show_thinking:
-                        # reasoning goes to stderr so stdout stays the clean answer
-                        sys.stderr.write(str(payload))
-                        sys.stderr.flush()
-                elif event == "text":
-                    sys.stdout.write(str(payload))
-                    sys.stdout.flush()
-                    text_parts.append(str(payload))
-                elif event == "done":
-                    turn = payload  # type: ignore[assignment]  # ("done", Turn)
-        except ProviderError as exc:
-            print(f"\nriftor: provider error [{exc.kind}] — {exc}", file=sys.stderr)
-            return 1
-        if turn is None:
-            break
-        context.add_message(turn.assistant_message)
-        if not turn.tool_calls:
-            break
-        for call in turn.tool_calls:
-            await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
+    try:
+        for _ in range(max_steps):
+            context.repair()
+            text_parts: list[str] = []
+            turn = None
+            try:
+                async for event, payload in provider.stream_turn(context.messages, schemas):
+                    if event == "thinking":
+                        if cfg.show_thinking:
+                            # reasoning goes to stderr so stdout stays the clean answer
+                            sys.stderr.write(str(payload))
+                            sys.stderr.flush()
+                    elif event == "text":
+                        sys.stdout.write(str(payload))
+                        sys.stdout.flush()
+                        text_parts.append(str(payload))
+                    elif event == "done":
+                        turn = payload  # type: ignore[assignment]  # ("done", Turn)
+            except ProviderError as exc:
+                print(f"\nriftor: provider error [{exc.kind}] — {exc}", file=sys.stderr)
+                return 1
+            if turn is None:
+                break
+            context.add_message(turn.assistant_message)
+            if not turn.tool_calls:
+                break
+            for call in turn.tool_calls:
+                await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
+    finally:
+        if toolctx.browser is not None and toolctx.browser.launched:
+            try:
+                await toolctx.browser.close()
+            except Exception:  # noqa: BLE001
+                pass
     print()  # trailing newline
     return 0
 

--- a/riftor/tools/__init__.py
+++ b/riftor/tools/__init__.py
@@ -31,6 +31,16 @@ from riftor.tools.engagement import (
     SetStageTool,
 )
 from riftor.tools.subagent import DispatchChaklaTool
+from riftor.tools.browser import (
+    BrowserClickTool,
+    BrowserConsoleMessagesTool,
+    BrowserEvalTool,
+    BrowserNavigateTool,
+    BrowserNetworkRequestsTool,
+    BrowserScreenshotTool,
+    BrowserSnapshotTool,
+    BrowserTypeTool,
+)
 
 # Order is roughly safe -> mutating; it's also the order shown to the model.
 ALL_TOOLS: list[Tool] = [
@@ -40,6 +50,13 @@ ALL_TOOLS: list[Tool] = [
     GlobTool(),
     GrepTool(),
     WebFetchTool(),
+    BrowserNavigateTool(),
+    BrowserSnapshotTool(),
+    BrowserClickTool(),
+    BrowserTypeTool(),
+    BrowserScreenshotTool(),
+    BrowserConsoleMessagesTool(),
+    BrowserNetworkRequestsTool(),
     SetStageTool(),
     ImportScanTool(),
     RecordServiceTool(),
@@ -58,6 +75,7 @@ ALL_TOOLS: list[Tool] = [
     WriteTool(),
     EditTool(),
     BashTool(),
+    BrowserEvalTool(),
 ]
 
 _BY_NAME = {t.name: t for t in ALL_TOOLS}

--- a/riftor/tools/base.py
+++ b/riftor/tools/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from riftor.engagement import Engagement
     from riftor.safety.audit import AuditLog
     from riftor.safety.permissions import Permissions
+    from riftor.tools.browser import BrowserManager
 
 MAX_RESULT_CHARS = 30_000
 
@@ -53,6 +54,10 @@ class ToolContext:
     #: the UI task and may mutate widgets directly. If the agent loop ever moves
     #: to a thread, the callback must marshal via call_from_thread.
     progress: "Callable[[dict], None] | None" = None
+    #: Lazily-launched, session-scoped browser. The first long-lived resource in
+    #: riftor (every other tool is stateless per call). None until a browser_*
+    #: tool launches it. Mirrors how ``engagement`` persists across calls.
+    browser: "BrowserManager | None" = None
 
 
 def resolve_path(ctx: ToolContext, raw: str) -> Path:

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -30,7 +30,7 @@ class BrowserManager:
         self._pw = None  # async_playwright context manager instance
         self._context = None  # BrowserContext
         self._page: "Page | None" = None
-        self._refs: dict[str, "Locator"] = {}
+        self._ref_targets: dict[str, dict] = {}
         self.console_log: list[str] = []
         self.network_log: list[str] = []
 
@@ -115,14 +115,15 @@ class BrowserManager:
         nodes get a stable [ref=eN] id used by click/type. Refs reset each call."""
         page = await self.page()
         tree = await page.accessibility.snapshot(interesting_only=False)
-        self._refs.clear()
-        self._ref_targets: dict[str, dict] = {}
+        self._ref_targets = {}
         lines: list[str] = []
-        counter = {"n": 0}
+        counter = 0
 
         def walk(node: dict, depth: int) -> None:
+            nonlocal counter
             role = node.get("role", "")
             if role in ("WebArea", "RootWebArea", "", "generic", "none"):
+                # elided container: keep children at the parent's depth (no extra indent)
                 for child in node.get("children", []) or []:
                     walk(child, depth)
                 return
@@ -132,8 +133,8 @@ class BrowserManager:
             if node.get("level"):
                 label += f" [level={node['level']}]"
             if role in self._INTERACTIVE:
-                counter["n"] += 1
-                ref = f"e{counter['n']}"
+                counter += 1
+                ref = f"e{counter}"
                 self._ref_targets[ref] = node
                 label += f" [ref={ref}]"
             lines.append(f"{indent}- {label}")
@@ -147,13 +148,19 @@ class BrowserManager:
     def resolve_ref(self, ref: str) -> "Locator":
         """Map a ref id from the last snapshot to a Playwright locator. The
         accessibility node carries role+name; we locate by ARIA role+name."""
-        node = getattr(self, "_ref_targets", {}).get(ref)
+        node = self._ref_targets.get(ref)
         if node is None:
             raise KeyError(ref)
         role = node.get("role", "")
         name = node.get("name", "") or ""
         page = self._page
         assert page is not None
+        # NOTE: accessibility.snapshot() returns platform-flavored AX role names;
+        # we assume they coincide with ARIA roles for the _INTERACTIVE set (true in
+        # practice for button/link/textbox/etc). get_by_role does not validate the
+        # role, so an out-of-vocabulary role would match nothing → a later action
+        # times out rather than erroring here. Task 11 asserts a resolved locator
+        # actually actuates, which is what catches a mismatch.
         if name:
             return page.get_by_role(role, name=name).first
         return page.get_by_role(role).first
@@ -173,4 +180,4 @@ class BrowserManager:
         self._context = None
         self._page = None
         self._pw = None
-        self._refs.clear()
+        self._ref_targets.clear()

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -112,11 +112,67 @@ class BrowserManager:
         "menuitem", "tab", "switch", "searchbox", "slider",
     }
 
+    async def _ax_tree(self, page: "Page") -> dict | None:
+        """Return a nested ``{role, name, level?, children}`` accessibility tree.
+
+        Playwright removed ``page.accessibility.snapshot()`` in 1.5x, so we source
+        the tree from the Chromium DevTools Protocol (``Accessibility.getFullAXTree``)
+        and rebuild the same nested-dict shape the old API produced — keeping
+        :meth:`snapshot_text` and :meth:`resolve_ref` unchanged. If the legacy API
+        is still present (or a test injects a fake page exposing it) we use it."""
+        legacy = getattr(page, "accessibility", None)
+        if legacy is not None and hasattr(legacy, "snapshot"):
+            return await legacy.snapshot(interesting_only=False)
+
+        cdp = await page.context.new_cdp_session(page)
+        try:
+            await cdp.send("Accessibility.enable")
+            raw = await cdp.send("Accessibility.getFullAXTree")
+        finally:
+            try:
+                await cdp.detach()
+            except Exception:  # noqa: BLE001
+                pass
+        nodes = {n["nodeId"]: n for n in raw.get("nodes", [])}
+        if not nodes:
+            return None
+
+        def convert_children(node: dict) -> list[dict]:
+            kids: list[dict] = []
+            for cid in node.get("childIds") or []:
+                child = nodes.get(cid)
+                if child is None:
+                    continue
+                if child.get("ignored"):
+                    # ignored container: drop the node but splice its (recursively
+                    # un-ignored) descendants up into the parent — matching how the
+                    # legacy snapshot API elided ignored/presentational wrappers.
+                    kids.extend(convert_children(child))
+                    continue
+                kids.append(convert(child))
+            return kids
+
+        def convert(node: dict) -> dict:
+            role = (node.get("role") or {}).get("value", "") or ""
+            name = (node.get("name") or {}).get("value", "") or ""
+            out: dict = {"role": role, "name": name}
+            for prop in node.get("properties") or []:
+                if prop.get("name") == "level":
+                    lvl = (prop.get("value") or {}).get("value")
+                    if lvl:
+                        out["level"] = lvl
+            out["children"] = convert_children(node)
+            return out
+
+        # The first node is the document root (RootWebArea).
+        root = raw["nodes"][0]
+        return convert(root)
+
     async def snapshot_text(self) -> str:
         """Compact, ref-tagged accessibility tree of the current page. Interactive
         nodes get a stable [ref=eN] id used by click/type. Refs reset each call."""
         page = await self.page()
-        tree = await page.accessibility.snapshot(interesting_only=False)
+        tree = await self._ax_tree(page)
         self._ref_targets = {}
         lines: list[str] = []
         counter = 0
@@ -157,12 +213,13 @@ class BrowserManager:
         name = node.get("name", "") or ""
         page = self._page
         assert page is not None
-        # NOTE: accessibility.snapshot() returns platform-flavored AX role names;
-        # we assume they coincide with ARIA roles for the _INTERACTIVE set (true in
-        # practice for button/link/textbox/etc). get_by_role does not validate the
-        # role, so an out-of-vocabulary role would match nothing → a later action
-        # times out rather than erroring here. Task 11 asserts a resolved locator
-        # actually actuates, which is what catches a mismatch.
+        # NOTE: the AX tree (CDP getFullAXTree, see _ax_tree) yields role names
+        # that coincide with ARIA roles for the _INTERACTIVE set (button/link/
+        # textbox/etc). get_by_role does not validate the role, so an out-of-
+        # vocabulary role would match nothing → a later action times out rather
+        # than erroring here. The Task 11 integration test asserts a resolved
+        # locator actually actuates (Submit sets document.title), catching a
+        # mismatch against a real browser.
         if name:
             return page.get_by_role(role, name=name).first
         return page.get_by_role(role).first

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -104,6 +104,60 @@ class BrowserManager:
             lambda r: self.network_log.append(f"{r.method} {r.url}"),
         )
 
+    # roles the model can act on → these get a [ref=eN] tag
+    _INTERACTIVE = {
+        "button", "link", "textbox", "checkbox", "radio", "combobox",
+        "menuitem", "tab", "switch", "searchbox", "slider",
+    }
+
+    async def snapshot_text(self) -> str:
+        """Compact, ref-tagged accessibility tree of the current page. Interactive
+        nodes get a stable [ref=eN] id used by click/type. Refs reset each call."""
+        page = await self.page()
+        tree = await page.accessibility.snapshot(interesting_only=False)
+        self._refs.clear()
+        self._ref_targets: dict[str, dict] = {}
+        lines: list[str] = []
+        counter = {"n": 0}
+
+        def walk(node: dict, depth: int) -> None:
+            role = node.get("role", "")
+            if role in ("WebArea", "RootWebArea", "", "generic", "none"):
+                for child in node.get("children", []) or []:
+                    walk(child, depth)
+                return
+            name = node.get("name", "") or ""
+            indent = "  " * depth
+            label = f'{role} "{name}"' if name else role
+            if node.get("level"):
+                label += f" [level={node['level']}]"
+            if role in self._INTERACTIVE:
+                counter["n"] += 1
+                ref = f"e{counter['n']}"
+                self._ref_targets[ref] = node
+                label += f" [ref={ref}]"
+            lines.append(f"{indent}- {label}")
+            for child in node.get("children", []) or []:
+                walk(child, depth + 1)
+
+        if tree:
+            walk(tree, 0)
+        return "\n".join(lines) if lines else "(empty page)"
+
+    def resolve_ref(self, ref: str) -> "Locator":
+        """Map a ref id from the last snapshot to a Playwright locator. The
+        accessibility node carries role+name; we locate by ARIA role+name."""
+        node = getattr(self, "_ref_targets", {}).get(ref)
+        if node is None:
+            raise KeyError(ref)
+        role = node.get("role", "")
+        name = node.get("name", "") or ""
+        page = self._page
+        assert page is not None
+        if name:
+            return page.get_by_role(role, name=name).first
+        return page.get_by_role(role).first
+
     async def close(self) -> None:
         """Idempotent teardown."""
         try:

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from riftor.tools.base import Tool, ToolContext, ToolResult
+
 if TYPE_CHECKING:
     from playwright.async_api import Locator, Page
 
@@ -181,3 +183,218 @@ class BrowserManager:
         self._page = None
         self._pw = None
         self._ref_targets.clear()
+
+
+def _ensure_manager(ctx: ToolContext) -> "BrowserManager | None":
+    """Get-or-create the session BrowserManager from ctx. Returns None if there's
+    no config to derive settings from (bare test contexts)."""
+    if ctx.browser is not None:
+        return ctx.browser
+    if ctx.config is None:
+        return None
+    mgr = BrowserManager(
+        ctx.workdir,
+        headless=getattr(ctx.config, "browser_headless", True),
+        persistent=getattr(ctx.config, "browser_persistent_profile", False),
+    )
+    ctx.browser = mgr
+    return mgr
+
+
+class _BrowserTool(Tool):
+    """Shared error handling for browser tools."""
+
+    async def _manager(self, ctx: ToolContext) -> "BrowserManager":
+        mgr = _ensure_manager(ctx)
+        if mgr is None:
+            raise BrowserError("no active browser context (config unavailable)")
+        return mgr
+
+
+class BrowserNavigateTool(_BrowserTool):
+    name = "browser_navigate"
+    description = "Navigate the browser to a URL. Returns load status and a ref-tagged accessibility snapshot of the resulting page."
+    scope_sensitive = True
+    parameters = {
+        "type": "object",
+        "properties": {"url": {"type": "string", "description": "Absolute URL to load."}},
+        "required": ["url"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return str(args.get("url", ""))[:300]
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        url = str(args.get("url", "")).strip()
+        if not url:
+            return ToolResult("error: empty url", is_error=True)
+        try:
+            mgr = await self._manager(ctx)
+            page = await mgr.page()
+            resp = await page.goto(url, wait_until="domcontentloaded")
+            status = resp.status if resp else "?"
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"navigated → {page.url} [{status}]\n\n{snap}").truncated(
+                ctx.max_result_chars
+            )
+        except BrowserError as exc:
+            return ToolResult(f"error: {exc}", is_error=True)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: navigation failed: {exc}", is_error=True)
+
+
+class BrowserSnapshotTool(_BrowserTool):
+    name = "browser_snapshot"
+    description = "Return a ref-tagged accessibility snapshot of the current page."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        try:
+            mgr = await self._manager(ctx)
+            if not mgr.launched:
+                return ToolResult("error: no page loaded; use browser_navigate first", is_error=True)
+            return ToolResult(await mgr.snapshot_text()).truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: {exc}", is_error=True)
+
+
+class BrowserClickTool(_BrowserTool):
+    name = "browser_click"
+    description = "Click an element by its [ref=eN] id from the latest snapshot. Returns the new page snapshot."
+    parameters = {
+        "type": "object",
+        "properties": {"ref": {"type": "string", "description": "Element ref, e.g. e9."}},
+        "required": ["ref"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return f"ref={args.get('ref', '')}"
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        ref = str(args.get("ref", "")).strip()
+        try:
+            mgr = await self._manager(ctx)
+            try:
+                locator = mgr.resolve_ref(ref)
+            except KeyError:
+                return ToolResult(f"error: unknown ref '{ref}' — snapshot may be stale", is_error=True)
+            await locator.click()
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"clicked {ref}\n\n{snap}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: click failed: {exc}", is_error=True)
+
+
+class BrowserTypeTool(_BrowserTool):
+    name = "browser_type"
+    description = "Type text into an element by its [ref=eN] id. Set submit=true to press Enter after. Returns the new page snapshot."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "ref": {"type": "string"},
+            "text": {"type": "string"},
+            "submit": {"type": "boolean", "description": "Press Enter after typing."},
+        },
+        "required": ["ref", "text"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return f"ref={args.get('ref', '')} text={str(args.get('text', ''))[:40]!r}"
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        ref = str(args.get("ref", "")).strip()
+        text = str(args.get("text", ""))
+        try:
+            mgr = await self._manager(ctx)
+            try:
+                locator = mgr.resolve_ref(ref)
+            except KeyError:
+                return ToolResult(f"error: unknown ref '{ref}' — snapshot may be stale", is_error=True)
+            await locator.fill(text)
+            if args.get("submit"):
+                await locator.press("Enter")
+            snap = await mgr.snapshot_text()
+            return ToolResult(f"typed into {ref}\n\n{snap}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: type failed: {exc}", is_error=True)
+
+
+class BrowserScreenshotTool(_BrowserTool):
+    name = "browser_screenshot"
+    description = "Save a PNG screenshot of the current page to .riftor/screenshots/ and return its path."
+    parameters = {
+        "type": "object",
+        "properties": {"full_page": {"type": "boolean", "description": "Capture full scrollable page."}},
+    }
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        try:
+            mgr = await self._manager(ctx)
+            if not mgr.launched:
+                return ToolResult("error: no page loaded; use browser_navigate first", is_error=True)
+            page = await mgr.page()
+            shots = ctx.workdir / ".riftor" / "screenshots"
+            shots.mkdir(parents=True, exist_ok=True)
+            n = len(list(shots.glob("*.png"))) + 1
+            path = shots / f"{n:03d}.png"
+            await page.screenshot(path=str(path), full_page=bool(args.get("full_page")))
+            size = path.stat().st_size
+            return ToolResult(f"screenshot saved → {path} ({size} bytes)\npage: {page.url}")
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: screenshot failed: {exc}", is_error=True)
+
+
+class BrowserEvalTool(_BrowserTool):
+    name = "browser_eval"
+    description = "Execute arbitrary JavaScript in the current page and return its result. Powerful and dangerous — like running shell code in the browser."
+    scope_sensitive = True
+    requires_permission = True
+    danger = True
+    parameters = {
+        "type": "object",
+        "properties": {"js": {"type": "string", "description": "JavaScript expression to evaluate."}},
+        "required": ["js"],
+    }
+
+    def preview(self, args: dict) -> str:
+        return str(args.get("js", ""))[:300]
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        js = str(args.get("js", ""))
+        try:
+            mgr = await self._manager(ctx)
+            page = await mgr.page()
+            value = await page.evaluate(js)
+            return ToolResult(f"{value!r}").truncated(ctx.max_result_chars)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(f"error: eval failed: {exc}", is_error=True)
+
+
+class BrowserConsoleMessagesTool(_BrowserTool):
+    name = "browser_console_messages"
+    description = "Return console messages captured from the current page (errors, warnings, logged values)."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        mgr = _ensure_manager(ctx)
+        if mgr is None or not mgr.launched:
+            return ToolResult("(no browser activity)")
+        log = mgr.console_log[-200:]
+        return ToolResult("\n".join(log) if log else "(no console messages)").truncated(
+            ctx.max_result_chars
+        )
+
+
+class BrowserNetworkRequestsTool(_BrowserTool):
+    name = "browser_network_requests"
+    description = "Return the network requests (method + URL) captured from the current page."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        mgr = _ensure_manager(ctx)
+        if mgr is None or not mgr.launched:
+            return ToolResult("(no browser activity)")
+        log = mgr.network_log[-200:]
+        return ToolResult("\n".join(log) if log else "(no requests captured)").truncated(
+            ctx.max_result_chars
+        )

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -112,6 +112,11 @@ class BrowserManager:
         "menuitem", "tab", "switch", "searchbox", "slider",
     }
 
+    # Low-value text leaves the legacy accessibility.snapshot() folded into the
+    # parent's name; CDP's getFullAXTree surfaces them as separate nodes. Drop
+    # them so the model-facing snapshot stays compact (token economy).
+    _NOISE_ROLES = {"StaticText", "InlineTextBox", "ListMarker", "LineBreak"}
+
     async def _ax_tree(self, page: "Page") -> dict | None:
         """Return a nested ``{role, name, level?, children}`` accessibility tree.
 
@@ -182,6 +187,11 @@ class BrowserManager:
             role = node.get("role", "")
             if role in ("WebArea", "RootWebArea", "", "generic", "none"):
                 # elided container: keep children at the parent's depth (no extra indent)
+                for child in node.get("children", []) or []:
+                    walk(child, depth)
+                return
+            if role in self._NOISE_ROLES:
+                # drop redundant text leaves; recurse children defensively
                 for child in node.get("children", []) or []:
                     walk(child, depth)
                 return

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -1,0 +1,117 @@
+"""Playwright browser: a lazily-launched, session-scoped BrowserManager plus the
+browser_* tools. The manager is riftor's first long-lived resource — every other
+tool is stateless per call. It lives on ToolContext (like ctx.engagement) and is
+torn down on app exit / session switch / explicit /browser close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.async_api import Locator, Page
+
+
+class BrowserError(Exception):
+    """Browser couldn't launch (binaries missing, install failed, etc.)."""
+
+
+class BrowserManager:
+    """Owns one Chromium context+page for the session. Lazy: nothing launches
+    until ``page()`` is first awaited."""
+
+    def __init__(self, workdir: Path, *, headless: bool, persistent: bool) -> None:
+        self._workdir = workdir
+        self._headless = headless
+        self._persistent = persistent
+        self._pw = None  # async_playwright context manager instance
+        self._context = None  # BrowserContext
+        self._page: "Page | None" = None
+        self._refs: dict[str, "Locator"] = {}
+        self.console_log: list[str] = []
+        self.network_log: list[str] = []
+
+    @property
+    def launched(self) -> bool:
+        return self._page is not None
+
+    async def _launch(self) -> tuple[object, "Page"]:
+        """Start Playwright + Chromium. Returns (context, page). Auto-installs
+        Chromium binaries on first use; raises BrowserError on failure."""
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:  # pragma: no cover - playwright is a core dep
+            raise BrowserError(f"playwright not installed: {exc}") from exc
+
+        self._pw = await async_playwright().start()
+        profile = self._workdir / ".riftor" / "browser-profile"
+        try:
+            context, page = await self._do_launch(profile)
+        except Exception as exc:  # noqa: BLE001 — likely missing browser binaries
+            if not await self._try_install():
+                raise BrowserError(
+                    "Chromium not available and auto-install failed. "
+                    "Run: playwright install chromium"
+                ) from exc
+            context, page = await self._do_launch(profile)
+        return context, page
+
+    async def _do_launch(self, profile: Path) -> tuple[object, "Page"]:
+        if self._persistent:
+            profile.mkdir(parents=True, exist_ok=True)
+            context = await self._pw.chromium.launch_persistent_context(
+                str(profile), headless=self._headless
+            )
+            page = context.pages[0] if context.pages else await context.new_page()
+        else:
+            browser = await self._pw.chromium.launch(headless=self._headless)
+            context = await browser.new_context()
+            page = await context.new_page()
+        return context, page
+
+    async def _try_install(self) -> bool:
+        """Run `playwright install chromium`. Returns True on success."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-m", "playwright", "install", "chromium",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+            )
+            await proc.communicate()
+            return proc.returncode == 0
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def page(self) -> "Page":
+        if self._page is None:
+            self._context, self._page = await self._launch()
+            self._attach_listeners(self._page)
+        return self._page
+
+    def _attach_listeners(self, page: "Page") -> None:
+        if not hasattr(page, "on"):
+            return
+        page.on("console", lambda m: self.console_log.append(f"[{m.type}] {m.text}"))
+        page.on(
+            "requestfinished",
+            lambda r: self.network_log.append(f"{r.method} {r.url}"),
+        )
+
+    async def close(self) -> None:
+        """Idempotent teardown."""
+        try:
+            if self._context is not None:
+                await self._context.close()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            if self._pw is not None:
+                await self._pw.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        self._context = None
+        self._page = None
+        self._pw = None
+        self._refs.clear()

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -52,6 +52,7 @@ class BrowserManager:
             context, page = await self._do_launch(profile)
         except Exception as exc:  # noqa: BLE001 — likely missing browser binaries
             if not await self._try_install():
+                await self.close()  # reap the dangling driver before raising
                 raise BrowserError(
                     "Chromium not available and auto-install failed. "
                     "Run: playwright install chromium"
@@ -79,7 +80,11 @@ class BrowserManager:
                 sys.executable, "-m", "playwright", "install", "chromium",
                 stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
             )
-            await proc.communicate()
+            try:
+                await asyncio.wait_for(proc.communicate(), timeout=300)
+            except asyncio.TimeoutError:
+                proc.kill()
+                return False
             return proc.returncode == 0
         except Exception:  # noqa: BLE001
             return False

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -584,6 +584,9 @@ class RiftorApp(App):
         self.config.lore = result["lore"]
         self.config.show_thinking = result.get("show_thinking", self.config.show_thinking)
         self.config.show_tool_output = result.get("show_tool_output", self.config.show_tool_output)
+        self.config.browser_headless = result.get("browser_headless", self.config.browser_headless)
+        self.config.browser_persistent_profile = result.get(
+            "browser_persistent_profile", self.config.browser_persistent_profile)
         self.config.reasoning_effort = result.get("reasoning_effort", self.config.reasoning_effort)
         self.config.chakla_model = result.get("chakla_model", self.config.chakla_model)
         self.config.label_main = result.get("label_main", self.config.label_main)
@@ -983,8 +986,8 @@ class RiftorApp(App):
             return
         if sub == "close":
             if mgr is not None and mgr.launched:
-                self.run_worker(mgr.close(), exclusive=False)
-                self._note("browser closed")
+                self.run_worker(mgr.close(), exclusive=False, exit_on_error=False)
+                self._note("closing browser…")
             else:
                 self._note("no browser running")
             return

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -38,6 +38,14 @@ from riftor.tui.config_screen import ConfigScreen
 from riftor.tui.theme import THEMES, css_variable_defaults, palette
 from riftor.tui.widgets import STAGE_NAMES, Banner, CommandDropdown, FlockPane, StatusBar
 
+# Optional inline image rendering. textual-image needs Python >= 3.12 and a
+# graphics-capable terminal (Kitty/Sixel); import at module top per its detection
+# requirement. A failed import simply means we show the screenshot path instead.
+try:
+    from textual_image.widget import Image as _InlineImage  # type: ignore
+except Exception:  # noqa: BLE001 — never let a missing optional dep break startup
+    _InlineImage = None
+
 if TYPE_CHECKING:
     from riftor.config import Config
 
@@ -1438,6 +1446,22 @@ class RiftorApp(App):
             result_len=len(result.content),
         )
         await self._show_tool_result(result.content, is_error=result.is_error)
+        if (
+            call.name == "browser_screenshot"
+            and not result.is_error
+            and _InlineImage is not None
+        ):
+            # parse "screenshot saved → <path> (...)" from the result content
+            import re
+
+            m = re.search(r"saved → (\S+\.png)", result.content)
+            if m:
+                shot = Path(m.group(1))
+                if shot.exists():
+                    try:
+                        await self._mount(_InlineImage(str(shot)))
+                    except Exception:  # noqa: BLE001 — fall back to the path line already shown
+                        pass
         self.context.add_tool_result(call.id, result.content)
         self._last_output = result.content
         self._refresh_status()

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -1121,6 +1121,7 @@ class RiftorApp(App):
         if not data:
             self._note(f"no such session: {sid}")
             return
+        self._reset_browser_for_session()
         self.session_id = data["id"]
         self.context.load(data.get("messages", []))
         self.context.repair()
@@ -1129,8 +1130,19 @@ class RiftorApp(App):
         self._replay_transcript(self.context.messages)
         self._note(f"resumed session {sid} ({len(data.get('messages', []))} messages)")
 
+    def _reset_browser_for_session(self) -> None:
+        """Close and forget the session's browser on a session switch (/new, /resume)
+        so a new session starts with no carried-over page/cookies, and the first-run
+        incognito hint fires again."""
+        mgr = self.toolctx.browser
+        if mgr is not None and mgr.launched:
+            self.run_worker(mgr.close(), exclusive=False, exit_on_error=False)
+        self.toolctx.browser = None
+        self._browser_hint_shown = False
+
     def _new_session(self) -> None:
         self._save_session()
+        self._reset_browser_for_session()
         self.session_id = sessions.new_id()
         self.context.clear()
         self.usage = Usage()
@@ -1446,22 +1458,27 @@ class RiftorApp(App):
             result_len=len(result.content),
         )
         await self._show_tool_result(result.content, is_error=result.is_error)
-        if (
-            call.name == "browser_screenshot"
-            and not result.is_error
-            and _InlineImage is not None
-        ):
-            # parse "screenshot saved → <path> (...)" from the result content
+        if call.name == "browser_screenshot" and not result.is_error:
             import re
 
             m = re.search(r"saved → (\S+\.png)", result.content)
             if m:
                 shot = Path(m.group(1))
                 if shot.exists():
-                    try:
-                        await self._mount(_InlineImage(str(shot)))
-                    except Exception:  # noqa: BLE001 — fall back to the path line already shown
-                        pass
+                    rendered_inline = False
+                    if _InlineImage is not None:
+                        try:
+                            await self._mount(_InlineImage(str(shot)))
+                            rendered_inline = True
+                        except Exception:  # noqa: BLE001 — terminal can't render; fall back
+                            rendered_inline = False
+                    if not rendered_inline:
+                        # OSC-8 clickable hyperlink to the PNG (works in modern
+                        # terminals; the plain path is also shown by the result line).
+                        uri = shot.resolve().as_uri()
+                        link = Text("open screenshot", style=f"underline {self._pal()['cyan']}")
+                        link.stylize(f"link {uri}")
+                        await self._mount(Static(link, classes="note"))
         self.context.add_tool_result(call.id, result.content)
         self._last_output = result.content
         self._refresh_status()

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -55,7 +55,7 @@ _COMMANDS = [
     "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
     "/sessions", "/resume", "/new", "/theme", "/config", "/tools", "/permissions",
     "/lore", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
-    "/timeline", "/audit", "/export", "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/exit",
+    "/timeline", "/audit", "/export", "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/browser", "/exit",
 ]
 
 HELP = """\
@@ -83,6 +83,7 @@ _Settings & sessions_
 - `/config` — settings panel · `/permissions` — review allow/deny rules
 - `/lore` — toggle the rift persona · `/audit` — recent tool-call audit log
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed
+- `/browser [headed|headless|close]` — browser status / mode / teardown
 - `/review` — self-critique findings for false positives before reporting
 - `/hypotheses` — list tracked hypotheses (open leads)
 - `/lesson <text>` — teach a durable lesson (persists across sessions)
@@ -184,6 +185,7 @@ class RiftorApp(App):
         )
         self._rate_times: list[float] = []
         self._autoscroll = True
+        self._browser_hint_shown = False
 
     def compose(self) -> ComposeResult:
         yield Banner(id="banner")
@@ -235,6 +237,14 @@ class RiftorApp(App):
             self._note(
                 "rift online · set scope with /scope add <target> before tasking the agent"
             )
+
+    async def on_unmount(self) -> None:
+        mgr = self.toolctx.browser
+        if mgr is not None and mgr.launched:
+            try:
+                await mgr.close()
+            except Exception:  # noqa: BLE001
+                pass
 
     def _toolchain_heads_up(self) -> None:
         """One-line note if recon tools are missing — surfaced up front, not mid-task."""
@@ -499,6 +509,7 @@ class RiftorApp(App):
             "/audit": self._audit_cmd,
             "/export": self._export_cmd,
             "/doctor": self._doctor_cmd,
+            "/browser": lambda: self._browser_cmd(arg),
             "/review": self._review_cmd,
             "/hypotheses": self._hypotheses_cmd,
             "/lesson": lambda: self._lesson_cmd(arg),
@@ -962,6 +973,26 @@ class RiftorApp(App):
 
         self._markdown(render_markdown(check_toolchain()))
 
+    def _browser_cmd(self, arg: str) -> None:
+        sub = (arg or "").strip().lower()
+        mgr = self.toolctx.browser
+        if sub in ("headed", "headless"):
+            self.config.browser_headless = sub == "headless"
+            self.config.save()
+            self._note(f"browser mode → {sub} (applies on next launch)")
+            return
+        if sub == "close":
+            if mgr is not None and mgr.launched:
+                self.run_worker(mgr.close(), exclusive=False)
+                self._note("browser closed")
+            else:
+                self._note("no browser running")
+            return
+        mode = "headless" if self.config.browser_headless else "headed"
+        profile = "persistent" if self.config.browser_persistent_profile else "incognito"
+        state = "running" if (mgr and mgr.launched) else "not launched"
+        self._note(f"browser: {state} · {mode} · {profile} (toggle in /config)")
+
     def _export_cmd(self) -> None:
         import json
         import shutil
@@ -1378,6 +1409,13 @@ class RiftorApp(App):
             # "once" → approve this single call, remember nothing
 
         audit_preview = preview + (" [scope-override]" if scope_warning else "")
+        if call.name.startswith("browser_") and not self._browser_hint_shown:
+            self._browser_hint_shown = True
+            if not self.config.browser_persistent_profile:
+                self._note(
+                    "browser running in incognito (nothing saved) · enable persistent "
+                    "profile in /config to keep cookies/logins across runs"
+                )
         start = time.monotonic()
         try:
             result = await tool.execute(call.arguments, self.toolctx)

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -168,6 +168,10 @@ class ConfigScreen(ModalScreen[dict | None]):
                             value=self.config.show_thinking, id="cfg-show-thinking"))
                         yield _row("Show tool output", Switch(
                             value=self.config.show_tool_output, id="cfg-show-tool-output"))
+                        yield _row("Browser headless", Switch(
+                            value=self.config.browser_headless, id="cfg-browser-headless"))
+                        yield _row("Persistent profile", Switch(
+                            value=self.config.browser_persistent_profile, id="cfg-browser-persistent"))
                         _effort = (self.config.reasoning_effort
                                    if self.config.reasoning_effort in REASONING_EFFORTS else "medium")
                         yield _row("Reasoning effort", Select(
@@ -347,6 +351,8 @@ class ConfigScreen(ModalScreen[dict | None]):
             "lore": self.query_one("#cfg-lore", Switch).value,
             "show_thinking": self.query_one("#cfg-show-thinking", Switch).value,
             "show_tool_output": self.query_one("#cfg-show-tool-output", Switch).value,
+            "browser_headless": self.query_one("#cfg-browser-headless", Switch).value,
+            "browser_persistent_profile": self.query_one("#cfg-browser-persistent", Switch).value,
             "reasoning_effort": self.query_one("#cfg-reasoning-effort", Select).value,
             "chakla_model": chakla_model,
             "chakla_provider": w_provider if w_chosen else None,

--- a/tests/fixtures/login.html
+++ b/tests/fixtures/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head><title>Login Fixture</title></head>
+<body>
+  <header><a href="#home">Home</a></header>
+  <main>
+    <h1>Sign in</h1>
+    <form>
+      <label>Username <input type="text" aria-label="Username"></label>
+      <label>Password <input type="password" aria-label="Password"></label>
+      <button type="button" onclick="document.title='clicked'">Submit</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -164,6 +164,38 @@ async def test_snapshot_text_tags_interactive_nodes(monkeypatch, tmp_workdir):
 
 
 @pytest.mark.asyncio
+async def test_snapshot_drops_noise_text_leaves(tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    tree = {
+        "role": "WebArea",
+        "name": "",
+        "children": [
+            {"role": "button", "name": "Submit", "children": [
+                {"role": "StaticText", "name": "Submit", "children": [
+                    {"role": "InlineTextBox", "name": "Submit"},
+                ]},
+            ]},
+            {"role": "ListMarker", "name": "•"},
+        ],
+    }
+
+    class _AxPage:
+        class accessibility:
+            @staticmethod
+            async def snapshot(interesting_only=False):
+                return tree
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    mgr._page = _AxPage()
+    text = await mgr.snapshot_text()
+    assert "button \"Submit\" [ref=e" in text
+    assert "StaticText" not in text
+    assert "InlineTextBox" not in text
+    assert "ListMarker" not in text
+
+
+@pytest.mark.asyncio
 async def test_resolve_unknown_ref_raises(tmp_workdir):
     from riftor.tools import browser as bmod
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -74,3 +74,43 @@ async def test_manager_close_idempotent(monkeypatch, tmp_workdir):
     assert ctx_obj.closed
     await mgr.close()  # second close must not raise
     assert not mgr.launched
+
+
+@pytest.mark.asyncio
+async def test_launch_failure_reaps_driver_and_raises(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    started = {"stopped": False}
+
+    class _FakePW:
+        async def stop(self):
+            started["stopped"] = True
+
+    async def fake_start():
+        return _FakePW()
+
+    async def boom(self, profile):
+        raise RuntimeError("no chromium")
+
+    async def install_fails(self):
+        return False
+
+    # async_playwright().start() → our fake driver
+    class _FakeAP:
+        def start(self):
+            return fake_start()
+
+    # _launch does `from playwright.async_api import async_playwright` at call
+    # time, so patch the attribute on the playwright.async_api module itself —
+    # the `from ... import` re-reads it each call.
+    monkeypatch.setattr("playwright.async_api.async_playwright", lambda: _FakeAP())
+    monkeypatch.setattr(bmod.BrowserManager, "_do_launch", boom)
+    monkeypatch.setattr(bmod.BrowserManager, "_try_install", install_fails)
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    with pytest.raises(bmod.BrowserError):
+        await mgr.page()
+    # driver was reaped (close() called _pw.stop() and reset handles)
+    assert mgr._pw is None
+    assert started["stopped"] is True
+    assert not mgr.launched

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -114,3 +114,42 @@ async def test_launch_failure_reaps_driver_and_raises(monkeypatch, tmp_workdir):
     assert mgr._pw is None
     assert started["stopped"] is True
     assert not mgr.launched
+
+
+@pytest.mark.asyncio
+async def test_snapshot_text_tags_interactive_nodes(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    tree = {
+        "role": "WebArea",
+        "name": "",
+        "children": [
+            {"role": "heading", "name": "Sign in", "level": 1},
+            {"role": "textbox", "name": "Username"},
+            {"role": "button", "name": "Submit"},
+        ],
+    }
+
+    class _AxPage:
+        class accessibility:
+            @staticmethod
+            async def snapshot(interesting_only=False):
+                return tree
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    mgr._page = _AxPage()  # inject a fake page
+    text = await mgr.snapshot_text()
+    assert "heading \"Sign in\"" in text
+    assert "textbox \"Username\" [ref=e" in text
+    assert "button \"Submit\" [ref=e" in text
+    # non-interactive heading gets no ref
+    assert "heading \"Sign in\" [ref=" not in text
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_ref_raises(tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    with pytest.raises(KeyError):
+        mgr.resolve_ref("e99")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -153,3 +153,37 @@ async def test_resolve_unknown_ref_raises(tmp_workdir):
     mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
     with pytest.raises(KeyError):
         mgr.resolve_ref("e99")
+
+
+def test_browser_tools_registered_with_correct_flags():
+    from riftor import tools
+
+    names = {t.name for t in tools.all_tools()}
+    expected = {
+        "browser_navigate", "browser_snapshot", "browser_click", "browser_type",
+        "browser_screenshot", "browser_eval", "browser_console_messages",
+        "browser_network_requests",
+    }
+    assert expected <= names
+
+    nav = tools.get("browser_navigate")
+    assert nav.scope_sensitive is True
+    assert nav.requires_permission is False
+
+    ev = tools.get("browser_eval")
+    assert ev.scope_sensitive is True
+    assert ev.requires_permission is True
+    assert ev.danger is True
+
+    # action-on-loaded-page tools are NOT independently scope-sensitive
+    for n in ("browser_click", "browser_type", "browser_snapshot", "browser_screenshot"):
+        assert tools.get(n).scope_sensitive is False
+
+
+@pytest.mark.asyncio
+async def test_navigate_without_browser_errors_cleanly(toolctx):
+    from riftor import tools
+
+    # toolctx.browser is None and config is None → tool must error, not crash
+    r = await tools.get("browser_navigate").execute({"url": "https://example.com"}, toolctx)
+    assert r.is_error

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,12 @@
+"""Browser tool behavior: context wiring, lifecycle, snapshot, scope, screenshots."""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401  # used by browser tests added in later tasks
+
+from riftor.tools import ToolContext
+
+
+def test_toolcontext_has_browser_field_default_none():
+    ctx = ToolContext()
+    assert ctx.browser is None

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2,9 +2,26 @@
 
 from __future__ import annotations
 
-import pytest  # noqa: F401  # used by browser tests added in later tasks
+import importlib.util
+from pathlib import Path
+
+import pytest
 
 from riftor.tools import ToolContext
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "login.html"
+
+
+def _browser_available() -> bool:
+    if importlib.util.find_spec("playwright") is None:
+        return False
+    cache = Path.home() / ".cache" / "ms-playwright"
+    return cache.exists() and any(cache.glob("chromium-*"))
+
+
+requires_browser = pytest.mark.skipif(
+    not _browser_available(), reason="playwright/Chromium not installed"
+)
 
 
 def test_toolcontext_has_browser_field_default_none():
@@ -198,3 +215,34 @@ def test_config_browser_defaults_and_toml():
     toml = cfg._to_toml()
     assert "browser_headless = true" in toml
     assert "browser_persistent_profile = false" in toml
+
+
+@requires_browser
+@pytest.mark.asyncio
+async def test_real_navigate_snapshot_click(tmp_workdir):
+    from riftor.config import Config
+    from riftor.tools import ToolContext
+    from riftor import tools
+
+    ctx = ToolContext(workdir=tmp_workdir, config=Config(browser_headless=True))
+    url = _FIXTURE.as_uri()
+    r = await tools.get("browser_navigate").execute({"url": url}, ctx)
+    assert not r.is_error
+    assert "Sign in" in r.content
+    assert "[ref=e" in r.content  # interactive elements got refs
+    # find a ref for the Submit button from the snapshot text
+    import re
+    refs = re.findall(r"button \"Submit\" \[ref=(e\d+)\]", r.content)
+    assert refs, r.content
+    rc = await tools.get("browser_click").execute({"ref": refs[0]}, ctx)
+    assert not rc.is_error
+    # HARDENING (from Task 4 review): the click must actually ACTUATE — not just
+    # return without error — to catch any AX-role vs ARIA-role mismatch in
+    # resolve_ref. The fixture's Submit button sets document.title='clicked'.
+    rt = await tools.get("browser_eval").execute({"js": "document.title"}, ctx)
+    assert "clicked" in rt.content
+    # screenshot writes a file
+    rs = await tools.get("browser_screenshot").execute({}, ctx)
+    assert not rs.is_error
+    assert (tmp_workdir / ".riftor" / "screenshots" / "001.png").exists()
+    await ctx.browser.close()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -187,3 +187,14 @@ async def test_navigate_without_browser_errors_cleanly(toolctx):
     # toolctx.browser is None and config is None → tool must error, not crash
     r = await tools.get("browser_navigate").execute({"url": "https://example.com"}, toolctx)
     assert r.is_error
+
+
+def test_config_browser_defaults_and_toml():
+    from riftor.config import Config
+
+    cfg = Config()
+    assert cfg.browser_headless is True
+    assert cfg.browser_persistent_profile is False
+    toml = cfg._to_toml()
+    assert "browser_headless = true" in toml
+    assert "browser_persistent_profile = false" in toml

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -10,3 +10,67 @@ from riftor.tools import ToolContext
 def test_toolcontext_has_browser_field_default_none():
     ctx = ToolContext()
     assert ctx.browser is None
+
+
+class _FakePage:
+    def __init__(self):
+        self.closed = False
+        self.url = "about:blank"
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeContext:
+    def __init__(self):
+        self.pages_created = 0
+        self.closed = False
+
+    async def new_page(self):
+        self.pages_created += 1
+        return _FakePage()
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_manager_lazy_no_launch_until_page(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    launches = {"n": 0}
+
+    async def fake_launch(self):
+        launches["n"] += 1
+        return _FakeContext(), _FakePage()
+
+    monkeypatch.setattr(bmod.BrowserManager, "_launch", fake_launch)
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    assert not mgr.launched
+    assert launches["n"] == 0
+    page = await mgr.page()
+    assert isinstance(page, _FakePage)
+    assert mgr.launched
+    assert launches["n"] == 1
+    # second call reuses, no relaunch
+    await mgr.page()
+    assert launches["n"] == 1
+    await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_manager_close_idempotent(monkeypatch, tmp_workdir):
+    from riftor.tools import browser as bmod
+
+    ctx_obj = _FakeContext()
+
+    async def fake_launch(self):
+        return ctx_obj, _FakePage()
+
+    monkeypatch.setattr(bmod.BrowserManager, "_launch", fake_launch)
+    mgr = bmod.BrowserManager(tmp_workdir, headless=True, persistent=False)
+    await mgr.page()
+    await mgr.close()
+    assert ctx_obj.closed
+    await mgr.close()  # second close must not raise
+    assert not mgr.launched

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -43,6 +43,7 @@ async def test_config_modal_renders_all_fields():
                 ("#cfg-label-main", Input), ("#cfg-label-worker", Input),
                 ("#cfg-theme", Select), ("#cfg-lore", Switch),
                 ("#cfg-show-thinking", Switch), ("#cfg-show-tool-output", Switch),
+                ("#cfg-browser-headless", Switch), ("#cfg-browser-persistent", Switch),
                 ("#cfg-reasoning-effort", Select),
             ]:
                 assert screen.query_one(fid, kind) is not None, fid
@@ -52,8 +53,8 @@ async def test_config_modal_renders_all_fields():
             # 3 picker rows + 2 label rows (was 1 plain input + 2 labels) => +2.
             # +3 field rows for the DISPLAY section => 15 + 3 = 18, plus the
             # GENERATION "Tool call steps" row => 19, plus the MODEL "Codex login"
-            # status row => 20.
-            assert len(list(screen.query(".field-label"))) == 20
+            # status row => 20, plus 2 DISPLAY browser switches => 22.
+            assert len(list(screen.query(".field-label"))) == 22
             await pilot.press("escape")
             await pilot.pause()
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -48,3 +48,11 @@ def test_render_plain(monkeypatch):
     plain = doctor.render_plain(doctor.check_toolchain())
     assert "MISSING" in plain and "ok" in plain
     assert "missing (not fatal):" in plain
+
+
+def test_browser_status_in_plain_report():
+    from riftor.engagement import doctor
+
+    text = doctor.render_plain(doctor.check_toolchain())
+    assert "browser" in text.lower()
+    assert "playwright" in text.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -496,6 +500,83 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/8fd452fd81adb9ec79c8275c1375702ab0fd6bee4952da12eaa09b9508d8/greenlet-3.5.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360", size = 623515, upload-time = "2026-05-20T14:09:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/c318aa9f3ffc77320fddcee3d892be957b42e2ff947198d9450b004f3a38/greenlet-3.5.1-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747", size = 418439, upload-time = "2026-05-20T14:01:38.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a9/a3c2fa886c5b94863fb0e61b3bc14610b7aa94cf4f17f8741b11708305fc/greenlet-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523", size = 234989, upload-time = "2026-05-20T13:08:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -1102,12 +1183,118 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
 ]
 
 [[package]]
@@ -1345,6 +1532,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -1614,11 +1813,15 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "textual" },
 ]
 
 [package.optional-dependencies]
+browser-ui = [
+    { name = "textual-image", extra = ["textual"], marker = "python_full_version >= '3.12'" },
+]
 dev = [
     { name = "pyright" },
     { name = "pytest" },
@@ -1630,6 +1833,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "litellm", specifier = ">=1.55" },
+    { name = "playwright", specifier = ">=1.44" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1637,8 +1841,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "textual", specifier = ">=0.79" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "textual-image", extras = ["textual"], marker = "python_full_version >= '3.12' and extra == 'browser-ui'", specifier = ">=0.13" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "browser-ui"]
 
 [[package]]
 name = "rpds-py"
@@ -1852,6 +2057,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/fd/fd5ad9527b536c306a5a860a33a45e13983a59804b48b91ea52b42ba030a/textual_dev-1.8.0.tar.gz", hash = "sha256:7e56867b0341405a95e938cac0647e6d2763d38d0df08710469ad6b6a8db76df", size = 25026, upload-time = "2025-10-11T09:47:01.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/c6/1dc08ceee6d0bdf219c500cb2fbd605b681b63507c4ff27a6477f12f8245/textual_dev-1.8.0-py3-none-any.whl", hash = "sha256:227b6d24a485fbbc77e302aa21f4fdf3083beb57eb45cd95bae082c81cbeddeb", size = 27541, upload-time = "2025-10-11T09:47:00.531Z" },
+]
+
+[[package]]
+name = "textual-image"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/77/b2128ced69556bfbb8e1c19d8f013e621cf12531eaba4e9b09e1cfa81e37/textual_image-0.13.2.tar.gz", hash = "sha256:8ca0cee2bfcd7734de5b16a1936da226b77b745e28830d9cf2bc202cb70e43ee", size = 2185178, upload-time = "2026-05-30T21:42:33.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/be/60aafd7263a6daa8cc4017e8bd4452c85b63ccd82a64f02636ca46e073b7/textual_image-0.13.2-py3-none-any.whl", hash = "sha256:41635f545ce2d0b3544763a2d10f25ada7f64c51acef77483b80fbfcf7ab22ee", size = 118469, upload-time = "2026-05-30T21:42:31.964Z" },
+]
+
+[package.optional-dependencies]
+textual = [
+    { name = "textual", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Gives riftor's agent a real browser for SPA-aware recon, authenticated scanning, and form-driven testing — embedded Python Playwright (not an MCP sidecar), so every browser action flows through riftor's existing scope/permission/audit/YOLO guardrails in-process.

- **8 browser tools** (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_screenshot`, `browser_eval`, `browser_console_messages`, `browser_network_requests`). The model perceives pages as a compact **ref-tagged accessibility snapshot** (`click ref=e9`) — cheap and model-agnostic — and acts by ref. navigate/click/type auto-return the new snapshot.
- **Guardrails:** `browser_navigate`/`browser_eval` are scope-sensitive (URL/JS checked against engagement scope). `browser_eval` (arbitrary JS) is `danger` + `requires_permission` — gated like `bash` in the TUI, auto-denied in headless. YOLO bypasses consistently.
- **Lifecycle:** lazy-launched, session-scoped `BrowserManager` on `ToolContext` (riftor's first long-lived resource); torn down on app exit, `/browser close`, **and session switch** (`/new`, `/resume`). Headless mode closes the browser in a `finally`.
- **Profile: incognito by default**, persistent opt-in (`browser_persistent_profile`, in `/config`). A first-run note points users to the toggle. A pentest tool shouldn't silently persist a client's session cookies.
- **Headed/headless:** headless default; override via `--browser-headed` (per-run), `/browser headed|headless` (persisted), or the `/config` Display toggles.
- **Screenshots** save to `.riftor/screenshots/` and render **inline** via the optional `textual-image` extra (Kitty/Sixel, Python ≥3.12); otherwise an OSC-8 clickable path link is shown.
- **Install:** `playwright` is a core dep; Chromium **auto-installs on first use** (graceful failure). `--doctor`/`/doctor` report browser readiness.
- Note: Playwright 1.60 removed `page.accessibility.snapshot()`; the snapshot uses a CDP `getFullAXTree` fallback that rebuilds the same tree shape and drops redundant text-leaf nodes to keep snapshots compact.

Built spec-first (`docs/superpowers/specs/`) then via a TDD implementation plan (`docs/superpowers/plans/`), one task at a time with per-task spec + code-quality review and a final holistic review.

## Test Plan

- [x] `make check` green: ruff clean, pyright 0 errors, **276 tests pass**, smoke OK (`smoke: browser ok`)
- [x] CI stays **fully offline** — real-browser tests skip-guard when Chromium is absent (like recon-tool PATH skips)
- [x] Real-browser integration test (`test_real_navigate_snapshot_click`) passes: navigate → ref-snapshot → click → **asserts the click actuated** (`document.title=='clicked'`) → screenshot written
- [x] Mocked unit tests cover lifecycle (lazy launch, idempotent close, launch-failure driver reaping), snapshot/ref logic, tool flags, the no-config error path, config round-trip, doctor row
- [ ] Manual: run `uv run riftor`, `/browser` status, navigate an in-scope target, screenshot (inline on Kitty/Sixel), toggle persistent in `/config`, `--browser-headed` for a visible run

🤖 Generated with [Claude Code](https://claude.com/claude-code)