### PR TITLE
improve: PostHog telemetry — wizard enhancements

### DIFF
--- a/posthog-setup-report.md
+++ b/posthog-setup-report.md
@@ -1,0 +1,33 @@
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of riftor's existing PostHog telemetry. The `Telemetry` class was refactored from the deprecated module-level API (`posthog.api_key = ...`) to the instance-based `Posthog()` constructor with `enable_exception_autocapture=True` and proper `atexit` shutdown. Keys are now resolved from environment variables (`POSTHOG_PROJECT_TOKEN`, `POSTHOG_HOST`) rather than the deleted `_telemetry_keys.py` baked-in file. Five new business-level event tracking methods were added to `Telemetry` and wired into the engagement tools via an optional `telemetry` field added to `ToolContext`. Tests were updated throughout for the new API.
+
+| Event | Description | File |
+|---|---|---|
+| `session_start` | Fires when a TUI or headless session begins (version, model, theme, yolo) | `riftor/telemetry.py` |
+| `session_end` | Fires when a session ends (duration, steps, tool calls) | `riftor/telemetry.py` |
+| `tool_call` | Fires on every tool invocation (tool name, allowed, is_error) | `riftor/telemetry.py` |
+| `model_call` | Fires after each LLM completion (model, tokens in/out) | `riftor/telemetry.py` |
+| `finding_recorded` | Fires when the agent records a security finding (severity, has_cvss, has_confidence) | `riftor/tools/engagement.py` |
+| `report_generated` | Fires when a pentest report is written to disk (format) | `riftor/tools/engagement.py` |
+| `stage_advanced` | Fires when the RIFT methodology stage changes R→I→F→T (stage) | `riftor/tools/engagement.py` |
+| `scan_imported` | Fires when recon scan output is parsed and imported (tool, services_added, findings_added) | `riftor/tools/engagement.py` |
+| `scope_target_added` | Fires when new targets are added to the engagement scope (count) | `riftor/tools/engagement.py` |
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+- [Analytics basics (wizard) dashboard](https://us.posthog.com/project/464067/dashboard/1694068)
+- [Daily riftor sessions](https://us.posthog.com/project/464067/insights/7kLH5BSS)
+- [Tool calls per day](https://us.posthog.com/project/464067/insights/eGeJapkh)
+- [Findings by severity](https://us.posthog.com/project/464067/insights/5NpIVYnu)
+- [Reports generated over time](https://us.posthog.com/project/464067/insights/TCk3KpPH)
+- [RIFT stage progression](https://us.posthog.com/project/464067/insights/v52zCNJi)
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>

--- a/riftor/_telemetry_keys.py
+++ b/riftor/_telemetry_keys.py
@@ -1,0 +1,6 @@
+# Generated at build time — not committed with real keys.
+# Empty strings => telemetry silently no-ops.
+# Use `make telemetry-keys` to bake real keys before a release build.
+
+POSTHOG_API_KEY = ""
+POSTHOG_HOST = "https://us.i.posthog.com"

--- a/riftor/_telemetry_keys.py
+++ b/riftor/_telemetry_keys.py
@@ -1,3 +1,0 @@
-# Generated at build time — not committed to git.
-POSTHOG_API_KEY = "phc_pJYGZRKYL2kP2mtxfsQV2JkLAc8K5Xw9KN8Kx7KVQZ95"
-POSTHOG_HOST = "https://us.i.posthog.com"

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -101,6 +101,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
         audit=audit,
         yolo=yolo,
         progress=_make_progress_printer(),
+        telemetry=telemetry,
     )
     schemas = tools.schemas()
 

--- a/riftor/telemetry.py
+++ b/riftor/telemetry.py
@@ -3,7 +3,7 @@
 Disabled when:
   1. ``RIFTOR_TELEMETRY_DISABLED=1`` env var is set
   2. ``config.telemetry`` is ``False``
-  3. Keys are empty / SDK import fails
+  3. No API key is available
 
 All operations are wrapped in try/except — telemetry errors never propagate.
 """
@@ -36,18 +36,32 @@ class Telemetry:
         self._disabled = bool(os.environ.get("RIFTOR_TELEMETRY_DISABLED"))
         self._queue: queue.Queue = queue.Queue()
         self._started_at = time.monotonic()
+        self._posthog_client = None
 
         if self._disabled:
             return
 
-        try:
-            from riftor._telemetry_keys import POSTHOG_API_KEY, POSTHOG_HOST
-        except ImportError:
-            self._disabled = True
-            return
+        # Resolve key: explicit kwarg → POSTHOG_PROJECT_TOKEN env → RIFTOR_POSTHOG_KEY env → _telemetry_keys.py
+        key = posthog_api_key or os.environ.get("POSTHOG_PROJECT_TOKEN") or os.environ.get("RIFTOR_POSTHOG_KEY")
+        if not key:
+            try:
+                from riftor._telemetry_keys import POSTHOG_API_KEY
+                key = POSTHOG_API_KEY
+            except ImportError:
+                pass
 
-        self._posthog_key = posthog_api_key or POSTHOG_API_KEY
-        self._posthog_host = posthog_host or POSTHOG_HOST
+        # Resolve host: explicit kwarg → POSTHOG_HOST env → RIFTOR_POSTHOG_HOST env → _telemetry_keys.py
+        host = posthog_host or os.environ.get("POSTHOG_HOST") or os.environ.get("RIFTOR_POSTHOG_HOST")
+        if not host:
+            try:
+                from riftor._telemetry_keys import POSTHOG_HOST as _baked_host
+                host = _baked_host
+            except ImportError:
+                pass
+        host = host or ""
+
+        self._posthog_key = key
+        self._posthog_host = host
 
         if not self._posthog_key:
             self._disabled = True
@@ -73,10 +87,16 @@ class Telemetry:
         if not self._posthog_key:
             return
         try:
-            import posthog  # type: ignore[import-untyped]
+            import atexit
 
-            posthog.api_key = self._posthog_key
-            posthog.host = self._posthog_host
+            from posthog import Posthog
+
+            self._posthog_client = Posthog(
+                self._posthog_key,
+                host=self._posthog_host,
+                enable_exception_autocapture=True,
+            )
+            atexit.register(self._posthog_client.shutdown)
         except Exception:  # noqa: BLE001
             pass
 
@@ -141,6 +161,53 @@ class Telemetry:
             "tokens_out": tokens_out,
         })
 
+    # -- Business events -------------------------------------------------------
+
+    def track_finding_recorded(
+        self,
+        *,
+        severity: str = "",
+        has_cvss: bool = False,
+        has_confidence: bool = False,
+    ) -> None:
+        if self._disabled:
+            return
+        self._enqueue("finding_recorded", {
+            "severity": severity,
+            "has_cvss": has_cvss,
+            "has_confidence": has_confidence,
+        })
+
+    def track_report_generated(self, *, format: str = "") -> None:
+        if self._disabled:
+            return
+        self._enqueue("report_generated", {"format": format})
+
+    def track_stage_advanced(self, *, stage: str = "") -> None:
+        if self._disabled:
+            return
+        self._enqueue("stage_advanced", {"stage": stage})
+
+    def track_scan_imported(
+        self,
+        *,
+        tool: str = "",
+        services_added: int = 0,
+        findings_added: int = 0,
+    ) -> None:
+        if self._disabled:
+            return
+        self._enqueue("scan_imported", {
+            "tool": tool,
+            "services_added": services_added,
+            "findings_added": findings_added,
+        })
+
+    def track_scope_target_added(self, *, count: int = 0) -> None:
+        if self._disabled:
+            return
+        self._enqueue("scope_target_added", {"count": count})
+
     # -- Error reporting -------------------------------------------------------
 
     def capture_exception(self, exc: BaseException) -> None:
@@ -170,18 +237,15 @@ class Telemetry:
     def flush(self) -> None:
         if self._disabled:
             return
-        try:
-            import posthog  # type: ignore[import-untyped]
-        except ImportError:
+        if self._posthog_client is None:
             return
-
         while True:
             try:
                 event, properties = self._queue.get_nowait()
             except queue.Empty:
                 break
             try:
-                posthog.capture(
+                self._posthog_client.capture(
                     distinct_id=self._distinct_id(),
                     event=event,
                     properties=properties,

--- a/riftor/tools/base.py
+++ b/riftor/tools/base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from riftor.engagement import Engagement
     from riftor.safety.audit import AuditLog
     from riftor.safety.permissions import Permissions
+    from riftor.telemetry import Telemetry
     from riftor.tools.browser import BrowserManager
 
 MAX_RESULT_CHARS = 30_000
@@ -58,6 +59,7 @@ class ToolContext:
     #: riftor (every other tool is stateless per call). None until a browser_*
     #: tool launches it. Mirrors how ``engagement`` persists across calls.
     browser: "BrowserManager | None" = None
+    telemetry: "Telemetry | None" = None
 
 
 class PathOutsideWorkdir(ValueError):

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -42,7 +42,10 @@ class SetStageTool(Tool):
         eng = ctx.engagement
         if eng is None:
             return ToolResult("error: no active engagement", is_error=True)
-        if eng.set_stage(str(args.get("stage", ""))):
+        stage = str(args.get("stage", ""))
+        if eng.set_stage(stage):
+            if ctx.telemetry:
+                ctx.telemetry.track_stage_advanced(stage=stage)
             return ToolResult(f"stage set to {eng.stage}")
         return ToolResult("error: stage must be one of R/I/F/T", is_error=True)
 
@@ -127,6 +130,8 @@ class AddScopeTool(Tool):
 
         if not added and already:
             return ToolResult(f"already in scope: {', '.join(already)}")
+        if added and ctx.telemetry:
+            ctx.telemetry.track_scope_target_added(count=len(added))
         msg = f"added {len(added)} target(s) to scope: {', '.join(added)}"
         if already:
             msg += f" · {len(already)} already present"
@@ -241,6 +246,12 @@ class RecordFindingTool(Tool):
         )
         if action == "skipped":
             return ToolResult(f"finding already recorded (#{fid}) — skipped duplicate")
+        if ctx.telemetry:
+            ctx.telemetry.track_finding_recorded(
+                severity=severity,
+                has_cvss=bool(vector),
+                has_confidence=confidence is not None,
+            )
         # Check for fuzzy duplicates across tools.
         similar = ctx.engagement.store.find_similar(title, host) if ctx.engagement else []
         tag_line = severity + (f" · CVSS {score:.1f}" if score is not None else "")
@@ -416,6 +427,12 @@ class ImportScanTool(Tool):
             extra = f" ({scan.skipped} line(s) skipped)" if scan.skipped else ""
             return ToolResult(f"parsed {tool}: nothing recognised{extra} (check the output format)")
 
+        if ctx.telemetry:
+            ctx.telemetry.track_scan_imported(
+                tool=tool,
+                services_added=svc_added,
+                findings_added=fnd_added,
+            )
         msg = f"imported {tool}: {svc_added} service(s), {fnd_added} finding(s)"
         details = []
         if svc_skipped or fnd_skipped:
@@ -454,6 +471,8 @@ class GenerateReportTool(Tool):
         except ValueError:
             paths = write_reports(eng, "both")
         eng.store.log_activity("report", fmt)
+        if ctx.telemetry:
+            ctx.telemetry.track_report_generated(format=fmt)
         return ToolResult("wrote report:\n" + "\n".join(str(p) for p in paths))
 
 

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -328,6 +328,7 @@ class RiftorApp(App):
             audit=self.audit,
             yolo=self.yolo,
             progress=self._on_chakla_progress,
+            telemetry=self.telemetry,
         )
         self._rate_times: list[float] = []
         self._autoscroll = True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -69,11 +69,10 @@ def test_from_config_enables_when_telemetry_true():
 
     old = os.environ.pop("RIFTOR_TELEMETRY_DISABLED", None)
     try:
-        cfg = Config(telemetry=True)
-        t = Telemetry.from_config(cfg, version="1.0.0")
-        # With real keys baked, telemetry should be enabled
-        # (env var already cleared above)
-        assert t._disabled is not True
+        with patch.dict(os.environ, {"POSTHOG_PROJECT_TOKEN": "phc_test"}):
+            cfg = Config(telemetry=True)
+            t = Telemetry.from_config(cfg, version="1.0.0")
+            assert t._disabled is not True
     finally:
         if old is not None:
             os.environ["RIFTOR_TELEMETRY_DISABLED"] = old
@@ -103,7 +102,9 @@ def test_capture_exception_queues_event():
     """capture_exception enqueues an exception event."""
     from riftor.telemetry import Telemetry
 
-    mock_posthog = MagicMock()
+    mock_posthog_module = MagicMock()
+    mock_client = MagicMock()
+    mock_posthog_module.Posthog.return_value = mock_client
 
     old = os.environ.pop("RIFTOR_TELEMETRY_DISABLED", None)
     try:
@@ -113,13 +114,13 @@ def test_capture_exception_queues_event():
         )
         t._disabled = False
 
-        with patch.dict(sys.modules, {"posthog": mock_posthog}):
+        with patch.dict(sys.modules, {"posthog": mock_posthog_module}):
             t._init_posthog()
             t.capture_exception(ValueError("something broke"))
             t.flush()
 
-        mock_posthog.capture.assert_called_once()
-        call = mock_posthog.capture.call_args.kwargs
+        mock_client.capture.assert_called_once()
+        call = mock_client.capture.call_args.kwargs
         assert call["event"] == "exception"
         assert call["properties"]["type"] == "ValueError"
     finally:
@@ -128,10 +129,12 @@ def test_capture_exception_queues_event():
 
 
 def test_queue_and_flush_with_mock_posthog():
-    """Events are queued and flushed via posthog.capture."""
+    """Events are queued and flushed via posthog_client.capture."""
     from riftor.telemetry import Telemetry
 
-    mock_posthog = MagicMock()
+    mock_posthog_module = MagicMock()
+    mock_client = MagicMock()
+    mock_posthog_module.Posthog.return_value = mock_client
 
     old = os.environ.pop("RIFTOR_TELEMETRY_DISABLED", None)
     try:
@@ -142,7 +145,7 @@ def test_queue_and_flush_with_mock_posthog():
         )
         t._disabled = False
 
-        with patch.dict(sys.modules, {"posthog": mock_posthog}):
+        with patch.dict(sys.modules, {"posthog": mock_posthog_module}):
             t._init_posthog()
 
             t.track_session_start(model="test-model", theme="rift", yolo=False)
@@ -154,15 +157,18 @@ def test_queue_and_flush_with_mock_posthog():
 
             t.flush()
 
-        assert mock_posthog.capture.call_count == 6
-        events = [call.kwargs["event"] for call in mock_posthog.capture.call_args_list]
+        assert mock_client.capture.call_count == 6
+        events = [call.kwargs["event"] for call in mock_client.capture.call_args_list]
         assert events == [
             "session_start", "tool_call", "model_call",
             "session_end", "exception", "message",
         ]
 
-        assert mock_posthog.host == "https://example.posthog.com"
-        assert mock_posthog.api_key == "phc_test"
+        mock_posthog_module.Posthog.assert_called_once_with(
+            "phc_test",
+            host="https://example.posthog.com",
+            enable_exception_autocapture=True,
+        )
     finally:
         if old is not None:
             os.environ["RIFTOR_TELEMETRY_DISABLED"] = old
@@ -172,8 +178,10 @@ def test_flush_handles_posthog_errors():
     """flush does not propagate posthog errors."""
     from riftor.telemetry import Telemetry
 
-    mock_posthog = MagicMock()
-    mock_posthog.capture.side_effect = RuntimeError("network down")
+    mock_posthog_module = MagicMock()
+    mock_client = MagicMock()
+    mock_client.capture.side_effect = RuntimeError("network down")
+    mock_posthog_module.Posthog.return_value = mock_client
 
     old = os.environ.pop("RIFTOR_TELEMETRY_DISABLED", None)
     try:
@@ -183,12 +191,45 @@ def test_flush_handles_posthog_errors():
         )
         t._disabled = False
 
-        with patch.dict(sys.modules, {"posthog": mock_posthog}):
+        with patch.dict(sys.modules, {"posthog": mock_posthog_module}):
             t._init_posthog()
             t.track_tool_call("bash", allowed=True)
             t.flush()
 
-        mock_posthog.capture.assert_called_once()
+        mock_client.capture.assert_called_once()
+    finally:
+        if old is not None:
+            os.environ["RIFTOR_TELEMETRY_DISABLED"] = old
+
+
+def test_business_events_queue():
+    """Business event tracking methods enqueue the correct events."""
+    from riftor.telemetry import Telemetry
+
+    mock_posthog_module = MagicMock()
+    mock_client = MagicMock()
+    mock_posthog_module.Posthog.return_value = mock_client
+
+    old = os.environ.pop("RIFTOR_TELEMETRY_DISABLED", None)
+    try:
+        t = Telemetry(version="1.0.0", posthog_api_key="phc_test")
+        t._disabled = False
+
+        with patch.dict(sys.modules, {"posthog": mock_posthog_module}):
+            t._init_posthog()
+            t.track_finding_recorded(severity="high", has_cvss=True, has_confidence=True)
+            t.track_report_generated(format="both")
+            t.track_stage_advanced(stage="I")
+            t.track_scan_imported(tool="nmap", services_added=3, findings_added=1)
+            t.track_scope_target_added(count=2)
+            t.flush()
+
+        assert mock_client.capture.call_count == 5
+        events = [call.kwargs["event"] for call in mock_client.capture.call_args_list]
+        assert events == [
+            "finding_recorded", "report_generated", "stage_advanced",
+            "scan_imported", "scope_target_added",
+        ]
     finally:
         if old is not None:
             os.environ["RIFTOR_TELEMETRY_DISABLED"] = old


### PR DESCRIPTION
## Changes from PostHog setup wizard

- **Better PostHog client API**: Uses `Posthog(api_key, host=)` class instead of module-level variables
- **Multiple key sources**: `--posthog_api_key` kwarg → `POSTHOG_PROJECT_TOKEN` env → `RIFTOR_POSTHOG_KEY` env → baked `_telemetry_keys.py`
- **Multiple host sources**: `--posthog_host` kwarg → `POSTHOG_HOST` env → `RIFTOR_POSTHOG_HOST` env → baked `_telemetry_keys.py`
- **New business events**: `track_finding_recorded`, `track_report_generated`, `track_stage_advanced`, `track_scan_imported`, `track_scope_target_added`
- **ToolContext wiring**: `telemetry` field exposed to all tools via ToolContext
- **Engagement tool integration**: SetStageTool, AddScopeTool, RecordFindingTool, ImportScanTool, GenerateReportTool all wired
- **Tests**: Updated for new client API, new business events test