### PR TITLE
fix(safety): make PERMISSIONS_PATH redirectable so tests are hermetic

### DIFF
--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -22,6 +22,7 @@ async def main() -> None:
 
     cfgmod.CONFIG_DIR = Path(workdir)
     cfgmod.CONFIG_PATH = Path(workdir) / "config.toml"
+    cfgmod.PERMISSIONS_PATH = Path(workdir) / "permissions.toml"
     app = RiftorApp(cfg, workdir=Path(workdir))
     async with app.run_test() as pilot:
         # composes with the core widgets

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -16,7 +16,8 @@ from typing import Callable
 from riftor import tools
 from riftor.agent.context import Context
 from riftor.agent.provider import Provider, ProviderError, ToolCall
-from riftor.config import PERMISSIONS_PATH, Config
+from riftor.config import Config
+from riftor import config as configmod
 from riftor.engagement import Engagement
 from riftor.safety.audit import AuditLog
 from riftor.safety.permissions import Permissions
@@ -85,7 +86,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
             engagement.import_scope(Path(scope_file).expanduser().read_text(encoding="utf-8"))
         except Exception as exc:  # noqa: BLE001
             print(f"riftor: scope file error: {exc}", file=sys.stderr)
-    permissions = Permissions.load(PERMISSIONS_PATH)
+    permissions = Permissions.load(configmod.PERMISSIONS_PATH)
     audit = AuditLog()
     toolctx = ToolContext(
         workdir=workdir,

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -31,7 +31,7 @@ from riftor.agent import antiloop
 from riftor.agent import session as sessions
 from riftor.agent.context import Context
 from riftor.agent.provider import Provider, ProviderError, ToolCall, Turn, Usage
-from riftor.config import PERMISSIONS_PATH
+from riftor import config as configmod
 from riftor.engagement import Engagement
 from riftor.engagement.report import write_reports
 from riftor.safety.audit import AuditLog
@@ -311,7 +311,7 @@ class RiftorApp(App):
         self.tools = tools.all_tools()
         self.tool_schemas = tools.schemas()
         self.engagement = Engagement(self.workdir)
-        self.permissions = Permissions.load(PERMISSIONS_PATH)
+        self.permissions = Permissions.load(configmod.PERMISSIONS_PATH)
         self.audit = AuditLog()
         self.max_steps = config.max_steps
         self.session_id = sessions.new_id()


### PR DESCRIPTION
## Summary

`PERMISSIONS_PATH` was imported **by value** in `app.py` and `headless.py`, which broke the path-redirect pattern several tests already rely on to isolate runs. This made the smoke suite non-hermetic and environment-dependent.

## Problem

`riftor/tui/app.py` and `riftor/headless.py` did:
```python
from riftor.config import PERMISSIONS_PATH   # bound at import time
...
self.permissions = Permissions.load(PERMISSIONS_PATH)
```

Reassigning `cfgmod.PERMISSIONS_PATH` (as `dev/smoke.py` and the pytest TUI tests do) had **no effect** — the app kept loading the operator's real `~/.config/riftor/permissions.toml`.

This broke the smoke suite's scope-enforcement assertion whenever the operator had a blanket deny rule (e.g. `{ tool = "bash" }`):
- `_run_tool`'s hard-deny branch (`app.py:1909`) fired **before** the scope-warning modal (`app.py:1921`)
- the test's mocked modal was never called
- assertion failed with `None`

The failure was environment-dependent: passed in CI (fresh config dir), failed locally.

## Fix

Read the path at **call time** via the module, mirroring how `CONFIG_PATH`/`KEYBINDINGS_PATH` already work as in-module globals:

- `riftor/tui/app.py` — `from riftor import config as configmod`; `Permissions.load(configmod.PERMISSIONS_PATH)`
- `riftor/headless.py` — same change
- `dev/smoke.py` — redirect `PERMISSIONS_PATH` to the temp dir (now that the redirect actually works)

Audited the sibling paths: `CONFIG_PATH` and `KEYBINDINGS_PATH` are referenced *inside* `config.py` as module globals, so the redirect pattern already worked for them — only `PERMISSIONS_PATH` had the by-value bug.

## Verification

| Gate | Result |
|------|--------|
| Lint (`ruff check riftor dev tests`) | ✅ Clean |
| Typecheck (`pyright riftor`) | ✅ 0 errors, 10 warnings (pre-existing, unchanged) |
| Tests (`pytest`) | ✅ 396 passed |
| Smoke (`dev/smoke.py`) | ✅ Passes |

Confirmed pre-existing by reproducing the failure at `HEAD~1`.