### PR TITLE
release: 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "1.0.1"
+version = "1.1.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Version bump for the 1.1.0 release, collecting three merged fix PRs since v1.0.1.

## Changes since 1.0.1

### Guardrail fixes (#75)
- Fork-bomb deny rule now catches the readable spaced form (`: () { : | : & }`)
- Wildcard scope (`*.example.com`) no longer matches the bare base domain
- Circuit breaker actually stops the loop after 8 barren rounds

### CI & packaging (#76)
- `release.yml` now re-runs the full CI suite on the tag before publishing to PyPI
- Playwright moved from a mandatory core dependency to an optional `[browser]` extra

### Robustness & tests (#77)
- File tools (read/write/edit/glob/grep) sandboxed to the engagement workdir
- Tool-call stream reassembly hardened (provider index-collision + codex None call_id drop)
- Nmap parser rejects out-of-range ports
- Safety-critical test coverage added: scope matching/violations, headless-gate auto-deny, YOLO bypass, permissions deny-before-allow precedence

### Hygiene (#75)
- `Development Status` Pre-Alpha → Beta · Dockerfile pinned to `python:3.12-slim` · internal AI planning docs untracked

## Release flow
After this PR is merged to main, the release is triggered by tagging the merge commit:

```bash
git checkout main && git pull
git tag v1.1.0 && git push origin v1.1.0
```

The release workflow will re-run the full CI suite on the tag, then publish to PyPI + GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)