### PR TITLE
release: 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "1.0.0"
+version = "1.0.1"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Version bump to **1.0.1**.

Ships the changes merged to main since 1.0.0:
- fix: enable copying text via Ctrl+Y (mouse-selection copy) (#67)
- fix: move Reasoning effort from Display to Generation in /config (#66)
- chore(deps): bump setup-uv to 8.2.0 (#37)
- chore(deps): bump python-minor-patch group (#38)

Only `pyproject.toml` + `uv.lock` change. Tag `v1.0.1` will be pushed after this merges to trigger the PyPI + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)