### PR TITLE
release: 1.3.0 — animated pulse spinner in StatusBar and chat (#85)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "1.2.0"
+version = "1.3.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -39,7 +39,7 @@ from riftor.safety.permissions import ConfirmScreen, Permissions
 from riftor.tools import ToolContext, ToolResult
 from riftor.tui.config_screen import ConfigScreen
 from riftor.tui.theme import THEMES, css_variable_defaults, palette
-from riftor.tui.widgets import STAGE_NAMES, GENZ_STAGE_NAMES, GENZ_STAGE_LETTERS, Banner, CommandDropdown, FlockPane, StatusBar
+from riftor.tui.widgets import STAGE_NAMES, GENZ_STAGE_NAMES, GENZ_STAGE_LETTERS, Banner, CommandDropdown, FlockPane, PulseSpinner, StatusBar
 
 # Optional inline image rendering. textual-image needs Python >= 3.12 and a
 # graphics-capable terminal (Kitty/Sixel); import at module top per its detection
@@ -316,6 +316,7 @@ class RiftorApp(App):
         self.usage = Usage()
         self.chakla_usage = Usage()
         self._flock: tuple[Static, FlockPane] | None = None  # (header, table) while a dispatch is live
+        self._spinner: PulseSpinner | None = None  # chat-area spinner while agent is running
         self.toolctx = ToolContext(
             workdir=self.workdir,
             engagement=self.engagement,
@@ -474,6 +475,17 @@ class RiftorApp(App):
         try:
             header.remove()
             table.remove()
+        except Exception:  # noqa: BLE001 — teardown must never crash the loop
+            pass
+
+    def _clear_spinner(self) -> None:
+        if self._spinner is None:
+            return
+        spinner = self._spinner
+        self._spinner = None
+        try:
+            spinner.stop()
+            spinner.remove()
         except Exception:  # noqa: BLE001 — teardown must never crash the loop
             pass
 
@@ -1501,6 +1513,11 @@ class RiftorApp(App):
             self.context.add_user(user_text)
             self._last_user_text = user_text
         self.status.set_busy(True)
+        # chat-area pulse spinner
+        label = "Baaj is cooking…" if self.config.genz else "opening rift…"
+        self._spinner = PulseSpinner(label, classes="spinner")
+        await self._mount(self._spinner)
+        self._spinner.start()
         budget = 10**9 if self.yolo else self.max_steps + extra_steps
         _recent_cmds: list[str] = []
         _barren_rounds = 0
@@ -1581,6 +1598,7 @@ class RiftorApp(App):
         except Exception as exc:  # noqa: BLE001
             self._error(f"rift collapsed — {exc}")
         finally:
+            self._clear_spinner()
             self._clear_flock()
             self.status.set_busy(False)
             self.chat.scroll_end(animate=False)

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -48,6 +48,12 @@ Screen {
     text-style: italic;
 }
 
+.spinner {
+    margin: 1 0 0 0;
+    padding: 0 2;
+    color: $cyan;
+}
+
 .tool {
     margin: 1 0 0 0;
     padding: 0 2;

--- a/riftor/tui/widgets.py
+++ b/riftor/tui/widgets.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import difflib
 
 from rich.text import Text
+from textual.timer import Timer
 from textual.widgets import DataTable, ListItem, ListView, Static
 
 from riftor.tui.theme import palette
+
+#: Frames for the pulse/breathing spinner — ● → ○ → ◎ → ◉ → ◎ → ○ → ●
+PULSE_FRAMES = ["●", "○", "◎", "◉", "◎", "○", "●"]
 
 RIFT_STAGES = ["R", "I", "F", "T"]
 STAGE_NAMES = {"R": "Recon", "I": "Intrusion", "F": "Foothold", "T": "Takeover"}
@@ -45,6 +49,60 @@ class Banner(Static):
         return t
 
 
+class PulseSpinner(Static):
+    """Animated pulse/breathing spinner that cycles through ● ○ ◎ ◉ frames.
+
+    Call :meth:`start` to begin the animation and :meth:`stop` to end it.
+    The spinner renders as ``frame label`` (e.g. ``◉ opening rift…``).
+    """
+
+    FRAMES = PULSE_FRAMES
+
+    def __init__(
+        self,
+        label: str = "",
+        *,
+        classes: str = "",
+        id: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(classes=classes, id=id, **kwargs)
+        self.label = label
+        self._frame_idx = 0
+        self._timer: Timer | None = None
+
+    def start(self, label: str | None = None) -> None:
+        """Begin the animation. Optionally update the label text."""
+        if label is not None:
+            self.label = label
+        if self._timer is not None:
+            return
+        self._timer = self.set_interval(0.12, self._tick)
+
+    def stop(self) -> None:
+        """Stop the animation."""
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+
+    def set_label(self, label: str) -> None:
+        """Change the label text without restarting."""
+        self.label = label
+        self._render_frame()
+
+    def _tick(self) -> None:
+        self._frame_idx = (self._frame_idx + 1) % len(self.FRAMES)
+        self._render_frame()
+
+    def _render_frame(self) -> None:
+        self.update(
+            Text(
+                f"{self.FRAMES[self._frame_idx]} {self.label}",
+                style=self.rich_style if self.rich_style else "",
+            )
+        )
+
+
 class StatusBar(Static):
     def __init__(self, model: str, stage: str = "R", lore: bool = True, yolo: bool = False, genz: bool = False) -> None:
         super().__init__()
@@ -63,12 +121,32 @@ class StatusBar(Static):
         self.ctx_pct = 0
         self.chakla_tokens = 0
         self.chakla_cost = 0.0
+        self._spinner_frame = 0
+        self._spinner_timer: Timer | None = None
 
     def on_mount(self) -> None:
         self.refresh_bar()
 
     def set_busy(self, busy: bool) -> None:
         self.busy = busy
+        if busy:
+            self._start_spinner()
+        else:
+            self._stop_spinner()
+        self.refresh_bar()
+
+    def _start_spinner(self) -> None:
+        if self._spinner_timer is not None:
+            return
+        self._spinner_timer = self.set_interval(0.12, self._spin_tick)
+
+    def _stop_spinner(self) -> None:
+        if self._spinner_timer is not None:
+            self._spinner_timer.stop()
+            self._spinner_timer = None
+
+    def _spin_tick(self) -> None:
+        self._spinner_frame = (self._spinner_frame + 1) % len(PULSE_FRAMES)
         self.refresh_bar()
 
     def set_model(self, model: str) -> None:
@@ -170,10 +248,11 @@ class StatusBar(Static):
         if self.yolo:
             t.append("   ⚡ yolo", style=f"bold {p['danger']}")
         if self.busy:
+            frame = PULSE_FRAMES[self._spinner_frame]
             if self.genz:
-                t.append("   ⟳ Baaj is cooking…", style=p["cyan"])
+                t.append(f"   {frame} Baaj is cooking…", style=p["cyan"])
             else:
-                t.append("   ⟳ opening rift…", style=p["cyan"])
+                t.append(f"   {frame} opening rift…", style=p["cyan"])
         self.update(t)
 
 


### PR DESCRIPTION
## What's new in 1.3.0

### 🎨 Animated pulse/breathing spinner

Replace the static `⟳` glyph with a 7-frame pulse animation (`● → ○ → ◎ → ◉`) that breathes while the agent is working, appearing both in the **StatusBar** and inline in the **chat feed**.

- New `PulseSpinner` widget — self-animating with `start()`/`stop()`
- StatusBar pulse replaces the old static \`⟳\` when busy
- Chat-area spinner mounts during agent loop, auto-cleans up on finish/cancel
- Both respect Gen Z mode (\`◉ Baaj is cooking…\` vs \`◉ opening rift…\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)