### PR TITLE
feat: terminal bell on permission dialog (#43)

### DIFF
--- a/riftor/safety/permissions.py
+++ b/riftor/safety/permissions.py
@@ -242,6 +242,11 @@ class ConfirmScreen(ModalScreen[str]):
         return text
 
     def on_mount(self) -> None:
+        # Ring the terminal bell so the operator notices the permission prompt
+        # even when tabbed away (long tool-chain runs).
+        import sys
+        sys.stdout.write("\x07")
+        sys.stdout.flush()
         self.query_one("#once", Button).focus()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
Ring the terminal bell (`\x07`) when the permission confirmation screen appears so the operator notices it even when tabbed away during long tool chains.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)