### PR TITLE
fix: move Reasoning effort to Generation in /config

### DIFF
--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -137,6 +137,11 @@ class ConfigScreen(ModalScreen[dict | None]):
                         yield _row("Temperature", Input(value=str(self.config.temperature), id="cfg-temp"))
                         yield _row("Max tokens", Input(value=str(self.config.max_tokens), id="cfg-maxtok"))
                         yield _row("Tool call steps", Input(value=str(self.config.max_steps), id="cfg-maxsteps"))
+                        _effort = (self.config.reasoning_effort
+                                   if self.config.reasoning_effort in REASONING_EFFORTS else "medium")
+                        yield _row("Reasoning effort", Select(
+                            [(e, e) for e in REASONING_EFFORTS],
+                            value=_effort, allow_blank=False, id="cfg-reasoning-effort"))
 
                     with Vertical(id="section-workers", classes="config-section-panel hidden"):
                         yield Label("Workers", classes="config-section")
@@ -172,11 +177,6 @@ class ConfigScreen(ModalScreen[dict | None]):
                             value=self.config.browser_headless, id="cfg-browser-headless"))
                         yield _row("Persistent profile", Switch(
                             value=self.config.browser_persistent_profile, id="cfg-browser-persistent"))
-                        _effort = (self.config.reasoning_effort
-                                   if self.config.reasoning_effort in REASONING_EFFORTS else "medium")
-                        yield _row("Reasoning effort", Select(
-                            [(e, e) for e in REASONING_EFFORTS],
-                            value=_effort, allow_blank=False, id="cfg-reasoning-effort"))
             with Horizontal(id="config-buttons"):
                 yield Button("Cancel", id="cancel", variant="error")
                 yield Button("Save", id="save", variant="success")


### PR DESCRIPTION
## Summary

`Reasoning effort` was rendered under the **Display** section of `/config`, alongside render/runtime toggles (Show thinking, Show tool output, Browser headless, Persistent profile). But reasoning effort is a **generation parameter** — it's sent to the model (litellm's reasoning-effort knob), shaping what the model produces, exactly like Temperature / Max tokens / Tool call steps. Moved it to the **Generation** section where it belongs.

Display now reads cleanly as "how riftor renders output + browser runtime toggles."

## Notes
- Pure relocation in `compose()`. The result dict and apply logic key off the widget id (`cfg-reasoning-effort`), not the parent panel, so the round-trip and persisted value are unchanged.
- The config-screen test asserts widget ids + total field-label count (both unchanged), not section membership — no test edit needed.

## Test Plan
- [x] `ruff` clean, `pyright` 0 errors
- [x] `tests/test_config_screen.py` passes (15)
- [x] smoke OK
- [ ] Manual: open `/config`, confirm Reasoning effort appears under Generation (after Tool call steps) and round-trips on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)