### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "1.5.0"
+version = "1.6.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Release bump for **v1.6.0**.

Lands the version bump on `main` first (per the release procedure in CONTRIBUTING.md / `release.yml`) so the `v1.6.0` tag can be cut against the merged commit.

### Since v1.5.0
- #93 — Screenshot gallery modal (`/screenshots`)
- #94 — Per-engagement memory (`/memory`, `remember` tool) + engagement templates (`/template`)

Both are new, backward-compatible features → minor bump.

### Changes
- `pyproject.toml` + `uv.lock`: `1.5.0` → `1.6.0` (via `uv version 1.6.0`)

After merge + green CI, tag `v1.6.0` on the merged commit to trigger the release workflow (PyPI publish + GitHub Release).