### PR TITLE
feat: add search/filter to model picker in config screen (#47)

### DIFF
--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -65,6 +65,8 @@ class ConfigScreen(ModalScreen[dict | None]):
         self._worker_provider = provider_key_for_model(
             self.config.chakla_model or self.config.model)
         self._worker_provider_initialized = False
+        self._full_models: list[tuple[str, str]] = []
+        self._full_chakla_models: list[tuple[str, str]] = []
 
     def compose(self) -> ComposeResult:
         theme = self.config.theme if self.config.theme in THEMES else "rift"
@@ -83,6 +85,7 @@ class ConfigScreen(ModalScreen[dict | None]):
         # 8.x and would crash on mount with InvalidSelectValueError.
         if bare and bare not in [v for _, v in model_opts]:
             model_opts = [(bare, bare), *model_opts]
+        self._full_models = model_opts
         model_val = bare if bare else Select.NULL
         # --- worker (Chakla) picker display values, mirroring the main model ---
         wkey = self._worker_provider
@@ -95,6 +98,7 @@ class ConfigScreen(ModalScreen[dict | None]):
         w_model_opts = _model_options(wkey)
         if wbare and wbare not in [v for _, v in w_model_opts]:
             w_model_opts = [(wbare, wbare), *w_model_opts]
+        self._full_chakla_models = w_model_opts
         # Empty chakla_model => "reuse main" => show nothing selected.
         w_model_val = wbare if self.config.chakla_model and wbare else Select.NULL
         with Vertical(id="config-box"):
@@ -117,6 +121,8 @@ class ConfigScreen(ModalScreen[dict | None]):
                         yield _row("Provider", Select(
                             [(m.label, k) for k, m in PROVIDERS.items()],
                             value=pkey, allow_blank=False, id="cfg-provider"))
+                        yield _row("Search", Input(
+                            placeholder="filter models…", id="cfg-model-filter"))
                         yield _row("Model", Select(
                             model_opts, value=model_val, allow_blank=True, id="cfg-model-select"))
                         yield _row("Custom id", Input(
@@ -148,6 +154,8 @@ class ConfigScreen(ModalScreen[dict | None]):
                         yield _row("Provider", Select(
                             [(m.label, k) for k, m in PROVIDERS.items()],
                             value=wkey, allow_blank=False, id="cfg-chakla-provider"))
+                        yield _row("Search", Input(
+                            placeholder="filter models…", id="cfg-chakla-model-filter"))
                         yield _row("Model", Select(
                             w_model_opts, value=w_model_val, allow_blank=True,
                             id="cfg-chakla-model-select"))
@@ -261,12 +269,35 @@ class ConfigScreen(ModalScreen[dict | None]):
                 self._worker_provider_initialized = True
 
     def _set_model_options(self, options: list[tuple[str, str]]) -> None:
-        sel = self.query_one("#cfg-model-select", Select)
-        sel.set_options(options or [("(type a custom id below)", "")])
+        self._full_models = options or [("(type a custom id below)", "")]
+        filt = self.query_one("#cfg-model-filter", Input).value
+        self._apply_model_filter(filt, self._full_models, "#cfg-model-select")
 
     def _set_chakla_model_options(self, options: list[tuple[str, str]]) -> None:
-        sel = self.query_one("#cfg-chakla-model-select", Select)
-        sel.set_options(options or [("(type a custom id below)", "")])
+        self._full_chakla_models = options or [("(type a custom id below)", "")]
+        filt = self.query_one("#cfg-chakla-model-filter", Input).value
+        self._apply_model_filter(filt, self._full_chakla_models, "#cfg-chakla-model-select")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter the model list on each keystroke."""
+        if event.input.id == "cfg-model-filter":
+            self._apply_model_filter(event.value, self._full_models, "#cfg-model-select")
+        elif event.input.id == "cfg-chakla-model-filter":
+            self._apply_model_filter(event.value, self._full_chakla_models, "#cfg-chakla-model-select")
+
+    def _apply_model_filter(
+        self, query: str, full: list[tuple[str, str]], select_id: str
+    ) -> None:
+        """Update *select_id* options to only those matching *query* (case-insensitive)."""
+        sel = self.query_one(select_id, Select)
+        q = query.strip().lower()
+        if not q:
+            sel.set_options(full)
+            return
+        filtered = [(label, value) for label, value in full if q in value.lower()]
+        if not filtered:
+            filtered = [("(no matches)", "")]
+        sel.set_options(filtered)
 
     @work(thread=True, exclusive=True, group="fetch")
     def _fetch_models_worker(self, provider: str, base: str, key: str | None) -> None:

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -35,10 +35,12 @@ async def test_config_modal_renders_all_fields():
             screen = app.screen
             # every field is present and addressable by its stable id
             for fid, kind in [
-                ("#cfg-provider", Select), ("#cfg-model-select", Select),
+                ("#cfg-provider", Select), ("#cfg-model-filter", Input),
+                ("#cfg-model-select", Select),
                 ("#cfg-model", Input), ("#cfg-base", Input), ("#cfg-key", Input),
                 ("#cfg-temp", Input), ("#cfg-maxtok", Input), ("#cfg-maxsteps", Input),
-                ("#cfg-chakla-provider", Select), ("#cfg-chakla-model-select", Select),
+                ("#cfg-chakla-provider", Select), ("#cfg-chakla-model-filter", Input),
+                ("#cfg-chakla-model-select", Select),
                 ("#cfg-chakla-custom", Input),
                 ("#cfg-label-main", Input), ("#cfg-label-worker", Input),
                 ("#cfg-theme", Select), ("#cfg-lore", Switch),
@@ -53,8 +55,9 @@ async def test_config_modal_renders_all_fields():
             # 3 picker rows + 2 label rows (was 1 plain input + 2 labels) => +2.
             # +3 field rows for the DISPLAY section => 15 + 3 = 18, plus the
             # GENERATION "Tool call steps" row => 19, plus the MODEL "Codex login"
-            # status row => 20, plus 2 DISPLAY browser switches => 22.
-            assert len(list(screen.query(".field-label"))) == 22
+            # status row => 20, plus 2 DISPLAY browser switches => 22,
+            # plus 2 model search/filter rows (MODEL + WORKERS) => 24.
+            assert len(list(screen.query(".field-label"))) == 24
             await pilot.press("escape")
             await pilot.pause()
 


### PR DESCRIPTION
Add a filter input above each model Select (main and Chakla worker) so users can type to case-insensitive substring-filter the model list instead of scrolling through hundreds of entries.

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)