### PR TITLE
fix: bake telemetry keys in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
           VER="$(uv version --short 2>/dev/null || grep -m1 '^version' pyproject.toml | cut -d'"' -f2)"
           echo "tag=$TAG pyproject=$VER"
           test "$TAG" = "$VER" || { echo "::error::tag v$TAG != pyproject version $VER"; exit 1; }
+      - name: Bake telemetry keys
+        env:
+          RIFTOR_POSTHOG_KEY: ${{ secrets.RIFTOR_POSTHOG_KEY }}
+        run: make telemetry-keys
       - name: Build sdist + wheel
         run: uv build
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
Adds a `make telemetry-keys` step to the release workflow so the PyPI wheel ships with the real PostHog key baked in.

**Before this merges**, you need to add the secret in GitHub repo settings:
- Go to Settings → Secrets and variables → Actions
- Add `RIFTOR_POSTHOG_KEY` = `phc_pJYGZRKYL2kP2mtxfsQV2JkLAc8K5Xw9KN8Kx7KVQZ95`

**To trigger a release:**
1. Bump version: `uv version 1.3.1`
2. Merge the version bump PR
3. Tag and push: `git tag v1.3.1 && git push origin v1.3.1`
4. The tag triggers CI → build (with baked key) → PyPI publish → GitHub Release