### PR TITLE
feat: screenshot gallery modal (#51)

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -380,6 +380,17 @@ async def main() -> None:
         await pilot.pause()
         assert len(list(app.query(Markdown))) == 0
 
+        # /screenshots opens the gallery modal; close it with escape
+        from riftor.tui.screenshot_gallery import ScreenshotGalleryScreen
+
+        inp.value = "/screenshots"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, ScreenshotGalleryScreen), type(app.screen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, ScreenshotGalleryScreen)
+
     print("SMOKE OK")
 
 

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -38,6 +38,7 @@ from riftor.safety.audit import AuditLog
 from riftor.safety.permissions import ConfirmScreen, Permissions
 from riftor.tools import ToolContext, ToolResult
 from riftor.tui.config_screen import ConfigScreen
+from riftor.tui.screenshot_gallery import ScreenshotGalleryScreen
 from riftor.tui.theme import THEMES, css_variable_defaults, palette
 from riftor.tui.widgets import STAGE_NAMES, GENZ_STAGE_NAMES, GENZ_STAGE_LETTERS, Banner, CommandDropdown, FlockPane, PulseSpinner, StatusBar
 
@@ -154,7 +155,7 @@ _COMMANDS = [
     "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
     "/sessions", "/resume", "/new", "/theme", "/config", "/tools", "/permissions",
     "/lore", "/genz", "/cost", "/retry", "/continue", "/compact", "/copy", "/show",
-    "/timeline", "/audit", "/export", "/conversation", "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/browser", "/clearlog", "/exit",
+    "/timeline", "/audit", "/export", "/conversation", "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/browser", "/clearlog", "/screenshots", "/exit",
 ]
 
 HELP = """\
@@ -185,6 +186,7 @@ _Settings & sessions_
 - `/audit` — recent tool-call audit log
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed
 - `/browser [headed|headless|close]` — browser status / mode / teardown
+- `/screenshots` — browse, view, and delete browser screenshots
 - `/review` — self-critique findings for false positives before reporting
 - `/hypotheses` — list tracked hypotheses (open leads)
 - `/lesson <text>` — teach a durable lesson (persists across sessions)
@@ -217,6 +219,7 @@ _PALETTE_COMMANDS = [
     ("/config", "Config", "Open the settings panel"),
     ("/new", "New session", "Start a fresh conversation"),
     ("/clear", "Clear", "Clear the conversation"),
+    ("/screenshots", "Screenshots", "Browse, view, and delete screenshots"),
 ]
 
 
@@ -744,6 +747,7 @@ class RiftorApp(App):
             "/conversation": self._conversation_cmd,
             "/doctor": self._doctor_cmd,
             "/browser": lambda: self._browser_cmd(arg),
+            "/screenshots": self._screenshots_cmd,
             "/review": self._review_cmd,
             "/hypotheses": self._hypotheses_cmd,
             "/lesson": lambda: self._lesson_cmd(arg),
@@ -1266,6 +1270,10 @@ class RiftorApp(App):
         profile = "persistent" if self.config.browser_persistent_profile else "incognito"
         state = "running" if (mgr and mgr.launched) else "not launched"
         self._note(f"browser: {state} · {mode} · {profile} (toggle in /config)")
+
+    @work(group="screenshots")
+    async def _screenshots_cmd(self) -> None:
+        await self.push_screen_wait(ScreenshotGalleryScreen(self.workdir))
 
     def _export_cmd(self) -> None:
         import json

--- a/riftor/tui/screenshot_gallery.py
+++ b/riftor/tui/screenshot_gallery.py
@@ -1,0 +1,292 @@
+"""Screenshot gallery modal — browse, view, and delete browser screenshots."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Button, Label, ListItem, ListView, Static
+
+from riftor.tui.theme import palette, css_variable_defaults
+
+try:
+    from textual_image.widget import Image as _InlineImage  # type: ignore
+except Exception:  # noqa: BLE001
+    _InlineImage = None
+
+
+def _human_size(nbytes: int) -> str:
+    if nbytes < 1024:
+        return f"{nbytes} B"
+    elif nbytes < 1024 * 1024:
+        return f"{nbytes / 1024:.1f} KB"
+    else:
+        return f"{nbytes / (1024 * 1024):.1f} MB"
+
+
+def _safe_palette(widget) -> dict[str, str]:
+    try:
+        return palette(widget.app)
+    except Exception:  # noqa: BLE001
+        return css_variable_defaults()
+
+
+class _ScreenshotItem(ListItem):
+    """A single screenshot entry in the list view."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self.screenshot_path = path
+        stat = path.stat()
+        self._label_text = self._format_label(path, stat.st_size, stat.st_mtime)
+
+    @staticmethod
+    def _format_label(path: Path, size: int, mtime: float) -> str:
+        name = path.name
+        hsize = _human_size(size)
+        dt = datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+        return f"{name}    {hsize}    {dt}"
+
+    def compose(self) -> ComposeResult:
+        yield Label(self._label_text)
+
+
+class _PreviewPane(Widget):
+    """Right-side panel showing the selected screenshot."""
+
+    def __init__(self, workdir: Path) -> None:
+        super().__init__()
+        self.workdir = workdir
+        self._current: Path | None = None
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll(id="gallery-preview-scroll"):
+            yield Static("", id="gallery-preview-info")
+            with Vertical(id="gallery-preview-image"):
+                yield Static("", classes="note")
+
+    def show(self, path: Path) -> None:
+        self._current = path
+        p = _safe_palette(self)
+        info = self.query_one("#gallery-preview-info", Static)
+        stat = path.stat()
+        size = _human_size(stat.st_size)
+        info.update(Text(f"{path.name}  ·  {size}", style=p["cyan"]))
+        container = self.query_one("#gallery-preview-image", Vertical)
+        container.remove_children()
+        if _InlineImage is not None:
+            try:
+                container.mount(_InlineImage(str(path)))
+            except Exception:  # noqa: BLE001 — terminal can't render; show link
+                self._show_link(container, path, p)
+        else:
+            self._show_link(container, path, p)
+
+    def clear(self) -> None:
+        self._current = None
+        self.query_one("#gallery-preview-info", Static).update("")
+        container = self.query_one("#gallery-preview-image", Vertical)
+        container.remove_children()
+        container.mount(Static("select a screenshot to preview", classes="note"))
+
+    @staticmethod
+    def _show_link(container: Vertical, path: Path, p: dict) -> None:
+        uri = path.resolve().as_uri()
+        link = Text("open screenshot", style=f"underline {p['cyan']}")
+        link.stylize(f"link {uri}")
+        container.mount(Static(link, classes="note"))
+
+
+class ScreenshotGalleryScreen(ModalScreen[None]):
+    """Browse, preview, and delete screenshots from .riftor/screenshots/."""
+
+    BINDINGS = [
+        ("escape", "cancel", "Close"),
+        ("d", "delete_current", "Delete"),
+        ("j", "cursor_down", "Down"),
+        ("k", "cursor_up", "Up"),
+    ]
+
+    def __init__(self, workdir: Path) -> None:
+        super().__init__()
+        self.workdir = workdir
+        self._shots_dir = workdir / ".riftor" / "screenshots"
+        self._deleting = False
+        self._delete_target: Path | None = None
+
+    def compose(self) -> ComposeResult:
+        p = _safe_palette(self)
+        with Vertical(id="gallery-box"):
+            yield Static(Text("screenshots", style=f"bold {p['violet']}"), id="gallery-title")
+            screenshots = sorted(
+                self._shots_dir.glob("*.png"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            ) if self._shots_dir.exists() else []
+            with Horizontal(id="gallery-main"):
+                if screenshots:
+                    yield ListView(
+                        *(_ScreenshotItem(s) for s in screenshots),
+                        id="gallery-list",
+                    )
+                    yield _PreviewPane(self.workdir)
+                else:
+                    yield Static(
+                        "No screenshots yet.  Use browser_screenshot in a browser session.",
+                        id="gallery-empty",
+                        classes="note",
+                    )
+            with Horizontal(id="gallery-footer"):
+                yield Label("↑↓ navigate · Enter preview · d delete · Esc close", classes="note")
+                if screenshots:
+                    yield Button("Delete", id="gallery-delete-btn", variant="error")
+                    yield Button("Close", id="gallery-close-btn", variant="primary")
+
+    def on_mount(self) -> None:
+        if self._shots_dir.exists():
+            items = self.query("#gallery-list > ListItem")
+            if items:
+                lv = self.query_one("#gallery-list", ListView)
+                lv.focus()
+                self._show_selected()
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        if isinstance(event.item, _ScreenshotItem):
+            self._show_item(event.item.screenshot_path)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        if isinstance(event.item, _ScreenshotItem):
+            self._show_item(event.item.screenshot_path)
+
+    def _current_item(self) -> _ScreenshotItem | None:
+        try:
+            lv = self.query_one("#gallery-list", ListView)
+        except Exception:  # noqa: BLE001
+            return None
+        if lv.index is None or lv.index >= len(lv.children):
+            return None
+        child = list(lv.children)[lv.index]
+        return child if isinstance(child, _ScreenshotItem) else None
+
+    def _show_selected(self) -> None:
+        item = self._current_item()
+        if item is not None:
+            self._show_item(item.screenshot_path)
+
+    def _show_item(self, path: Path) -> None:
+        try:
+            preview = self.query_one(_PreviewPane)
+        except Exception:  # noqa: BLE001
+            return
+        preview.show(path)
+
+    def action_cancel(self) -> None:
+        if self._deleting:
+            self._deleting = False
+            self._delete_target = None
+            self._set_status("")
+            return
+        self.dismiss(None)
+
+    def action_delete_current(self) -> None:
+        item = self._current_item()
+        if item is None:
+            return
+        path = item.screenshot_path
+        if not self._deleting or self._delete_target != path:
+            self._deleting = True
+            self._delete_target = path
+            p = _safe_palette(self)
+            self._set_status(Text(f"press d again to delete {path.name}  ·  Esc to cancel", style=p["danger"]))
+            return
+        self._delete(path)
+
+    def action_cursor_down(self) -> None:
+        try:
+            lv = self.query_one("#gallery-list", ListView)
+            lv.action_cursor_down()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_cursor_up(self) -> None:
+        try:
+            lv = self.query_one("#gallery-list", ListView)
+            lv.action_cursor_up()
+        except Exception:  # noqa: BLE001
+            pass
+
+    @work(group="gallery")
+    async def _delete(self, path: Path) -> None:
+        p = _safe_palette(self)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            self._set_status(Text(f"error deleting {path.name}: {exc}", style=p["danger"]))
+            self._deleting = False
+            self._delete_target = None
+            return
+        self._deleting = False
+        self._delete_target = None
+        self._set_status(Text(f"deleted {path.name}", style=p["cyan"]))
+        self._rebuild_list()
+        if not self._shots_dir.exists() or not list(self._shots_dir.glob("*.png")):
+            self.dismiss(None)
+
+    def _rebuild_list(self) -> None:
+        main = self.query_one("#gallery-main", Horizontal)
+        try:
+            lv = self.query_one("#gallery-list", ListView)
+        except Exception:  # noqa: BLE001
+            return
+        screenshots = sorted(
+            self._shots_dir.glob("*.png"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        ) if self._shots_dir.exists() else []
+        lv.clear()
+        if screenshots:
+            for s in screenshots:
+                lv.mount(_ScreenshotItem(s))
+            if lv.index is not None and lv.index >= len(lv.children):
+                lv.index = len(lv.children) - 1
+            self._show_selected()
+            try:
+                self.query_one("#gallery-delete-btn", Button).disabled = False
+            except Exception:  # noqa: BLE001
+                pass
+        else:
+            main.remove_children()
+            main.mount(Static(
+                "No screenshots yet.  Use browser_screenshot in a browser session.",
+                id="gallery-empty",
+                classes="note",
+            ))
+            try:
+                footer = self.query_one("#gallery-footer", Horizontal)
+                footer.remove_children()
+                footer.mount(Label("No screenshots — Esc to close", classes="note"))
+            except Exception:  # noqa: BLE001
+                pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "gallery-delete-btn":
+            self.action_delete_current()
+        elif event.button.id == "gallery-close-btn":
+            self.dismiss(None)
+
+    def _set_status(self, message: str | Text) -> None:
+        try:
+            title = self.query_one("#gallery-title", Static)
+            if isinstance(message, str):
+                p = _safe_palette(self)
+                title.update(Text(message, style=p["muted"]))
+            else:
+                title.update(message)
+        except Exception:  # noqa: BLE001
+            pass

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -379,3 +379,94 @@ StatusBar {
     padding: 0 2;
     scrollbar-color: $border;
 }
+
+/* ─────────────────────── screenshot gallery ────────────────────────── */
+ScreenshotGalleryScreen {
+    align: center middle;
+    background: $background 75%;
+}
+
+#gallery-box {
+    layout: vertical;
+    width: 90;
+    max-width: 95%;
+    height: 28;
+    max-height: 100%;
+    padding: 0;
+    background: $panel;
+    border: round $violet;
+}
+
+#gallery-title {
+    width: 1fr;
+    height: 3;
+    padding: 1 2 0 2;
+    background: $surface;
+    border-bottom: solid $border;
+    text-style: bold;
+}
+
+#gallery-main {
+    height: 1fr;
+    layout: horizontal;
+}
+
+#gallery-list {
+    width: 32;
+    height: 1fr;
+    background: $surface;
+    padding: 1 0;
+    scrollbar-color: $border;
+}
+
+#gallery-list > ListItem {
+    padding: 0 2;
+    color: $muted;
+}
+
+#gallery-list > ListItem.--highlight {
+    background: $violet 25%;
+    color: $foreground;
+    border-left: thick $violet;
+}
+
+#gallery-preview-scroll {
+    width: 1fr;
+    height: 1fr;
+    padding: 1 2;
+    border-left: solid $border;
+    overflow-y: auto;
+    scrollbar-color: $border;
+}
+
+#gallery-preview-info {
+    height: auto;
+    color: $cyan;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#gallery-preview-image {
+    height: auto;
+}
+
+#gallery-footer {
+    height: 3;
+    align: center middle;
+    background: $surface;
+    border-top: solid $border;
+    padding: 0 2;
+}
+
+#gallery-footer Label {
+    width: 1fr;
+    color: $muted;
+}
+
+#gallery-footer Button {
+    height: 1;
+    min-height: 1;
+    min-width: 10;
+    border: none;
+    margin: 0 0 0 2;
+}

--- a/tests/test_screenshot_gallery.py
+++ b/tests/test_screenshot_gallery.py
@@ -1,0 +1,221 @@
+"""ScreenshotGalleryScreen: renders entries, previews, deletes."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button, ListItem, ListView, Static
+
+import riftor.config as cfgmod
+from riftor.config import Config
+from riftor.tui.app import RiftorApp
+from riftor.tui.screenshot_gallery import (
+    ScreenshotGalleryScreen,
+    _PreviewPane,
+    _ScreenshotItem,
+)
+
+
+def _patch_paths(tmp: Path) -> None:
+    cfgmod.CONFIG_DIR = tmp
+    cfgmod.CONFIG_PATH = tmp / "config.toml"
+    cfgmod.PERMISSIONS_PATH = tmp / "permissions.toml"
+    cfgmod.KEYBINDINGS_PATH = tmp / "kb.toml"
+
+
+def _make_screenshots(workdir: Path, count: int = 3) -> list[Path]:
+    shots_dir = workdir / ".riftor" / "screenshots"
+    shots_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(1, count + 1):
+        p = shots_dir / f"{i:03d}.png"
+        p.write_bytes(b"\x89PNG\x0d\x0a\x1a\x0a" + b"\x00" * 42)
+        paths.append(p)
+    return paths
+
+
+@pytest.mark.asyncio
+async def test_gallery_empty_renders_note(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=Path(d))
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, ScreenshotGalleryScreen)
+            screen = app.screen
+            # empty state: the note widget exists, and there is no list
+            assert screen.query_one("#gallery-empty", Static) is not None
+            assert not screen.query("#gallery-list")
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_gallery_renders_entries(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=3)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, ScreenshotGalleryScreen)
+            screen = app.screen
+            lv = screen.query_one("#gallery-list", ListView)
+            items = list(lv.query(_ScreenshotItem))
+            assert len(items) == 3
+            # newest-first ordering; each item carries its source path
+            assert all(i.screenshot_path.suffix == ".png" for i in items)
+            assert {i.screenshot_path.name for i in items} == {"001.png", "002.png", "003.png"}
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_gallery_select_shows_preview(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=2)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            preview = screen.query_one(_PreviewPane)
+            assert preview._current is not None
+            assert preview._current.name in {"001.png", "002.png"}
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_gallery_delete_requires_double_press(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=2)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            lv = screen.query_one("#gallery-list", ListView)
+            assert len(list(lv.query(ListItem))) == 2
+            await pilot.press("d")
+            await pilot.pause()
+            assert screen._deleting is True
+            await pilot.press("escape")
+            await pilot.pause()
+            assert screen._deleting is False
+            assert screen._delete_target is None
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_gallery_delete_removes_entry(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=2)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            lv = screen.query_one("#gallery-list", ListView)
+            assert len(list(lv.query(ListItem))) == 2
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+            assert screen._deleting is False
+            items = list(lv.query(ListItem))
+            assert len(items) == 1
+            await pilot.press("escape")
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_gallery_delete_last_screenshot_dismisses(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=1)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+            assert not isinstance(app.screen, ScreenshotGalleryScreen)
+
+
+@pytest.mark.asyncio
+async def test_gallery_delete_button(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=2)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            btn = screen.query_one("#gallery-delete-btn", Button)
+            btn.press()
+            await pilot.pause()
+            assert screen._deleting is True
+            btn.press()
+            await pilot.pause()
+            assert screen._deleting is False
+            items = list(screen.query(ListItem))
+            assert len(items) == 1
+            await pilot.press("escape")
+
+
+@pytest.mark.asyncio
+async def test_gallery_close_button(monkeypatch):
+    monkeypatch.setattr(cfgmod, "CONFIG_DIR", Path(tempfile.mkdtemp()))
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        _make_screenshots(workdir, count=1)
+        cfg = Config()
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test() as pilot:
+            app.query_one("#prompt").value = "/screenshots"
+            await pilot.press("enter")
+            await pilot.pause()
+            screen = app.screen
+            screen.query_one("#gallery-close-btn", Button).press()
+            await pilot.pause()
+            assert not isinstance(app.screen, ScreenshotGalleryScreen)

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Closes #51.

Adds a `/screenshots` command that opens a gallery modal to browse, preview, and delete browser screenshots from `.riftor/screenshots/`.

## What's new
- **`riftor/tui/screenshot_gallery.py`** — `ScreenshotGalleryScreen`:
  - Newest-first list (name / size / date)
  - Inline preview pane via `textual_image`, with a clickable-link fallback when inline rendering isn't available
  - `j`/`k`/arrow navigation, `d`-to-delete with double-press confirm
  - Dismisses automatically when the last screenshot is removed; empty state otherwise
- **`riftor/tui/app.py`** — `/screenshots` wired into the command list, handler, help text, and Ctrl+P palette
- **`riftor/tui/themes/rift.tcss`** — gallery styling matching the config modal
- **`tests/test_screenshot_gallery.py`** — 8 unit tests
- **`dev/smoke.py`** — headless open/close smoke check
- **`uv.lock`** — sync `riftor` version to 1.5.0 (matches `pyproject.toml`)

## Verification
- `ruff`: clean
- `pyright`: 0 errors, 0 warnings (gallery file)
- `pytest`: 324 passed (8 new)
- smoke: `SMOKE OK` + real browser ok