### PR TITLE
release: 1.2.0 — genz mode (#46)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "1.1.0"
+version = "1.2.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/agent/context.py
+++ b/riftor/agent/context.py
@@ -17,6 +17,24 @@ LORE_PREAMBLE = (
     "accurate, actionable work."
 )
 
+GENZ_PREAMBLE = (
+    "\n\nVoice: you are the Baaj — the shot-caller, the orchestrator. Your Chaklas "
+    "(workers) do the grunt work; you make the calls. Speak with Gen Z energy: "
+    "use slang like \"no cap,\" \"fr,\" \"bet,\" \"cooked,\" \"ate,\" \"rizz,\" "
+    "\"W,\" \"L,\" \"bussin,\" \"mid,\" \"sus,\" \"valid,\" \"goated,\" "
+    "\"clapped,\" \"delulu,\" \"based.\"\n\n"
+    "The target's attack surface is \"the glaze.\" A vulnerability is \"the Rift.\" "
+    "Exploiting it is \"getting rifted.\" A pwned target is \"cooked\" or "
+    "\"clapped.\" Good recon intel \"slaps.\" A clean exploit \"ate.\" A failed "
+    "attempt is an \"L.\" Throw in a \"bhai,\" \"arre,\" \"solid,\" \"proper,\" "
+    "\"mast,\" \"scene,\" or \"jugaad\" where it fits — light seasoning, not a "
+    "full masala.\n\n"
+    "Keep it natural — don't force slang into every sentence. Be the Baaj: "
+    "confident, direct, a little cocky, but always accurate. The operator "
+    "needs actionable intel, not just vibes. When the work is done, drop a "
+    "clean summary with no cap."
+)
+
 # Rough chars-per-token; good enough for a status-bar gauge without tiktoken.
 _CHARS_PER_TOKEN = 4
 
@@ -45,9 +63,10 @@ def _content_len(msg: dict) -> int:
 
 
 class Context:
-    def __init__(self, lore: bool = True) -> None:
+    def __init__(self, lore: bool = True, genz: bool = False) -> None:
         self._base = _load_system_prompt()
         self.lore = lore
+        self.genz = genz
         self._messages: list[dict] = []
 
     @property
@@ -58,6 +77,8 @@ class Context:
             parts.append(lessons)
         if self.lore:
             parts.append(LORE_PREAMBLE)
+        if self.genz:
+            parts.append(GENZ_PREAMBLE)
         return "\n\n".join(parts)
 
     @property

--- a/riftor/agent/context.py
+++ b/riftor/agent/context.py
@@ -18,21 +18,35 @@ LORE_PREAMBLE = (
 )
 
 GENZ_PREAMBLE = (
-    "\n\nVoice: you are the Baaj — the shot-caller, the orchestrator. Your Chaklas "
-    "(workers) do the grunt work; you make the calls. Speak with Gen Z energy: "
-    "use slang like \"no cap,\" \"fr,\" \"bet,\" \"cooked,\" \"ate,\" \"rizz,\" "
-    "\"W,\" \"L,\" \"bussin,\" \"mid,\" \"sus,\" \"valid,\" \"goated,\" "
-    "\"clapped,\" \"delulu,\" \"based.\"\n\n"
-    "The target's attack surface is \"the glaze.\" A vulnerability is \"the Rift.\" "
-    "Exploiting it is \"getting rifted.\" A pwned target is \"cooked\" or "
-    "\"clapped.\" Good recon intel \"slaps.\" A clean exploit \"ate.\" A failed "
-    "attempt is an \"L.\" Throw in a \"bhai,\" \"arre,\" \"solid,\" \"proper,\" "
-    "\"mast,\" \"scene,\" or \"jugaad\" where it fits — light seasoning, not a "
-    "full masala.\n\n"
-    "Keep it natural — don't force slang into every sentence. Be the Baaj: "
-    "confident, direct, a little cocky, but always accurate. The operator "
-    "needs actionable intel, not just vibes. When the work is done, drop a "
-    "clean summary with no cap."
+    "\n\n"
+    "## CRITICAL VOICE DIRECTIVE — THIS OVERRIDES DEFAULT TONE\n\n"
+    "You are the Baaj 🦅 — the shot-caller, the orchestrator. Your Chaklas 🐦 "
+    "(workers) do the grunt work; you make the calls. Your voice is Gen Z / "
+    "street-smart / desi-casual. This is REQUIRED, not optional.\n\n"
+    "### Vocabulary you MUST use naturally:\n"
+    "- Affirmation: \"bet,\" \"fr,\" \"no cap,\" \"real,\" \"valid,\" \"based\"\n"
+    "- Excellence: \"ate,\" \"bussin,\" \"slaps,\" \"goated\"\n"
+    "- Failure: \"L,\" \"cooked,\" \"mid,\" \"delulu\"\n"
+    "- Suspicion: \"sus,\" \"cope\"\n"
+    "- Desi spice: \"bhai,\" \"arre,\" \"solid,\" \"proper,\" \"mast,\" \"scene,\" \"jugaad\"\n\n"
+    "### Riftor slang you MUST use:\n"
+    "- Recon intel = \"the glaze\" (e.g. \"let me check the glaze on this host\")\n"
+    "- A vulnerability = \"the Rift\" (e.g. \"found the Rift bhai, open redirect\")\n"
+    "- Exploited = \"rifted\" (e.g. \"we rifted it, no cap\")\n"
+    "- Pwned = \"cooked\" or \"clapped\" (e.g. \"target is cooked fr\")\n\n"
+    "### Examples of how you speak:\n"
+    '- "bet, running nmap to glaze the target real quick 🦅"\n'
+    '- "arre bhai, this endpoint is sus — trying a path traversal"\n'
+    '- "no cap, that SQLi slapped. we rifted it clean."\n'
+    '- "this WAF is cooking our payloads, taking Ls. lemme juggad something."\n'
+    '- "proper clapped. got RCE and dumped creds. this host is cooked."\n\n'
+    "### REQUIRED behaviors:\n"
+    "1. Lead EVERY response with at least one piece of slang or desi flavor.\n"
+    "2. Use riftor slang (glaze/rift/cooked/clapped) when discussing targets and vulns.\n"
+    "3. End key findings with a snappy one-liner (e.g. \"that's a W,\" \"solid find bhai\").\n"
+    "4. Be confident and a little cocky — you're the Baaj, act like it.\n"
+    "5. Accuracy comes FIRST. Slang seasons the intel; it doesn't replace it.\n"
+    "6. When the work is done, drop a clean summary ending with \"no cap.\""
 )
 
 # Rough chars-per-token; good enough for a status-bar gauge without tiktoken.

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -60,6 +60,7 @@ class Config(BaseModel):
     max_tokens: int = 2048
     theme: str = "rift"
     lore: bool = True
+    genz: bool = False
     # Display: reasoning + tool-output visibility (runtime, via /config).
     show_thinking: bool = True
     show_tool_output: bool = True
@@ -229,6 +230,7 @@ class Config(BaseModel):
             f"max_tokens = {self.max_tokens}",
             f'theme = "{self.theme}"',
             f"lore = {str(self.lore).lower()}",
+            f"genz = {str(self.genz).lower()}",
             f"show_thinking = {str(self.show_thinking).lower()}",
             f"show_tool_output = {str(self.show_tool_output).lower()}",
             f'reasoning_effort = "{self.reasoning_effort}"',

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -39,7 +39,7 @@ from riftor.safety.permissions import ConfirmScreen, Permissions
 from riftor.tools import ToolContext, ToolResult
 from riftor.tui.config_screen import ConfigScreen
 from riftor.tui.theme import THEMES, css_variable_defaults, palette
-from riftor.tui.widgets import STAGE_NAMES, Banner, CommandDropdown, FlockPane, StatusBar
+from riftor.tui.widgets import STAGE_NAMES, GENZ_STAGE_NAMES, GENZ_STAGE_LETTERS, Banner, CommandDropdown, FlockPane, StatusBar
 
 # Optional inline image rendering. textual-image needs Python >= 3.12 and a
 # graphics-capable terminal (Kitty/Sixel); import at module top per its detection
@@ -153,7 +153,7 @@ _COMMANDS = [
     "/help", "/clear", "/model", "/stage", "/scope", "/findings", "/finding",
     "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
     "/sessions", "/resume", "/new", "/theme", "/config", "/tools", "/permissions",
-    "/lore", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
+    "/lore", "/genz", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
     "/timeline", "/audit", "/export", "/conversation", "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/browser", "/exit",
 ]
 
@@ -181,7 +181,8 @@ _Engagement_
 _Settings & sessions_
 - `/model [name]` — show or switch the model · `/theme [name]` (dark: rift/dusk/void/fracture/singularity · light: dawn/paper)
 - `/config` — settings panel · `/permissions` — review allow/deny rules
-- `/lore` — toggle the rift persona · `/audit` — recent tool-call audit log
+- `/lore` — toggle the rift persona · `/genz` — toggle Gen Z / Chakla Baaj mode 🦅
+- `/audit` — recent tool-call audit log
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed
 - `/browser [headed|headless|close]` — browser status / mode / teardown
 - `/review` — self-critique findings for false positives before reporting
@@ -297,7 +298,7 @@ class RiftorApp(App):
         self.config = config
         self.workdir = workdir or Path.cwd()
         self.yolo = yolo
-        self.context = Context(lore=config.lore)
+        self.context = Context(lore=config.lore, genz=config.genz)
         self.provider = Provider(config)
         self.tools = tools.all_tools()
         self.tool_schemas = tools.schemas()
@@ -330,9 +331,9 @@ class RiftorApp(App):
         self._browser_hint_shown = False
 
     def compose(self) -> ComposeResult:
-        yield Banner(id="banner")
+        yield Banner(genz=self.config.genz, id="banner")
         yield VerticalScroll(id="chat")
-        yield StatusBar(self.config.model, lore=self.config.lore, yolo=self.yolo)
+        yield StatusBar(self.config.model, lore=self.config.lore, yolo=self.yolo, genz=self.config.genz)
         yield CommandDropdown(_COMMANDS, id="cmd-dropdown")
         yield PromptInput(placeholder="task riftor — or /help", id="prompt")
 
@@ -633,6 +634,7 @@ class RiftorApp(App):
             "/tools": self._tools_cmd,
             "/clear": self.action_clear,
             "/lore": self._lore_cmd,
+            "/genz": self._genz_cmd,
             "/model": lambda: self._model_cmd(arg),
             "/stage": lambda: self._set_stage(arg),
             "/scope": lambda: self._scope_cmd(arg),
@@ -692,7 +694,23 @@ class RiftorApp(App):
         self.config.lore = not self.config.lore
         self.context.lore = self.config.lore
         self.status.set_lore(self.config.lore)
-        self._note(f"lore {'engaged' if self.config.lore else 'disengaged'}")
+        if self.config.genz:
+            self._note(f"lore {'engaged no cap' if self.config.lore else 'disengaged, say less'}")
+        else:
+            self._note(f"lore {'engaged' if self.config.lore else 'disengaged'}")
+
+    def _genz_cmd(self) -> None:
+        self.config.genz = not self.config.genz
+        self.context.genz = self.config.genz
+        self.status.set_genz(self.config.genz)
+        try:
+            self.query_one(Banner).set_genz(self.config.genz)
+        except Exception:
+            pass
+        if self.config.genz:
+            self._note("genz engaged fr 🦅")
+        else:
+            self._note("genz disengaged, back to normie mode")
 
     def _model_cmd(self, arg: str) -> None:
         if arg:
@@ -733,6 +751,7 @@ class RiftorApp(App):
         self.config.max_steps = result.get("max_steps", self.config.max_steps)
         self.max_steps = self.config.max_steps
         self.config.lore = result["lore"]
+        self.config.genz = result.get("genz", self.config.genz)
         self.config.show_thinking = result.get("show_thinking", self.config.show_thinking)
         self.config.show_tool_output = result.get("show_tool_output", self.config.show_tool_output)
         self.config.browser_headless = result.get("browser_headless", self.config.browser_headless)
@@ -772,6 +791,12 @@ class RiftorApp(App):
         self.provider = Provider(self.config)
         self.context.lore = self.config.lore
         self.status.set_lore(self.config.lore)
+        self.status.set_genz(self.config.genz)
+        self.context.genz = self.config.genz
+        try:
+            self.query_one(Banner).set_genz(self.config.genz)
+        except Exception:
+            pass
         self.status.set_model(self.config.model)
         self.config.theme = result["theme"]
         self._apply_theme(result["theme"])
@@ -798,8 +823,14 @@ class RiftorApp(App):
     def _set_stage(self, arg: str) -> None:
         if not arg:
             cur = self.engagement.stage
-            stages = " · ".join(f"{k} {v}" for k, v in STAGE_NAMES.items())
-            self._note(f"stage: {cur} ({STAGE_NAMES[cur]})   ·   {stages}")
+            if self.config.genz:
+                names = GENZ_STAGE_NAMES
+                letters = GENZ_STAGE_LETTERS
+                stages = " · ".join(f"{letters[k]} {v}" for k, v in names.items())
+                self._note(f"stage: {letters[cur]} ({names[cur]})   ·   {stages}")
+            else:
+                stages = " · ".join(f"{k} {v}" for k, v in STAGE_NAMES.items())
+                self._note(f"stage: {cur} ({STAGE_NAMES[cur]})   ·   {stages}")
             return
         name_to_letter = {v.lower(): k for k, v in STAGE_NAMES.items()}
         token = arg.strip()
@@ -818,7 +849,13 @@ class RiftorApp(App):
         color = colors.get(letter, p["cyan"])
         line = Text()
         line.append("──◢ ", style=color)
-        line.append(f"{letter} · {STAGE_NAMES[letter]}", style=f"bold {color}")
+        if self.config.genz:
+            label = GENZ_STAGE_LETTERS.get(letter, letter)
+            name = GENZ_STAGE_NAMES.get(letter, STAGE_NAMES.get(letter, letter))
+        else:
+            label = letter
+            name = STAGE_NAMES.get(letter, letter)
+        line.append(f"{label} · {name}", style=f"bold {color}")
         line.append(" ◣" + "─" * 30, style=color)
         self.chat.mount(Static(line, classes="note"))
         self._scroll_if_following()
@@ -826,7 +863,8 @@ class RiftorApp(App):
     def _scope_cmd(self, arg: str) -> None:
         parts = arg.split()
         if not parts:
-            ins = ", ".join(t.raw for t in self.engagement.scope.in_scope) or "(none)"
+            none_label = "no glaze yet fr" if self.config.genz else "(none)"
+            ins = ", ".join(t.raw for t in self.engagement.scope.in_scope) or none_label
             outs = self.engagement.scope.out_of_scope
             mode = "dry-run" if self.engagement.dry_run else ("on" if self.engagement.enforce else "off")
             line = f"scope · enforce {mode} · in: {ins}"

--- a/riftor/tui/config_screen.py
+++ b/riftor/tui/config_screen.py
@@ -174,6 +174,7 @@ class ConfigScreen(ModalScreen[dict | None]):
                         yield _row("Theme", Select([(n, n) for n in THEMES], value=theme,
                                                    allow_blank=False, id="cfg-theme"))
                         yield _row("Lore", Switch(value=self.config.lore, id="cfg-lore"))
+                        yield _row("Genz", Switch(value=self.config.genz, id="cfg-genz"))
 
                     with Vertical(id="section-display", classes="config-section-panel hidden"):
                         yield Label("Display", classes="config-section")
@@ -380,6 +381,7 @@ class ConfigScreen(ModalScreen[dict | None]):
             "max_steps": max_steps,
             "theme": self.query_one("#cfg-theme", Select).value,
             "lore": self.query_one("#cfg-lore", Switch).value,
+            "genz": self.query_one("#cfg-genz", Switch).value,
             "show_thinking": self.query_one("#cfg-show-thinking", Switch).value,
             "show_tool_output": self.query_one("#cfg-show-tool-output", Switch).value,
             "browser_headless": self.query_one("#cfg-browser-headless", Switch).value,

--- a/riftor/tui/widgets.py
+++ b/riftor/tui/widgets.py
@@ -12,24 +12,47 @@ from riftor.tui.theme import palette
 RIFT_STAGES = ["R", "I", "F", "T"]
 STAGE_NAMES = {"R": "Recon", "I": "Intrusion", "F": "Foothold", "T": "Takeover"}
 
+GENZ_STAGES = ["Glaze", "Rizz", "In", "Clapped"]
+GENZ_STAGE_NAMES = {
+    "R": "On the Glaze",
+    "I": "Rizz the Rift",
+    "F": "So In",
+    "T": "Clapped",
+}
+GENZ_STAGE_LETTERS = {
+    "R": "Glaze", "I": "Rizz", "F": "In", "T": "Clapped",
+}
+
 
 class Banner(Static):
+    def __init__(self, genz: bool = False, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.genz = genz
+
+    def set_genz(self, genz: bool) -> None:
+        self.genz = genz
+        self.refresh()
+
     def render(self) -> Text:
         p = palette(self.app)
         t = Text()
         t.append("riftor", style=f"bold {p['violet']}")
         t.append("  ▍  ", style=p["cyan"])
-        t.append("find the rift · open it · cross through", style=f"dim {p['muted']}")
+        if self.genz:
+            t.append("glaze the target · rizz the rift · get clapped", style=f"dim {p['muted']}")
+        else:
+            t.append("find the rift · open it · cross through", style=f"dim {p['muted']}")
         return t
 
 
 class StatusBar(Static):
-    def __init__(self, model: str, stage: str = "R", lore: bool = True, yolo: bool = False) -> None:
+    def __init__(self, model: str, stage: str = "R", lore: bool = True, yolo: bool = False, genz: bool = False) -> None:
         super().__init__()
         self.model = model
         self.stage = stage
         self.lore = lore
         self.yolo = yolo
+        self.genz = genz
         self.busy = False
         self.scope_count = 0
         self.enforce = True
@@ -54,6 +77,10 @@ class StatusBar(Static):
 
     def set_lore(self, lore: bool) -> None:
         self.lore = lore
+        self.refresh_bar()
+
+    def set_genz(self, genz: bool) -> None:
+        self.genz = genz
         self.refresh_bar()
 
     def set_yolo(self, yolo: bool) -> None:
@@ -93,12 +120,19 @@ class StatusBar(Static):
         p = palette(self.app)
         t = Text()
         t.append("[ ", style=p["faint"])
-        for i, stage in enumerate(RIFT_STAGES):
-            t.append(stage, style=f"bold {p['cyan']}" if stage == self.stage else p["dim"])
-            if i < len(RIFT_STAGES) - 1:
+        if self.genz:
+            stages = GENZ_STAGES
+            stage_names = GENZ_STAGE_NAMES
+        else:
+            stages = RIFT_STAGES
+            stage_names = STAGE_NAMES
+        active_idx = RIFT_STAGES.index(self.stage) if self.stage in RIFT_STAGES else 0
+        for i, stage in enumerate(stages):
+            t.append(stage, style=f"bold {p['cyan']}" if i == active_idx else p["dim"])
+            if i < len(stages) - 1:
                 t.append("·", style=p["faint"])
         t.append(" ]  ", style=p["faint"])
-        t.append(STAGE_NAMES[self.stage], style=p["violet"])
+        t.append(stage_names[self.stage], style=p["violet"])
         t.append("   scope:", style=p["dim"])
         if self.scope_count:
             t.append(str(self.scope_count), style=p["muted"])
@@ -130,10 +164,16 @@ class StatusBar(Static):
         t.append(self.model, style=p["muted"])
         t.append("   lore:", style=p["dim"])
         t.append("on" if self.lore else "off", style=p["muted"])
+        if self.genz:
+            t.append("   genz:", style=p["dim"])
+            t.append("on", style=p["violet"])
         if self.yolo:
             t.append("   ⚡ yolo", style=f"bold {p['danger']}")
         if self.busy:
-            t.append("   ⟳ opening rift…", style=p["cyan"])
+            if self.genz:
+                t.append("   ⟳ Baaj is cooking…", style=p["cyan"])
+            else:
+                t.append("   ⟳ opening rift…", style=p["cyan"])
         self.update(t)
 
 

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -44,6 +44,7 @@ async def test_config_modal_renders_all_fields():
                 ("#cfg-chakla-custom", Input),
                 ("#cfg-label-main", Input), ("#cfg-label-worker", Input),
                 ("#cfg-theme", Select), ("#cfg-lore", Switch),
+                ("#cfg-genz", Switch),
                 ("#cfg-show-thinking", Switch), ("#cfg-show-tool-output", Switch),
                 ("#cfg-browser-headless", Switch), ("#cfg-browser-persistent", Switch),
                 ("#cfg-reasoning-effort", Select),
@@ -56,8 +57,9 @@ async def test_config_modal_renders_all_fields():
             # +3 field rows for the DISPLAY section => 15 + 3 = 18, plus the
             # GENERATION "Tool call steps" row => 19, plus the MODEL "Codex login"
             # status row => 20, plus 2 DISPLAY browser switches => 22,
-            # plus 2 model search/filter rows (MODEL + WORKERS) => 24.
-            assert len(list(screen.query(".field-label"))) == 24
+            # plus 2 model search/filter rows (MODEL + WORKERS) => 24,
+            # plus the genz switch in APPEARANCE => 25.
+            assert len(list(screen.query(".field-label"))) == 25
             await pilot.press("escape")
             await pilot.pause()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,53 @@
+"""Tests for the Context class — system prompt assembly, genz/lore composition."""
+
+from riftor.agent.context import Context, GENZ_PREAMBLE, LORE_PREAMBLE
+
+
+def test_system_prompt_no_genz_no_lore():
+    """GENZ_PREAMBLE is absent when genz=False and lore=False."""
+    ctx = Context(lore=False, genz=False)
+    prompt = ctx.system_prompt
+    assert GENZ_PREAMBLE not in prompt
+    assert LORE_PREAMBLE not in prompt
+
+
+def test_system_prompt_genz_on():
+    """GENZ_PREAMBLE is present when genz=True."""
+    ctx = Context(lore=False, genz=True)
+    prompt = ctx.system_prompt
+    assert GENZ_PREAMBLE in prompt
+
+
+def test_system_prompt_genz_off():
+    """GENZ_PREAMBLE is absent when genz=False (lore on)."""
+    ctx = Context(lore=True, genz=False)
+    prompt = ctx.system_prompt
+    assert GENZ_PREAMBLE not in prompt
+    assert LORE_PREAMBLE in prompt
+
+
+def test_system_prompt_both_on():
+    """Both preambles present when both lore and genz are True."""
+    ctx = Context(lore=True, genz=True)
+    prompt = ctx.system_prompt
+    assert GENZ_PREAMBLE in prompt
+    assert LORE_PREAMBLE in prompt
+    # Genz should come after lore
+    assert prompt.index(LORE_PREAMBLE) < prompt.index(GENZ_PREAMBLE)
+
+
+def test_context_defaults():
+    """Context defaults: lore=True, genz=False."""
+    ctx = Context()
+    assert ctx.lore is True
+    assert ctx.genz is False
+
+
+def test_context_mutable_genz():
+    """genz property is mutable after construction."""
+    ctx = Context(lore=True, genz=False)
+    assert GENZ_PREAMBLE not in ctx.system_prompt
+    ctx.genz = True
+    assert GENZ_PREAMBLE in ctx.system_prompt
+    ctx.genz = False
+    assert GENZ_PREAMBLE not in ctx.system_prompt

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## 1.2.0 — Genz Mode 🦅

Adds Gen Z / Chakla Baaj personality mode — a toggleable voice that seasons the agent's replies with Gen Z slang, desi flavor, and riftor-internal terminology.

### Features
- **`/genz` slash command** — toggle Gen Z voice on/off mid-session
- **Config toggle** — Genz switch in `/config` → Appearance (next to Lore)
- **System prompt injection** — `GENZ_PREAMBLE` teaches the model riftor slang (glaze, rift, cooked, clapped, Baaj, Chakla) + Gen Z vocab + desi seasoning
- **Full TUI seasoning** — banner, status bar, stage names, stage divider, scope display, and slash command confirmations all switch to genz vocab
- **Additive with lore** — both toggles work independently; stack 'em

### Files
- `riftor/config.py` — `genz: bool = False` field + TOML
- `riftor/agent/context.py` — `GENZ_PREAMBLE` constant + genz property
- `riftor/tui/widgets.py` — genz stage constants, StatusBar & Banner genz rendering
- `riftor/tui/app.py` — `/genz` command, seasoned notifications
- `riftor/tui/config_screen.py` — genz Switch in Appearance panel
- `tests/test_context.py` — 6 composition tests

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)