### PR TITLE
fix: enable copying text via Ctrl+Y

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -30,6 +30,14 @@ async def main() -> None:
         assert app.query_one("#chat")
         inp = app.query_one("#prompt", Input)
 
+        # ctrl+y is wired to Textual's copy-selection action (ctrl+c is quit,
+        # so the built-in copy lives on ctrl+y) — drag-select + ctrl+y copies.
+        copy_binding = app.active_bindings.get("ctrl+y")
+        assert copy_binding is not None, "ctrl+y binding missing"
+        assert copy_binding.binding.action == "screen.copy_text", (
+            f"ctrl+y should copy the selection, got {copy_binding.binding.action}"
+        )
+
         # /help renders a Markdown block
         inp.value = "/help"
         await pilot.press("enter")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,27 @@ clear = "ctrl+k"      # rebind the clear action
 quit  = "ctrl+q"
 ```
 
+### Copying text
+
+While riftor is running it captures the mouse (like `vim`, `lazygit`, and other
+full-screen TUIs), so a plain click-drag is consumed by riftor instead of doing
+your terminal's native selection. Two ways to copy:
+
+- **Drag to select, then `Ctrl+Y`** — riftor copies the selection to your
+  clipboard over OSC-52. Works locally and over SSH, in any terminal that
+  honors OSC-52 clipboard writes (most modern ones: Ghostty, kitty, WezTerm,
+  iTerm2, recent GNOME Terminal/VTE).
+- **`Shift`+drag, then your terminal's copy** (`Ctrl+Shift+C`) — most terminals
+  treat `Shift` as a "bypass mouse capture" modifier, giving you their *own*
+  native selection. This is local-only. (Ghostty: default `mouse-shift-capture`;
+  set it to `never` to make `Shift` always select.)
+
+To copy the *last* agent/tool output without selecting at all, use the `/copy`
+command.
+
+`Ctrl+Y` maps to Textual's `screen.copy_text` action; rebind it like any other
+hotkey, e.g. `screen.copy_text = "ctrl+shift+c"`.
+
 ## Troubleshooting
 
 - **`authentication failed`** — the key for your model's provider is missing or

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -190,7 +190,7 @@ _Settings & sessions_
 - `/tools` — list tools · `/exit` — quit (`Ctrl+C`)
 
 Type anything else to task the agent. `↑/↓` recall input · `PgUp/PgDn` scroll ·
-`Esc` cancels a running response.
+`Esc` cancels a running response. Drag to select text, `Ctrl+Y` copies it.
 """
 
 
@@ -242,6 +242,10 @@ class RiftorApp(App):
         ("ctrl+c", "quit", "Quit"),
         ("ctrl+l", "clear", "Clear"),
         ("escape", "cancel", "Cancel"),
+        # Textual binds ctrl+c → copy-selection by default, but we use ctrl+c
+        # for quit; expose the built-in copy action on ctrl+y instead so a
+        # mouse drag-selection can be copied to the clipboard (via OSC-52).
+        Binding("ctrl+y", "screen.copy_text", "Copy selection", show=False),
         Binding("pageup", "scroll_chat('pageup')", "Scroll up", show=False),
         Binding("pagedown", "scroll_chat('pagedown')", "Scroll down", show=False),
         Binding("ctrl+home", "scroll_chat('home')", "Top", show=False),


### PR DESCRIPTION
## Problem

Copying text out of the terminal is impossible while riftor is running — drag-to-highlight + `Ctrl+Shift+C` does nothing.

Two compounding causes (confirmed against Textual 8.2.7):

1. **Mouse-reporting mode disables terminal-native selection.** Like every full-screen TUI (vim, lazygit), riftor puts the terminal in mouse-tracking mode, so the terminal hands click-drags to the app instead of doing its own selection. The OS-level `Ctrl+Shift+C` then has nothing in the terminal's selection buffer.
2. **`Ctrl+C` was bound to quit, shadowing Textual's built-in copy.** Textual 8.x ships native in-app selection and binds `ctrl+c → screen.copy_text`, but riftor binds `ctrl+c → quit`, which takes precedence. Selection worked and highlighted, but the one key that would copy it exited the app.

## Fix

Keep `Ctrl+C` = quit and expose Textual's existing copy action on a free key:

- **`Ctrl+Y` → `screen.copy_text`** — drag to select, press `Ctrl+Y`, selection copies to the clipboard via OSC-52 (works locally and over SSH).
- Documents both `Ctrl+Y` and the `Shift`+drag terminal escape hatch in `/help` and `docs/configuration.md`.
- Smoke-test asserts `app.active_bindings["ctrl+y"]` resolves to `screen.copy_text` (proves the binding is live, not just declared).

`ALLOW_SELECT` is left at its default (`True`) — selection already worked; only the copy key was missing. Fully compatible with the existing `keybindings.toml` override mechanism (`screen.copy_text` is rebindable).

## Verification

`make check` passes: lint clean, pyright 0 errors, all tests pass, smoke OK (including the new `ctrl+y` assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)