### PR TITLE
Wordlist management (#58) and plugin system (#62)

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -459,6 +459,13 @@ async def test_tools() -> None:
         for s in tools.schemas():
             assert s["type"] == "function" and s["function"]["name"]
 
+        # register_plugins is a no-op with no plugins dir; never shrinks the registry
+        from riftor.config import Config as _Config
+
+        _before = len(tools.all_tools())
+        tools.register_plugins(_Config())
+        assert len(tools.all_tools()) >= _before, "register_plugins shrank the registry"
+
     print("TOOLS OK")
 
 

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -450,6 +450,11 @@ async def test_tools() -> None:
         )
         assert r.is_error, "edit should fail on missing old_string"
 
+        # wordlist tool: registered and runs without crashing on a clean box
+        assert tools.get("wordlist") is not None, "wordlist tool not registered"
+        r = await tools.get("wordlist").execute({}, ctx)
+        assert not r.is_error, r.content
+
         # schemas are well-formed for litellm
         for s in tools.schemas():
             assert s["type"] == "function" and s["function"]["name"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |
 | `browser_headless` | bool | `true` | Run the Playwright browser headless (good for servers/SSH). Set `false` to launch it visibly. |
 | `browser_persistent_profile` | bool | `false` | Reuse a profile at `.riftor/browser-profile/` (persists cookies/sessions). Default is incognito — a fresh context per launch. |
+| `wordlists_dir` | string | — | Extra directory the `wordlist` tool searches, in addition to the known SecLists/system locations. |
 | `chakla_model` | string | `anthropic/claude-haiku-4-5-20251001` | The cheap worker model used by dispatched Chakla subagents. |
 | `chakla_max_workers` | int | `5` | Max number of Chakla workers per dispatch batch. |
 | `chakla_timeout_s` | int | `300` | Per-worker wall-clock timeout in seconds. |
@@ -52,6 +53,23 @@ rate_limit_per_min = 0
 # model = "ollama_chat/llama3.1"
 # api_base = "http://localhost:11434"
 ```
+
+### Wordlists
+
+The `wordlist` agent tool discovers local wordlists for fuzzing/brute-forcing
+(ffuf, gobuster, nuclei, hydra). It probes these locations:
+
+- `/usr/share/seclists`
+- `/usr/share/wordlists/seclists`
+- `/usr/share/wordlists`
+- `~/.local/share/seclists`
+- the `wordlists_dir` you configure, if any
+
+Call it with no arguments for the full catalog grouped by category, or pass a
+`query` (e.g. `directory`, `subdomains`, `common`, `usernames`) to find the best
+match. It returns absolute paths to plug straight into a `bash` command. If no
+wordlists are found, install [SecLists](https://github.com/danielmiessler/SecLists)
+or set `wordlists_dir`.
 
 ### Subagents (Baaj / Chakla)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,9 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `browser_headless` | bool | `true` | Run the Playwright browser headless (good for servers/SSH). Set `false` to launch it visibly. |
 | `browser_persistent_profile` | bool | `false` | Reuse a profile at `.riftor/browser-profile/` (persists cookies/sessions). Default is incognito — a fresh context per launch. |
 | `wordlists_dir` | string | — | Extra directory the `wordlist` tool searches, in addition to the known SecLists/system locations. |
+| `plugins_enabled` | bool | `true` | Master switch for operator plugins. `false` disables all plugin loading. |
+| `plugins_allow` | list | `[]` | If non-empty, only these plugin module names are loaded. |
+| `plugins_deny` | list | `[]` | Plugin module names to skip. Deny wins over allow. |
 | `chakla_model` | string | `anthropic/claude-haiku-4-5-20251001` | The cheap worker model used by dispatched Chakla subagents. |
 | `chakla_max_workers` | int | `5` | Max number of Chakla workers per dispatch batch. |
 | `chakla_timeout_s` | int | `300` | Per-worker wall-clock timeout in seconds. |
@@ -152,6 +155,54 @@ Screenshots are saved to `.riftor/screenshots/`. They render inline in the termi
 if the optional extra is installed (`pip install 'riftor[browser-ui]'`) on Python
 ≥3.12 and the terminal supports Kitty or Sixel graphics; otherwise riftor shows the
 saved file path.
+
+## Plugins
+
+Operators can extend riftor with their own tools by dropping Python files (or
+packages) into the plugins directory:
+
+- `$XDG_CONFIG_HOME/riftor/plugins` if `XDG_CONFIG_HOME` is set,
+- otherwise `~/.config/riftor/plugins`.
+
+Each top-level `.py` file or package (a directory with `__init__.py`) must export a
+module-level `TOOLS` list. Files and directories whose names start with `_` or `.`
+are ignored.
+
+```python
+# ~/.config/riftor/plugins/hello.py
+from riftor.tools.base import Tool, ToolResult
+
+
+class HelloTool(Tool):
+    name = "hello"
+    description = "Say hello."
+    parameters = {"type": "object", "properties": {}}
+
+    async def execute(self, args, ctx):
+        return ToolResult("hello from a plugin")
+
+
+TOOLS = [HelloTool()]
+```
+
+Each item in `TOOLS` must be an instance of a `Tool` subclass with a unique,
+non-built-in `name` and a `dict` `parameters` schema. Plugins are discovered and
+registered once at startup. A plugin that fails to load (missing/invalid `TOOLS`,
+a non-`Tool` item, an empty name, a name that collides with a built-in or another
+plugin, or an import error) is skipped with a warning — it never crashes riftor.
+In the TUI the warning appears as a startup notice; in `--headless` it prints to
+stderr.
+
+Control loading with the config fields above:
+
+- `plugins_enabled = false` disables all plugins (kill switch).
+- `plugins_allow = ["foo"]` loads only the listed modules.
+- `plugins_deny = ["bar"]` skips the listed modules; **deny wins over allow**.
+
+> **Trust:** plugin code runs with the **same privileges as riftor itself** — the
+> operator-owned config directory is the trust boundary. Only install plugins you
+> trust. Plugin tools still flow through the permission and scope engine according
+> to their own `requires_permission` / `danger` / `scope_sensitive` flags.
 
 ## Providers & models
 

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -78,6 +78,12 @@ class Config(BaseModel):
     # Optional extra root searched by the `wordlist` tool (in addition to known
     # SecLists/system locations). None => only the known roots are probed.
     wordlists_dir: str | None = None
+    # Operator plugins (.py / packages under ~/.config/riftor/plugins exporting
+    # a module-level TOOLS list). Loaded at startup. plugins_enabled is the kill
+    # switch; deny wins over allow.
+    plugins_enabled: bool = True
+    plugins_allow: list[str] = []
+    plugins_deny: list[str] = []
     # Tracks whether we've shown the first-run onboarding.
     onboarded: bool = False
 
@@ -247,6 +253,9 @@ class Config(BaseModel):
             f'wordlists_dir = "{self.wordlists_dir}"' if self.wordlists_dir
             else '# wordlists_dir = "/usr/share/seclists"',
             f"onboarded = {str(self.onboarded).lower()}",
+            f"plugins_enabled = {str(self.plugins_enabled).lower()}",
+            f"plugins_allow = [{', '.join(repr(x) for x in self.plugins_allow)}]",
+            f"plugins_deny = [{', '.join(repr(x) for x in self.plugins_deny)}]",
 
             f'chakla_model = "{self.chakla_model}"',
             f"chakla_max_workers = {self.chakla_max_workers}",

--- a/riftor/config.py
+++ b/riftor/config.py
@@ -75,6 +75,9 @@ class Config(BaseModel):
     # persist a client's session cookies. Persistent profile is opt-in via /config.
     browser_headless: bool = True
     browser_persistent_profile: bool = False
+    # Optional extra root searched by the `wordlist` tool (in addition to known
+    # SecLists/system locations). None => only the known roots are probed.
+    wordlists_dir: str | None = None
     # Tracks whether we've shown the first-run onboarding.
     onboarded: bool = False
 
@@ -241,6 +244,8 @@ class Config(BaseModel):
             f"rate_limit_per_min = {self.rate_limit_per_min}",
             f"browser_headless = {str(self.browser_headless).lower()}",
             f"browser_persistent_profile = {str(self.browser_persistent_profile).lower()}",
+            f'wordlists_dir = "{self.wordlists_dir}"' if self.wordlists_dir
+            else '# wordlists_dir = "/usr/share/seclists"',
             f"onboarded = {str(self.onboarded).lower()}",
 
             f'chakla_model = "{self.chakla_model}"',

--- a/riftor/engagement/wordlists.py
+++ b/riftor/engagement/wordlists.py
@@ -1,0 +1,122 @@
+"""Wordlist discovery: probe known SecLists/system roots + an optional config dir.
+
+Pure and side-effect-free (filesystem reads only). Never raises — a missing or
+unreadable root is skipped silently, mirroring engagement/doctor.py's probing.
+The agent calls the ``wordlist`` tool, which resolves absolute paths to feed into
+ffuf/gobuster via ``bash``. v1 discovers existing lists only (no generation).
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Probed in order. A file reachable from several roots is deduped by resolved path.
+KNOWN_ROOTS: list[str] = [
+    "/usr/share/seclists",
+    "/usr/share/wordlists/seclists",
+    "/usr/share/wordlists",
+    "~/.local/share/seclists",
+]
+
+_EXTENSIONS = (".txt", ".lst")
+MAX_WORDLISTS = 500   # cap total results so we never flood the model's context
+MAX_DEPTH = 6         # cap recursion depth under each root
+
+# Cache line counts by (resolved path, mtime, size) so re-counting is free and a
+# changed file is recounted.
+_LINE_CACHE: dict[tuple[str, int, int], int] = {}
+
+
+@dataclass(frozen=True)
+class Wordlist:
+    name: str        # file name, e.g. "common.txt"
+    path: Path       # resolved absolute path
+    category: str    # path under its root, e.g. "Discovery/Web-Content"; "(root)" if direct
+
+
+def _roots(extra_dir: str | None, known_roots: list[str] | None) -> list[Path]:
+    raw = list(KNOWN_ROOTS if known_roots is None else known_roots)
+    if extra_dir:
+        raw.append(extra_dir)
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for r in raw:
+        try:
+            p = Path(r).expanduser().resolve()
+        except OSError:
+            continue
+        if p.is_dir() and p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _category(root: Path, file_path: Path) -> str:
+    rel = file_path.parent.relative_to(root)
+    return "(root)" if str(rel) == "." else str(rel)
+
+
+def discover(
+    extra_dir: str | None = None,
+    known_roots: list[str] | None = None,
+) -> list[Wordlist]:
+    """Walk known roots (+ optional extra dir) for *.txt/*.lst, capped & deduped."""
+    found: dict[Path, Wordlist] = {}
+    for root in _roots(extra_dir, known_roots):
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            depth = len(Path(dirpath).relative_to(root).parts)
+            if depth >= MAX_DEPTH:
+                dirnames[:] = []
+            # never descend into symlinked dirs (loops / escaping the root)
+            dirnames[:] = [d for d in dirnames if not (Path(dirpath) / d).is_symlink()]
+            for fn in filenames:
+                if not fn.endswith(_EXTENSIONS):
+                    continue
+                try:
+                    fp = (Path(dirpath) / fn).resolve()
+                except OSError:
+                    continue
+                if fp in found:
+                    continue
+                found[fp] = Wordlist(name=fn, path=fp, category=_category(root, fp))
+                if len(found) >= MAX_WORDLISTS:
+                    return list(found.values())
+    return list(found.values())
+
+
+def count_lines(path: Path) -> int | None:
+    """Line count for ``path``, cached by (path, mtime, size). None if unreadable."""
+    try:
+        st = path.stat()
+        key = (str(path), int(st.st_mtime), int(st.st_size))
+    except OSError:
+        return None
+    if key in _LINE_CACHE:
+        return _LINE_CACHE[key]
+    try:
+        with path.open("rb") as fh:
+            n = sum(buf.count(b"\n") for buf in iter(lambda: fh.read(1 << 20), b""))
+    except OSError:
+        return None
+    _LINE_CACHE[key] = n
+    return n
+
+
+def search(query: str, lists: list[Wordlist], limit: int = 25) -> list[Wordlist]:
+    """Substring match on 'category/name' and path; difflib fuzzy fallback on names."""
+    q = query.strip().lower()
+    if not q:
+        return lists[:limit]
+    hits = [
+        w for w in lists
+        if q in f"{w.category}/{w.name}".lower() or q in str(w.path).lower()
+    ]
+    if hits:
+        return hits[:limit]
+    names = [w.name for w in lists]
+    close = difflib.get_close_matches(q, [n.lower() for n in names], n=limit, cutoff=0.5)
+    chosen = {c for c in close}
+    return [w for w in lists if w.name.lower() in chosen][:limit]

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -97,6 +97,8 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
         yolo=yolo,
         progress=_make_progress_printer(),
     )
+    for err in tools.register_plugins(cfg):
+        print(f"riftor: plugin '{err.module}' skipped: {err.error.splitlines()[-1]}", file=sys.stderr)
     schemas = tools.schemas()
 
     context.add_user(prompt)

--- a/riftor/plugins.py
+++ b/riftor/plugins.py
@@ -1,0 +1,112 @@
+"""Operator-authored plugins: drop a .py file or package into the XDG plugins dir
+exporting a module-level ``TOOLS: list[Tool]``. They are discovered + validated at
+app/headless startup (see riftor.tools.register_plugins).
+
+Pure: ``load_plugins`` never mutates the tool registry — it returns the accepted
+tools and a list of per-plugin errors. A bad plugin is warned + skipped, never
+fatal (mirrors "bad config never crashes"). Plugin code runs with the SAME trust as
+riftor itself — the operator-owned XDG config dir is the trust boundary.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+from riftor.tools.base import Tool
+
+
+@dataclass
+class PluginError:
+    module: str
+    error: str
+
+
+def plugins_dir() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path.home() / ".config"
+    return root / "riftor" / "plugins"
+
+
+def _module_paths(pdir: Path) -> list[tuple[str, Path]]:
+    """(module_name, import_target) for each top-level .py file and package dir."""
+    out: list[tuple[str, Path]] = []
+    for entry in sorted(pdir.iterdir()):
+        name = entry.name
+        if name.startswith(("_", ".")):
+            continue
+        if entry.is_file() and name.endswith(".py"):
+            out.append((entry.stem, entry))
+        elif entry.is_dir() and (entry / "__init__.py").exists():
+            out.append((name, entry))
+    return out
+
+
+def _import_module(mod_name: str, target: Path):
+    if target.is_dir():
+        parent = str(target.parent)
+        if parent not in sys.path:
+            sys.path.insert(0, parent)
+        return importlib.import_module(mod_name)
+    spec = importlib.util.spec_from_file_location(f"riftor_plugin_{mod_name}", target)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load spec for {target}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_plugins(config, builtin_names: set[str]) -> tuple[list[Tool], list[PluginError]]:
+    """Discover + validate plugins. Returns (accepted_tools, errors). Never raises."""
+    enabled = getattr(config, "plugins_enabled", True)
+    if not enabled:
+        return [], []
+    pdir = plugins_dir()
+    if not pdir.is_dir():
+        return [], []
+
+    allow = set(getattr(config, "plugins_allow", []) or [])
+    deny = set(getattr(config, "plugins_deny", []) or [])
+
+    accepted: list[Tool] = []
+    errors: list[PluginError] = []
+    taken = set(builtin_names)
+
+    for mod_name, target in _module_paths(pdir):
+        if mod_name in deny:  # deny wins over allow
+            continue
+        if allow and mod_name not in allow:
+            continue
+        try:
+            module = _import_module(mod_name, target)
+        except Exception:  # noqa: BLE001 — one bad plugin must not break the rest
+            errors.append(PluginError(mod_name, traceback.format_exc(limit=3).strip()))
+            continue
+
+        tools_attr = getattr(module, "TOOLS", None)
+        if not isinstance(tools_attr, list):
+            errors.append(PluginError(mod_name, "missing or non-list TOOLS"))
+            continue
+
+        for item in tools_attr:
+            if not isinstance(item, Tool):
+                errors.append(PluginError(mod_name, f"TOOLS item is not a Tool: {item!r}"))
+                continue
+            if not isinstance(item.name, str) or not item.name.strip():
+                errors.append(PluginError(mod_name, "tool has empty/invalid name"))
+                continue
+            if not isinstance(item.parameters, dict):
+                errors.append(PluginError(mod_name, f"tool {item.name}: parameters not a dict"))
+                continue
+            if item.name in taken:
+                errors.append(PluginError(mod_name, f"tool name '{item.name}' collides; skipped"))
+                continue
+            taken.add(item.name)
+            accepted.append(item)
+
+    return accepted, errors

--- a/riftor/tools/__init__.py
+++ b/riftor/tools/__init__.py
@@ -30,6 +30,7 @@ from riftor.tools.engagement import (
     ResolveHypothesisTool,
     ScopeListTool,
     SetStageTool,
+    WordlistTool,
 )
 from riftor.tools.subagent import DispatchChaklaTool
 from riftor.tools.browser import (
@@ -47,6 +48,7 @@ from riftor.tools.browser import (
 ALL_TOOLS: list[Tool] = [
     ScopeListTool(),
     ListHostsTool(),
+    WordlistTool(),
     ReadTool(),
     GlobTool(),
     GrepTool(),

--- a/riftor/tools/__init__.py
+++ b/riftor/tools/__init__.py
@@ -89,6 +89,26 @@ def all_tools() -> list[Tool]:
     return ALL_TOOLS
 
 
+def register_plugins(config) -> list:
+    """Discover operator plugins and register them into ALL_TOOLS + _BY_NAME.
+
+    The single registry mutator. Keeps all_tools()/schemas()/get() consistent so a
+    plugin tool offered to the model can also be dispatched. Idempotent: a tool name
+    already present (built-in or already-registered plugin) is skipped. Returns the
+    list of PluginError for the caller to surface. Explicit at startup — NOT called
+    at import time, so the registry stays deterministic for tests.
+    """
+    from riftor.plugins import load_plugins
+
+    plugin_tools, errors = load_plugins(config, builtin_names=set(_BY_NAME))
+    for t in plugin_tools:
+        if t.name in _BY_NAME:
+            continue
+        ALL_TOOLS.append(t)
+        _BY_NAME[t.name] = t
+    return errors
+
+
 def get(name: str) -> Tool | None:
     return _BY_NAME.get(name)
 
@@ -97,4 +117,4 @@ def schemas() -> list[dict]:
     return [t.schema() for t in ALL_TOOLS]
 
 
-__all__ = ["Tool", "ToolContext", "ToolResult", "all_tools", "get", "schemas"]
+__all__ = ["Tool", "ToolContext", "ToolResult", "all_tools", "get", "register_plugins", "schemas"]

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -511,6 +511,73 @@ class LoadSkillTool(Tool):
         )
 
 
+class WordlistTool(Tool):
+    name = "wordlist"
+    description = (
+        "List or search local wordlists for fuzzing/brute-forcing (ffuf, gobuster, "
+        "nuclei, hydra). Searches known SecLists/system locations and any configured "
+        "dir, returning absolute paths to plug into a bash command. Call with no args "
+        "to see the catalog grouped by category; pass `query` (e.g. 'directory', "
+        "'subdomains', 'common', 'usernames') to find the best match. An empty result "
+        "means none are installed — suggest the operator install SecLists."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": (
+                    "Optional filter, e.g. 'directory', 'subdomains', 'common', "
+                    "'usernames'. Omit to list the full catalog grouped by category."
+                ),
+            },
+        },
+    }
+
+    async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
+        from riftor.engagement.wordlists import KNOWN_ROOTS, count_lines, discover, search
+
+        extra = ctx.config.wordlists_dir if ctx.config is not None else None
+        lists = discover(extra_dir=extra)
+        if not lists:
+            roots = list(KNOWN_ROOTS) + ([extra] if extra else [])
+            return ToolResult(
+                "no wordlists found. Searched: "
+                + ", ".join(roots)
+                + ". Install SecLists or set `wordlists_dir` in config "
+                + "(~/.config/riftor/config.toml)."
+            )
+
+        query = str(args.get("query") or "").strip()
+        if query:
+            matches = search(query, lists)
+            if not matches:
+                cats = sorted({w.category for w in lists})
+                return ToolResult(
+                    f"no wordlist matched '{query}'. Categories available: "
+                    + ", ".join(cats)
+                )
+            lines = [f"# wordlists matching '{query}'"]
+            for w in matches:
+                n = count_lines(w.path)
+                lines.append(f"- {w.path}  ({w.category}, {n if n is not None else '?'} lines)")
+            return ToolResult("\n".join(lines)).truncated(ctx.max_result_chars)
+
+        # No query: grouped catalog.
+        by_cat: dict[str, list] = {}
+        for w in lists:
+            by_cat.setdefault(w.category, []).append(w)
+        out = [f"# {len(lists)} wordlists ({len(by_cat)} categories)"]
+        for cat in sorted(by_cat):
+            out.append(f"\n## {cat}")
+            for w in sorted(by_cat[cat], key=lambda x: x.name):
+                n = count_lines(w.path)
+                out.append(f"- {w.name}  {w.path}  ({n if n is not None else '?'} lines)")
+        if len(lists) >= 500:
+            out.append("\n…list capped at 500; pass a `query` to narrow.")
+        return ToolResult("\n".join(out)).truncated(ctx.max_result_chars)
+
+
 class RecordHypothesisTool(Tool):
     name = "record_hypothesis"
     description = (

--- a/riftor/tools/engagement.py
+++ b/riftor/tools/engagement.py
@@ -535,15 +535,22 @@ class WordlistTool(Tool):
     }
 
     async def execute(self, args: dict, ctx: ToolContext) -> ToolResult:
-        from riftor.engagement.wordlists import KNOWN_ROOTS, count_lines, discover, search
+        from riftor.engagement.wordlists import (
+            KNOWN_ROOTS,
+            Wordlist,
+            count_lines,
+            discover,
+            search,
+        )
 
         extra = ctx.config.wordlists_dir if ctx.config is not None else None
         lists = discover(extra_dir=extra)
         if not lists:
             roots = list(KNOWN_ROOTS) + ([extra] if extra else [])
+            shown = ", ".join(str(Path(r).expanduser()) for r in roots)
             return ToolResult(
                 "no wordlists found. Searched: "
-                + ", ".join(roots)
+                + shown
                 + ". Install SecLists or set `wordlists_dir` in config "
                 + "(~/.config/riftor/config.toml)."
             )
@@ -564,7 +571,7 @@ class WordlistTool(Tool):
             return ToolResult("\n".join(lines)).truncated(ctx.max_result_chars)
 
         # No query: grouped catalog.
-        by_cat: dict[str, list] = {}
+        by_cat: dict[str, list[Wordlist]] = {}
         for w in lists:
             by_cat.setdefault(w.category, []).append(w)
         out = [f"# {len(lists)} wordlists ({len(by_cat)} categories)"]

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -307,6 +307,7 @@ class RiftorApp(App):
         self.yolo = yolo
         self.context = Context(lore=config.lore, genz=config.genz, workdir=self.workdir)
         self.provider = Provider(config)
+        self._plugin_errors = tools.register_plugins(config)
         self.tools = tools.all_tools()
         self.tool_schemas = tools.schemas()
         self.engagement = Engagement(self.workdir)
@@ -393,6 +394,8 @@ class RiftorApp(App):
         warning = self.config.model_warning()
         if warning:
             self._note("⚠ " + warning)
+        for err in getattr(self, "_plugin_errors", []):
+            self._note(f"plugin '{err.module}' skipped: {err.error.splitlines()[-1]}")
         self._toolchain_heads_up()
         # If the previous run crashed (incomplete session), prompt for recovery
         # after mount; otherwise resume the latest complete session as normal.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,18 @@ def test_creds_for_openrouter_routed_id_is_miskeyed_known_limitation(monkeypatch
     cfg = Config(model="openrouter/auto")
     cfg.providers = {"openrouter": cfgmod.ProviderCreds(api_key="sk-or")}
     assert cfg.creds_for("openai/gpt-5.5") == (None, None)
+
+
+def test_wordlists_dir_defaults_none_and_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setattr("riftor.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("riftor.config.CONFIG_PATH", tmp_path / "config.toml")
+    from riftor.config import Config
+
+    cfg = Config()
+    assert cfg.wordlists_dir is None
+
+    cfg.wordlists_dir = "/opt/wordlists"
+    cfg.save()
+    import tomllib
+    data = tomllib.loads((tmp_path / "config.toml").read_text())
+    assert data["riftor"]["wordlists_dir"] == "/opt/wordlists"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -259,3 +259,22 @@ def test_wordlists_dir_defaults_none_and_round_trips(tmp_path, monkeypatch):
     import tomllib
     data = tomllib.loads((tmp_path / "config.toml").read_text())
     assert data["riftor"]["wordlists_dir"] == "/opt/wordlists"
+
+
+def test_plugin_fields_default_and_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr("riftor.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("riftor.config.CONFIG_PATH", tmp_path / "config.toml")
+    from riftor.config import Config
+
+    cfg = Config()
+    assert cfg.plugins_enabled is True
+    assert cfg.plugins_allow == [] and cfg.plugins_deny == []
+
+    cfg.plugins_enabled = False
+    cfg.plugins_deny = ["sketchy"]
+    cfg.save()
+
+    import tomllib
+    data = tomllib.loads((tmp_path / "config.toml").read_text())
+    assert data["riftor"]["plugins_enabled"] is False
+    assert data["riftor"]["plugins_deny"] == ["sketchy"]

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -110,3 +110,26 @@ async def test_yolo_bypasses_requires_permission(gate):
     msg = _last_tool_result(context)
     assert "denied" not in msg.lower()
     assert (gate[3].workdir / "x.txt").read_text() == "yo"
+
+
+def test_headless_registers_plugins(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    pdir = tmp_path / "riftor" / "plugins"
+    pdir.mkdir(parents=True)
+    (pdir / "demo.py").write_text(
+        "from riftor.tools.base import Tool, ToolResult\n"
+        "class T(Tool):\n"
+        "    name='hello_plugin'; description='d'; parameters={'type':'object','properties':{}}\n"
+        "    async def execute(self, args, ctx): return ToolResult('hi')\n"
+        "TOOLS=[T()]\n"
+    )
+    import riftor.tools as tools_pkg
+
+    snap_list, snap_map = list(tools_pkg.ALL_TOOLS), dict(tools_pkg._BY_NAME)
+    try:
+        tools_pkg.register_plugins(Config())
+        assert tools_pkg.get("hello_plugin") is not None
+    finally:
+        tools_pkg.ALL_TOOLS[:] = snap_list
+        tools_pkg._BY_NAME.clear()
+        tools_pkg._BY_NAME.update(snap_map)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -51,8 +51,6 @@ def test_valid_single_file_plugin_loads(monkeypatch, tmp_path):
     assert [t.name for t in tools] == ["hello_plugin"]
 
 
-# TODO(Task 3): remove this skip once Config gains the `plugins_enabled` field.
-@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
 def test_disabled_loads_nothing(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
@@ -60,8 +58,6 @@ def test_disabled_loads_nothing(monkeypatch, tmp_path):
     assert tools == [] and errors == []
 
 
-# TODO(Task 3): remove this skip once Config gains the `plugins_deny` field.
-@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
 def test_deny_skips_module(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
@@ -69,8 +65,6 @@ def test_deny_skips_module(monkeypatch, tmp_path):
     assert tools == []
 
 
-# TODO(Task 3): remove this skip once Config gains the `plugins_allow` field.
-@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
 def test_allowlist_loads_only_listed(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     pdir = tmp_path / "riftor" / "plugins"
@@ -80,8 +74,6 @@ def test_allowlist_loads_only_listed(monkeypatch, tmp_path):
     assert [t.name for t in tools] == ["hello_plugin"]
 
 
-# TODO(Task 3): remove this skip once Config gains the plugin allow/deny fields.
-@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
 def test_deny_wins_over_allow(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,8 +7,10 @@ from pathlib import Path
 
 import pytest
 
+import riftor.tools as tools_pkg
 from riftor.config import Config
 from riftor.plugins import PluginError, load_plugins, plugins_dir
+from riftor.tools import all_tools, get, schemas
 
 
 def _write_plugin(dirpath: Path, name: str, body: str) -> None:
@@ -131,3 +133,41 @@ def test_underscore_files_skipped(monkeypatch, tmp_path):
     _write_plugin(tmp_path / "riftor" / "plugins", "_private", _GOOD)
     tools, errors = load_plugins(Config(), builtin_names=set())
     assert tools == [] and errors == []
+
+
+@pytest.fixture
+def restore_registry():
+    snap_list = list(tools_pkg.ALL_TOOLS)
+    snap_map = dict(tools_pkg._BY_NAME)
+    yield
+    tools_pkg.ALL_TOOLS[:] = snap_list
+    tools_pkg._BY_NAME.clear()
+    tools_pkg._BY_NAME.update(snap_map)
+
+
+def test_import_does_not_load_plugins(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    import importlib
+
+    importlib.reload(tools_pkg)
+    assert tools_pkg.get("hello_plugin") is None
+
+
+def test_register_updates_all_three_seams(monkeypatch, tmp_path, restore_registry):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    errors = tools_pkg.register_plugins(Config())
+    assert errors == []
+    assert get("hello_plugin") is not None
+    assert any(t.name == "hello_plugin" for t in all_tools())
+    assert any(s["function"]["name"] == "hello_plugin" for s in schemas())
+
+
+def test_register_is_idempotent(monkeypatch, tmp_path, restore_registry):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    tools_pkg.register_plugins(Config())
+    before = len(all_tools())
+    tools_pkg.register_plugins(Config())
+    assert len(all_tools()) == before

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,133 @@
+"""Plugin discovery + validation. Pure: load_plugins never mutates the registry."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from riftor.config import Config
+from riftor.plugins import PluginError, load_plugins, plugins_dir
+
+
+def _write_plugin(dirpath: Path, name: str, body: str) -> None:
+    dirpath.mkdir(parents=True, exist_ok=True)
+    (dirpath / f"{name}.py").write_text(textwrap.dedent(body))
+
+
+_GOOD = '''
+    from riftor.tools.base import Tool, ToolContext, ToolResult
+
+    class HelloTool(Tool):
+        name = "hello_plugin"
+        description = "demo"
+        parameters = {"type": "object", "properties": {}}
+        async def execute(self, args, ctx):
+            return ToolResult("hi")
+
+    TOOLS = [HelloTool()]
+'''
+
+
+def test_plugins_dir_uses_xdg(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert plugins_dir() == tmp_path / "riftor" / "plugins"
+
+
+def test_missing_dir_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == [] and errors == []
+
+
+def test_valid_single_file_plugin_loads(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert errors == []
+    assert [t.name for t in tools] == ["hello_plugin"]
+
+
+# TODO(Task 3): remove this skip once Config gains the `plugins_enabled` field.
+@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
+def test_disabled_loads_nothing(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    tools, errors = load_plugins(Config(plugins_enabled=False), builtin_names=set())
+    assert tools == [] and errors == []
+
+
+# TODO(Task 3): remove this skip once Config gains the `plugins_deny` field.
+@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
+def test_deny_skips_module(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    tools, errors = load_plugins(Config(plugins_deny=["demo"]), builtin_names=set())
+    assert tools == []
+
+
+# TODO(Task 3): remove this skip once Config gains the `plugins_allow` field.
+@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
+def test_allowlist_loads_only_listed(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    pdir = tmp_path / "riftor" / "plugins"
+    _write_plugin(pdir, "demo", _GOOD)
+    _write_plugin(pdir, "other", _GOOD.replace("hello_plugin", "other_plugin"))
+    tools, _ = load_plugins(Config(plugins_allow=["demo"]), builtin_names=set())
+    assert [t.name for t in tools] == ["hello_plugin"]
+
+
+# TODO(Task 3): remove this skip once Config gains the plugin allow/deny fields.
+@pytest.mark.skip(reason="needs Config plugin fields from Task 3")
+def test_deny_wins_over_allow(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", _GOOD)
+    cfg = Config(plugins_allow=["demo"], plugins_deny=["demo"])
+    tools, _ = load_plugins(cfg, builtin_names=set())
+    assert tools == []
+
+
+def test_missing_TOOLS_is_error_and_skipped(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "bad", "X = 1\n")
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == []
+    assert len(errors) == 1 and errors[0].module == "bad"
+    assert isinstance(errors[0], PluginError)
+
+
+def test_TOOLS_not_a_list_is_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "bad", "TOOLS = 'nope'\n")
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == [] and len(errors) == 1
+
+
+def test_non_tool_item_is_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "bad", "TOOLS = [object()]\n")
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == [] and len(errors) == 1
+
+
+def test_collision_with_builtin_skipped(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    body = _GOOD.replace("hello_plugin", "bash")  # collide with built-in
+    _write_plugin(tmp_path / "riftor" / "plugins", "demo", body)
+    tools, errors = load_plugins(Config(), builtin_names={"bash"})
+    assert tools == [] and len(errors) == 1
+
+
+def test_import_error_is_caught(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "boom", "raise RuntimeError('x')\n")
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == [] and len(errors) == 1 and "x" in errors[0].error
+
+
+def test_underscore_files_skipped(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_plugin(tmp_path / "riftor" / "plugins", "_private", _GOOD)
+    tools, errors = load_plugins(Config(), builtin_names=set())
+    assert tools == [] and errors == []

--- a/tests/test_wordlists.py
+++ b/tests/test_wordlists.py
@@ -1,0 +1,71 @@
+"""Wordlist discovery: known roots + optional config dir, capped recursive walk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from riftor.engagement.wordlists import Wordlist, count_lines, discover
+
+
+def _mkroot(base: Path) -> Path:
+    root = base / "seclists"
+    (root / "Discovery" / "Web-Content").mkdir(parents=True)
+    (root / "Usernames").mkdir(parents=True)
+    (root / "Discovery" / "Web-Content" / "common.txt").write_text("a\nb\nc\n")
+    (root / "Usernames" / "top-usernames.txt").write_text("admin\nroot\n")
+    (root / "raw.lst").write_text("x\ny\n")            # directly under root
+    (root / "notes.md").write_text("ignored")          # wrong extension
+    return root
+
+
+def test_discover_finds_and_categorizes(tmp_path):
+    root = _mkroot(tmp_path)
+    lists = discover(extra_dir=str(root), known_roots=[])
+    by_name = {w.name: w for w in lists}
+    assert set(by_name) == {"common.txt", "top-usernames.txt", "raw.lst"}
+    assert by_name["common.txt"].category == "Discovery/Web-Content"
+    assert by_name["top-usernames.txt"].category == "Usernames"
+    assert by_name["raw.lst"].category == "(root)"
+    assert by_name["common.txt"].path.is_absolute()
+
+
+def test_discover_missing_root_is_silent(tmp_path):
+    lists = discover(extra_dir=str(tmp_path / "nope"), known_roots=["/does/not/exist"])
+    assert lists == []
+
+
+def test_discover_dedups_same_file_reachable_from_two_roots(tmp_path):
+    root = _mkroot(tmp_path)
+    lists = discover(extra_dir=str(root), known_roots=[str(root)])
+    paths = [w.path for w in lists]
+    assert len(paths) == len(set(paths))  # no dupes
+
+
+def test_discover_respects_total_cap(tmp_path, monkeypatch):
+    root = tmp_path / "big"
+    root.mkdir()
+    for i in range(10):
+        (root / f"w{i}.txt").write_text("x\n")
+    monkeypatch.setattr("riftor.engagement.wordlists.MAX_WORDLISTS", 4)
+    lists = discover(extra_dir=str(root), known_roots=[])
+    assert len(lists) == 4
+
+
+def test_discover_skips_symlinked_dirs(tmp_path):
+    root = _mkroot(tmp_path)
+    loop = root / "Discovery" / "loop"
+    loop.symlink_to(root, target_is_directory=True)
+    lists = discover(extra_dir=str(root), known_roots=[])
+    assert all("loop" not in str(w.path) for w in lists)
+
+
+def test_count_lines_and_cache(tmp_path):
+    f = tmp_path / "x.txt"
+    f.write_text("a\nb\nc\n")
+    assert count_lines(f) == 3
+    assert count_lines(f) == 3  # cached path; same result
+
+
+def test_count_lines_unreadable_returns_none(tmp_path):
+    missing = tmp_path / "gone.txt"
+    assert count_lines(missing) is None

--- a/tests/test_wordlists.py
+++ b/tests/test_wordlists.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from riftor.config import Config
 from riftor.engagement.wordlists import Wordlist, count_lines, discover, search
+from riftor.tools import ToolContext, get
+from riftor.tools.engagement import WordlistTool
 
 
 def _mkroot(base: Path) -> Path:
@@ -98,3 +101,62 @@ def test_search_fuzzy_fallback_when_no_substring():
 
 def test_search_no_match_returns_empty():
     assert search("zzzznotathing", _lists()) == []
+
+
+def _ctx_with(root):
+    return ToolContext(config=Config(wordlists_dir=str(root)))
+
+
+async def test_tool_registered():
+    assert get("wordlist") is not None
+
+
+async def test_tool_lists_catalog_when_no_query(tmp_path):
+    root = tmp_path / "seclists"
+    (root / "Discovery").mkdir(parents=True)
+    (root / "Discovery" / "common.txt").write_text("a\nb\n")
+    tool = WordlistTool()
+    res = await tool.execute({}, _ctx_with(root))
+    assert not res.is_error
+    assert "common.txt" in res.content
+    assert "Discovery" in res.content
+    assert str((root / "Discovery" / "common.txt").resolve()) in res.content
+
+
+async def test_tool_search_returns_matches(tmp_path):
+    root = tmp_path / "seclists"
+    (root / "DNS").mkdir(parents=True)
+    (root / "DNS" / "subdomains.txt").write_text("a\n")
+    (root / "DNS" / "resolvers.txt").write_text("1.1.1.1\n")
+    tool = WordlistTool()
+    res = await tool.execute({"query": "subdomains"}, _ctx_with(root))
+    assert "subdomains.txt" in res.content
+    assert "resolvers.txt" not in res.content
+
+
+async def test_tool_empty_install_is_friendly(tmp_path):
+    tool = WordlistTool()
+    ctx = ToolContext(config=Config(wordlists_dir=str(tmp_path / "nope")))
+    # patch KNOWN_ROOTS empty so the host's real /usr/share doesn't leak in
+    import riftor.engagement.wordlists as wl
+    orig = wl.KNOWN_ROOTS
+    wl.KNOWN_ROOTS = []
+    try:
+        res = await tool.execute({}, ctx)
+    finally:
+        wl.KNOWN_ROOTS = orig
+    assert not res.is_error
+    assert "no wordlists" in res.content.lower()
+    assert "wordlists_dir" in res.content
+
+
+async def test_tool_handles_none_config(tmp_path):
+    tool = WordlistTool()
+    import riftor.engagement.wordlists as wl
+    orig = wl.KNOWN_ROOTS
+    wl.KNOWN_ROOTS = []
+    try:
+        res = await tool.execute({}, ToolContext())  # config is None
+    finally:
+        wl.KNOWN_ROOTS = orig
+    assert not res.is_error  # degrades to "no wordlists" message, no crash

--- a/tests/test_wordlists.py
+++ b/tests/test_wordlists.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from riftor.engagement.wordlists import Wordlist, count_lines, discover
+from riftor.engagement.wordlists import Wordlist, count_lines, discover, search
 
 
 def _mkroot(base: Path) -> Path:
@@ -69,3 +69,32 @@ def test_count_lines_and_cache(tmp_path):
 def test_count_lines_unreadable_returns_none(tmp_path):
     missing = tmp_path / "gone.txt"
     assert count_lines(missing) is None
+
+
+def _lists():
+    return [
+        Wordlist("common.txt", Path("/r/Discovery/Web-Content/common.txt"), "Discovery/Web-Content"),
+        Wordlist("subdomains-top1million.txt", Path("/r/DNS/subdomains-top1million.txt"), "DNS"),
+        Wordlist("top-usernames.txt", Path("/r/Usernames/top-usernames.txt"), "Usernames"),
+    ]
+
+
+def test_search_empty_query_returns_all():
+    assert search("", _lists()) == _lists()
+
+
+def test_search_substring_on_category_and_name():
+    hits = search("web-content", _lists())
+    assert [w.name for w in hits] == ["common.txt"]
+    hits = search("subdomains", _lists())
+    assert [w.name for w in hits] == ["subdomains-top1million.txt"]
+
+
+def test_search_fuzzy_fallback_when_no_substring():
+    # "usernme" has no substring hit but fuzzy-matches top-usernames.txt
+    hits = search("usernmes", _lists())
+    assert any(w.name == "top-usernames.txt" for w in hits)
+
+
+def test_search_no_match_returns_empty():
+    assert search("zzzznotathing", _lists()) == []


### PR DESCRIPTION
Implements two features on a shared branch.

## #58 — Wordlist management
- `riftor/engagement/wordlists.py`: pure discovery over known SecLists/system roots (capped walk, depth/count limits, symlink-dir skip), line counts cached by `(path, mtime, size)`, substring + `difflib` fuzzy `search()`. Never raises.
- New optional `wordlists_dir` config field (extra root) + `_to_toml()` serialization.
- New read-only `wordlist` agent tool: no args -> catalog grouped by category; `query` -> best matches. Returns absolute paths for `bash` ffuf/gobuster. Registered in `ALL_TOOLS`.
- Docs (`configuration.md`) + smoke assertion.

## #62 — Plugin system
- `riftor/plugins.py`: pure `load_plugins(config, builtin_names) -> (tools, errors)`. Discovers top-level `.py` files and packages under `$XDG_CONFIG_HOME/riftor/plugins` (else `~/.config/riftor/plugins`), each exporting a module-level `TOOLS: list[Tool]`. Validates each item (Tool instance, non-empty name, dict params, no built-in/duplicate collision). Bad plugins warn + skip, never crash.
- `register_plugins(config)` in `tools/__init__.py`: the single registry mutator — updates `ALL_TOOLS` **and** `_BY_NAME` together so plugin tools appear in `all_tools()`, `schemas()`, and `get()` (dispatch). Idempotent. NOT called at import time, so the registry stays deterministic for tests.
- Config: `plugins_enabled` (kill switch), `plugins_allow`, `plugins_deny` (deny wins) + serialization.
- Wired into TUI `__init__`/`on_mount` (errors surfaced as notices) and headless startup (errors to stderr).
- Docs (dir, `TOOLS` contract, config fields, trust note) + smoke no-op assertion.

Non-goals respected: no `/plugins` command, no `--doctor` section, no hot-reload, no sandboxing.

## Notes
- Fixed a latent shadowing bug in the plugin importer (`import importlib.util` shadowing a nested `import importlib`) so single-file plugins import correctly.

## Verification
`make check` passes end-to-end: ruff clean, pyright 0 errors (10 pre-existing warnings, none in changed files), 396 tests pass, smoke OK.