### PR TITLE
build,ci: gate release on CI; make Playwright an optional extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Lets release.yml gate publishing on the full suite (lint/typecheck/test/smoke
+  # + docker) before it builds and pushes to PyPI.
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ name: release
 #   2. open a PR with the bump, get CI green, and merge it to main
 #   3. tag the merged commit: git checkout main && git pull
 #                             git tag vX.Y.Z && git push origin vX.Y.Z
-#   4. this workflow builds + publishes; PyPI rejects duplicate versions.
+#   4. this workflow re-runs the full CI suite on the tag, then builds +
+#      publishes; PyPI rejects duplicate versions.
 # See CONTRIBUTING.md "Releases" for why tagging before the merge is unsafe.
 
 on:
@@ -24,7 +25,14 @@ on:
       - "v*"
 
 jobs:
+  # Run the full CI suite (lint/typecheck/test/smoke on 3.11+3.12, plus the
+  # docker build) against the tagged commit BEFORE building/publishing. The
+  # "land the bump, get CI green, then tag" flow is procedure; this enforces it.
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   build:
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ through [litellm](https://docs.litellm.ai/) and wrapped in a full-screen
 
 ## Install
 ```bash
-pip install riftor          # or: uv tool install riftor / pipx install riftor
+pip install riftor                 # or: uv tool install riftor / pipx install riftor
+pip install 'riftor[browser]'      # + Playwright, for the browser_* tools (SPA recon)
 ```
 Requires Python 3.11+ and a model — set one of `ANTHROPIC_API_KEY`,
 `OPENAI_API_KEY`, `OPENROUTER_API_KEY` (or run a local [Ollama](https://ollama.com/) server).
+The `[browser]` extra is optional (it adds ~hundreds of MB of Chromium binaries);
+without it the browser tools just print an install hint and everything else works.
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY, etc.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,16 @@ riftor can drive a real Chromium browser (via Playwright) for SPA recon and
 authenticated flows. The agent navigates pages, reads them as accessibility
 snapshots, clicks/types, screenshots, and inspects console + network traffic.
 
+Playwright is an **optional extra** (it pulls in ~hundreds of MB of Chromium
+binaries), so the browser tools are available only when it's installed:
+
+```bash
+pip install 'riftor[browser]'   # adds Playwright; Chromium auto-installs on first use
+```
+
+Without it, the `browser_*` tools return a clear "install riftor[browser]" hint
+instead of running. The rest of riftor works unchanged.
+
 Two `[riftor]` fields control how the browser launches:
 
 - `browser_headless` (default `true`) — headless is the default so it works on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,19 +20,26 @@ dependencies = [
     "textual>=0.79",
     "litellm>=1.55",
     "pydantic>=2.6",
-    "playwright>=1.44",
 ]
 
 [project.optional-dependencies]
+# Browser automation (the browser_* tools). Optional because Playwright pulls in
+# ~hundreds of MB of Chromium binaries that a terminal-only run never needs; the
+# tools degrade with a clear "install riftor[browser]" hint when it's absent.
+browser = [
+    "playwright>=1.44",
+]
+# Inline screenshot rendering in the terminal (Python 3.12+).
+browser-ui = [
+    "textual-image[textual]>=0.13; python_version >= '3.12'",
+]
 dev = [
+    "riftor[browser]",  # so the browser tests/smoke actually exercise Playwright
     "textual-dev>=1.5",
     "ruff>=0.6",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pyright>=1.1.380",
-]
-browser-ui = [
-    "textual-image[textual]>=0.13; python_version >= '3.12'",
 ]
 
 [project.urls]

--- a/riftor/tools/browser.py
+++ b/riftor/tools/browser.py
@@ -45,8 +45,11 @@ class BrowserManager:
         Chromium binaries on first use; raises BrowserError on failure."""
         try:
             from playwright.async_api import async_playwright
-        except ImportError as exc:  # pragma: no cover - playwright is a core dep
-            raise BrowserError(f"playwright not installed: {exc}") from exc
+        except ImportError as exc:  # pragma: no cover - playwright is an optional extra
+            raise BrowserError(
+                "browser tools require Playwright — install it with: "
+                "pip install 'riftor[browser]' (then: playwright install chromium)"
+            ) from exc
 
         self._pw = await async_playwright().start()
         profile = self._workdir / ".riftor" / "browser-profile"

--- a/uv.lock
+++ b/uv.lock
@@ -1813,16 +1813,19 @@ version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },
-    { name = "playwright" },
     { name = "pydantic" },
     { name = "textual" },
 ]
 
 [package.optional-dependencies]
+browser = [
+    { name = "playwright" },
+]
 browser-ui = [
     { name = "textual-image", extra = ["textual"], marker = "python_full_version >= '3.12'" },
 ]
 dev = [
+    { name = "playwright" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1833,17 +1836,18 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "litellm", specifier = ">=1.55" },
-    { name = "playwright", specifier = ">=1.44" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.44" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.380" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "riftor", extras = ["browser"], marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "textual", specifier = ">=0.79" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "textual-image", extras = ["textual"], marker = "python_full_version >= '3.12' and extra == 'browser-ui'", specifier = ">=0.13" },
 ]
-provides-extras = ["dev", "browser-ui"]
+provides-extras = ["browser", "browser-ui", "dev"]
 
 [[package]]
 name = "rpds-py"


### PR DESCRIPTION
Packaging/CI hardening from the full-repo review. Closes #69 and #71.

## #69 — Release workflow now runs CI before publishing
`release.yml` previously built and published to PyPI on a `v*` tag **without ever running the test suite** — "get CI green" was a documented manual step, not enforced. A broken tagged commit could publish.

- `ci.yml` now also triggers on `workflow_call` (reusable).
- `release.yml` gains a `ci` job that calls it, and `build` is gated with `needs: ci`. Since `publish`/`github-release` already `needs: build`, the whole chain is now `ci → build → publish`.
- The full suite (lint / typecheck / test / smoke on 3.11+3.12, plus the docker build) runs against the **tagged commit** before anything is published.

## #71 — Playwright is now an optional `[browser]` extra
Playwright was a **mandatory core dependency**, forcing ~hundreds of MB of Chromium binaries onto every `pip install riftor`, for a terminal tool where browser automation is one feature among many.

- Moved `playwright>=1.44` from `dependencies` → a new `[project.optional-dependencies] browser` extra.
- The `browser_*` tools already degraded gracefully; the `ImportError` now surfaces a clear `pip install 'riftor[browser]'` hint (returned as a tool error, not a crash).
- The `dev` extra self-references `riftor[browser]`, so the test suite and smoke still exercise Playwright in CI — no coverage lost.
- README Install section and `docs/configuration.md` document the extra.
- `uv.lock` regenerated.

**Lean by default:** the base Docker image no longer ships Playwright either, consistent with its "minimal image, no recon binaries" design.

## Verification
`make check` green locally: ruff clean · pyright 0 errors · **281 tests** · smoke OK (incl. `smoke: browser ok` — Playwright present via the dev extra). Workflow YAML validated (`ci → build → publish` wiring confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)