### PR TITLE
release: 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "0.9.0"
+version = "1.0.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "0.9.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Bump version to **1.0.0**.

`uv version 1.0.0` — bumps `pyproject.toml` + `uv.lock` only. On merge, tag `v1.0.0` on the merged commit to trigger the release workflow (PyPI Trusted Publishing + GitHub Release).

### Headline of 1.0.0
First major release. Ships the **Playwright browser capability** (#64) — headed/headless browser tools with ref-tagged accessibility snapshots, incognito-by-default profile, scope/permission-gated `browser_eval`, lazy session-scoped lifecycle, and inline screenshot rendering — on top of 0.9.0, plus the multiline-paste fix (#63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)