### PR TITLE
feat: CVSS auto-scoring on edit + fuzzy finding dedup (#56, #57)

### DIFF
--- a/riftor/agent/prompts/system.md
+++ b/riftor/agent/prompts/system.md
@@ -41,9 +41,11 @@ Act through tools — don't just describe, do it. Shell tools run real binaries
 - `record_finding` — log a vulnerability (title, severity, host, evidence,
   remediation). Pass a `cvss_vector` when you can — severity is derived from it.
   Optional `tags` (e.g. `false-positive`, `needs-validation`) and `notes`.
-  Duplicate findings (same title/host/severity/evidence) are skipped.
-- `edit_finding` / `delete_finding` — correct a finding (wrong severity, add
-  tags/notes) or remove a duplicate/false positive, by its id.
+  Duplicate findings (same title/host/severity/evidence) are skipped; fuzzy
+  matches are flagged so the operator can merge them later.
+- `edit_finding` / `delete_finding` — correct a finding (fix severity, add
+  tags/notes/cvss_vector) or remove a duplicate/false positive, by its id.
+  Pass `cvss_vector` to update the CVSS; severity is auto-derived from it.
 - `generate_report` — write the report (md/html/json/sarif/all).
 
 ## Driving a browser

--- a/riftor/engagement/__init__.py
+++ b/riftor/engagement/__init__.py
@@ -131,11 +131,16 @@ class Engagement:
         if existing is None:
             return self.add_finding(**kwargs), "added"
         if dedup == "merge":
-            self.store.update_finding(
-                existing,
-                evidence=kwargs.get("evidence") or None,
-                recommendation=kwargs.get("recommendation") or None,
-            )
+            # Propagate enriched fields from the new finding onto the existing one,
+            # but only when the new finding actually provides them.
+            merge_fields: dict = {}
+            for fld in ("evidence", "recommendation", "cvss", "tags", "notes",
+                         "confidence", "verification_method"):
+                val = kwargs.get(fld)
+                if val is not None and val != "":
+                    merge_fields[fld] = val
+            if merge_fields:
+                self.store.update_finding(existing, **merge_fields)
             self.store.log_activity("finding_merge", f"#{existing}")
             return existing, "merged"
         return existing, "skipped"

--- a/riftor/engagement/state.py
+++ b/riftor/engagement/state.py
@@ -204,6 +204,59 @@ class Store:
     def count_findings(self) -> int:
         return int(self._conn.execute("SELECT COUNT(*) AS c FROM findings").fetchone()["c"])
 
+    def find_similar(
+        self, title: str, host: str = "", threshold: float = 0.75
+    ) -> list[dict]:
+        """Return findings with a similar title on the same host (or any host if
+        *host* is empty), scored by ``difflib.SequenceMatcher``. Only entries
+        at or above *threshold* are included, sorted best-match first.
+
+        Each result dict has keys: id, title, host, severity, score.
+        """
+        import difflib
+
+        rows = self._conn.execute(
+            "SELECT id, title, host, severity FROM findings ORDER BY id"
+        ).fetchall()
+        norm_title = title.strip().lower()
+        results: list[dict] = []
+        for row in rows:
+            if host and row["host"] and row["host"].strip().lower() != host.strip().lower():
+                continue
+            other = (row["title"] or "").strip().lower()
+            if not other or other == norm_title:
+                continue
+            score = difflib.SequenceMatcher(None, norm_title, other).ratio()
+            if score >= threshold:
+                results.append({
+                    "id": row["id"],
+                    "title": row["title"],
+                    "host": row["host"] or "",
+                    "severity": row["severity"] or "",
+                    "score": round(score, 3),
+                })
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results
+
+    def correlate_findings(self) -> dict[str, list[int]]:
+        """Group findings by host and by severity tag for cross-tool correlation.
+        Returns ``{key: [finding_id, ...]}`` where key is e.g. ``host:10.0.0.1``
+        or ``severity:critical``.
+        """
+        groups: dict[str, list[int]] = {}
+        for row in self._conn.execute("SELECT id, host, severity, tags FROM findings"):
+            fid = int(row["id"])
+            h = (row["host"] or "").strip()
+            s = (row["severity"] or "").strip().lower()
+            tags = (row["tags"] or "").strip()
+            if h:
+                groups.setdefault(f"host:{h}", []).append(fid)
+            if s:
+                groups.setdefault(f"severity:{s}", []).append(fid)
+            for tag in (t.strip() for t in tags.split(",") if t.strip()):
+                groups.setdefault(f"tag:{tag}", []).append(fid)
+        return {k: v for k, v in groups.items() if len(v) > 1}
+
     # -- hypotheses -------------------------------------------------------------
     _HYP_STATUSES = {"open", "confirmed", "refuted", "inconclusive"}
 

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -224,11 +224,13 @@ class RecordFindingTool(Tool):
 
         confidence = _parse_confidence(args.get("confidence"))
 
+        title = str(args["title"])
+        host = str(args.get("host") or "")
         fid, action = eng.add_finding_dedup(
             dedup="skip",
-            title=str(args["title"]),
+            title=title,
             severity=severity,
-            host=str(args.get("host") or ""),
+            host=host,
             evidence=str(args.get("evidence") or ""),
             recommendation=str(args.get("recommendation") or ""),
             tags=str(args.get("tags") or ""),
@@ -239,8 +241,14 @@ class RecordFindingTool(Tool):
         )
         if action == "skipped":
             return ToolResult(f"finding already recorded (#{fid}) — skipped duplicate")
-        tag = severity + (f" · CVSS {score:.1f}" if score is not None else "")
-        return ToolResult(f"recorded finding #{fid} [{tag}] {args['title']}")
+        # Check for fuzzy duplicates across tools.
+        similar = ctx.engagement.store.find_similar(title, host) if ctx.engagement else []
+        tag_line = severity + (f" · CVSS {score:.1f}" if score is not None else "")
+        msg = f"recorded finding #{fid} [{tag_line}] {title}"
+        if similar:
+            ids = ", ".join(f"#{s['id']}" for s in similar[:3])
+            msg += f"  ⚠ similar to: {ids} — review and /edit-finding or /delete-finding to merge"
+        return ToolResult(msg)
 
 
 class EditFindingTool(Tool):
@@ -248,7 +256,9 @@ class EditFindingTool(Tool):
     description = (
         "Update an existing finding by id (from /findings). Pass only the fields to "
         "change: title, severity, host, evidence, recommendation, tags, notes, "
-        "confidence, verification_method."
+        "confidence, verification_method, cvss_vector. "
+        "When cvss_vector is given, the severity is auto-derived from the computed "
+        "CVSS v3.1 base score — do NOT also pass severity in that case."
     )
     parameters = {
         "type": "object",
@@ -263,6 +273,12 @@ class EditFindingTool(Tool):
             "notes": {"type": "string"},
             "confidence": {"type": "integer", "minimum": 0, "maximum": 10},
             "verification_method": {"type": "string"},
+            "cvss_vector": {
+                "type": "string",
+                "description": "CVSS v3.1 vector, e.g. "
+                "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H. Severity is "
+                "auto-derived from the computed score.",
+            },
         },
         "required": ["id"],
     }
@@ -283,12 +299,22 @@ class EditFindingTool(Tool):
         }
         if args.get("confidence") is not None:
             fields["confidence"] = _parse_confidence(args.get("confidence"))
+        # When cvss_vector is given, auto-derive severity from the computed score.
+        vector = str(args.get("cvss_vector") or "").strip()
+        if vector:
+            score = base_score(vector)
+            if score is not None:
+                fields["severity"] = severity_from_score(score)
+                fields["cvss"] = vector
         if "severity" in fields and fields["severity"].lower() not in _SEVERITIES:
             return ToolResult(f"error: severity must be one of {', '.join(_SEVERITIES)}", is_error=True)
         if not eng.store.update_finding(fid, **fields):
             return ToolResult(f"error: no finding #{fid}", is_error=True)
         eng.store.log_activity("finding_edit", f"#{fid} {', '.join(fields)}")
-        return ToolResult(f"updated finding #{fid} ({', '.join(fields) or 'no changes'})")
+        note = ""
+        if vector and score is not None:
+            note = f" · CVSS {score:.1f} ({severity_from_score(score)})"
+        return ToolResult(f"updated finding #{fid} ({', '.join(fields) or 'no changes'}{note})")
 
 
 class DeleteFindingTool(Tool):


### PR DESCRIPTION
### CVSS auto-scoring (#56)
- `edit_finding` now accepts `cvss_vector`; severity is auto-derived from the computed CVSS v3.1 base score when a vector is provided
- On dedup merge, enriched fields (cvss, tags, notes, confidence, verification_method) are now propagated from the new finding to the existing one

### Fuzzy finding dedup (#57)
- `Store.find_similar(title, host)` uses `difflib.SequenceMatcher` to find close title matches on the same host (threshold 0.75)
- `Store.correlate_findings()` groups findings by host, severity, and tags for cross-tool correlation
- `record_finding` now flags potential fuzzy duplicates in the result (`⚠ similar to: #X, #Y`) so the operator can review and merge

Closes #56. Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)