### PR TITLE
fix: code hardening batch (SQLite, provider, antiloop, cvss, deny-list)

### DIFF
--- a/riftor/agent/antiloop.py
+++ b/riftor/agent/antiloop.py
@@ -8,17 +8,37 @@ side effects (running tools, injecting tool results); this module only decides
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 
 WARN_AT = 3   # operator gets a heads-up; the tool still runs
 STOP_AT = 5   # hard stop: skip the call and end the turn
 WINDOW = 20   # how many recent call signatures to remember
 
+# Display signatures are truncated for readability, but the dedup key is a hash
+# of the *full* signature so two calls that differ only past the truncation
+# point are not falsely counted as repeats (issue #118).
+_DISPLAY_LEN = 200
+
 
 def call_signature(name: str, arguments: dict) -> str:
-    """Stable signature for a tool call: name + whitespace-normalized args."""
+    """Stable signature for a tool call: name + whitespace-normalized args, hashed.
+
+    Returns a short hash that uniquely represents the full call. The hash is
+    deterministic for identical arguments, and distinct for arguments that
+    differ anywhere (not just in the first N characters). Whitespace within
+    argument values is collapsed so ``ls   -la`` and ``ls -la`` hash the same.
+    """
+    norm = {k: " ".join(str(v).split()) for k, v in arguments.items()}
+    raw = f"{name}:{json.dumps(norm, sort_keys=True, separators=(',', ':'))}"
+    return hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+def display_signature(name: str, arguments: dict) -> str:
+    """Human-readable one-liner for operator-facing messages (truncated)."""
     sig = f"{name}:{' '.join(str(v) for v in arguments.values())}"
-    return " ".join(sig.split()).strip()[:200]
+    return " ".join(sig.split()).strip()[:_DISPLAY_LEN]
 
 
 @dataclass

--- a/riftor/agent/context.py
+++ b/riftor/agent/context.py
@@ -53,8 +53,11 @@ GENZ_PREAMBLE = (
     "6. When the work is done, drop a clean summary ending with \"no cap.\""
 )
 
-# Rough chars-per-token; good enough for a status-bar gauge without tiktoken.
-_CHARS_PER_TOKEN = 4
+# Rough chars-per-token for the status-bar gauge. Biased toward *over-counting*
+# (3 not 4) so the 80% context-window warning fires early rather than late —
+# code/base64/nmap output has a higher token density than English prose, and a
+# late warning means a non-retryable context-length error from the provider.
+_CHARS_PER_TOKEN = 3
 
 
 def _load_system_prompt() -> str:

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -27,15 +27,22 @@ _litellm = None
 def _get_litellm():
     global _litellm
     if _litellm is None:
-        os.environ.setdefault("LITELLM_LOG", "ERROR")
-        import litellm
-
-        litellm.telemetry = False
-        litellm.drop_params = True
-        litellm.suppress_debug_info = True
-        _register_codex_provider(litellm)
-        _litellm = litellm
+        _litellm = _init_litellm()
     return _litellm
+
+
+def _init_litellm():
+    """Import and configure litellm once. Guarded by the caller's None-check so
+    a concurrent first-call race at worst imports litellm twice (harmless — the
+    codex registration has its own dedup guard)."""
+    os.environ.setdefault("LITELLM_LOG", "ERROR")
+    import litellm
+
+    litellm.telemetry = False
+    litellm.drop_params = True
+    litellm.suppress_debug_info = True
+    _register_codex_provider(litellm)
+    return litellm
 
 
 def _register_codex_provider(litellm) -> None:
@@ -206,6 +213,8 @@ class Provider:
         for attempt in range(self.max_retries):
             try:
                 return await litellm.acompletion(**kwargs)
+            except asyncio.CancelledError:
+                raise  # never retry a cancel — the operator hit Esc
             except Exception as exc:  # noqa: BLE001
                 err = classify_error(exc)
                 last = err

--- a/riftor/engagement/__init__.py
+++ b/riftor/engagement/__init__.py
@@ -171,5 +171,9 @@ class Engagement:
     def findings_count(self) -> int:
         return self.store.count_findings()
 
+    def close(self) -> None:
+        """Close the backing SQLite connection. Safe to call multiple times."""
+        self.store.close()
+
 
 __all__ = ["Engagement", "Scope", "Target", "Store", "VALID_STAGES", "STAGE_LABELS"]

--- a/riftor/engagement/cvss.py
+++ b/riftor/engagement/cvss.py
@@ -17,6 +17,20 @@ _PR_CHANGED = {"N": 0.85, "L": 0.68, "H": 0.5}
 _CIA = {"H": 0.56, "L": 0.22, "N": 0.0}
 _REQUIRED = ("AV", "AC", "PR", "UI", "S", "C", "I", "A")
 
+# Allowed metric values — any vector with an unrecognised value is rejected
+# (returns None) rather than silently mis-scored. Only S has values outside the
+# metric→weight dicts (U/C), so it gets its own set.
+_VALID_VALUES: dict[str, set[str]] = {
+    "AV": set(_AV),
+    "AC": set(_AC),
+    "PR": set(_PR_UNCHANGED),
+    "UI": set(_UI),
+    "S": {"U", "C"},
+    "C": set(_CIA),
+    "I": set(_CIA),
+    "A": set(_CIA),
+}
+
 
 def parse_vector(vector: str) -> dict[str, str] | None:
     if not vector:
@@ -28,6 +42,11 @@ def parse_vector(vector: str) -> dict[str, str] | None:
             metrics[key.upper()] = value.upper()
     if not all(m in metrics for m in _REQUIRED):
         return None
+    # Reject vectors with invalid metric values (e.g. S:X) instead of silently
+    # treating them as a default. The official spec says invalid → reject.
+    for m, val in metrics.items():
+        if m in _VALID_VALUES and val not in _VALID_VALUES[m]:
+            return None
     return metrics
 
 

--- a/riftor/engagement/injection.py
+++ b/riftor/engagement/injection.py
@@ -40,6 +40,7 @@ def engagement_injection(workdir: Path | None) -> str:
                 TEMPLATES,
             )
             conn = sqlite3.connect(str(db_path))
+            conn.execute("PRAGMA busy_timeout=5000")  # wait instead of SQLITE_BUSY
             try:
                 row = conn.execute(
                     "SELECT value FROM meta WHERE key=?",

--- a/riftor/engagement/state.py
+++ b/riftor/engagement/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 import time
 from pathlib import Path
 
@@ -50,23 +51,45 @@ CREATE TABLE IF NOT EXISTS hypotheses (
 class Store:
     def __init__(self, path: Path) -> None:
         self.path = path
+        self._lock = threading.RLock()
+        self._closed = False
         self._conn = sqlite3.connect(str(path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
+        # WAL allows concurrent readers + one writer; busy_timeout makes writers
+        # retry instead of immediately raising SQLITE_BUSY when another connection
+        # holds the lock (e.g. injection.py's separate read connection).
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.executescript(_SCHEMA)
         self._migrate()
         self._conn.commit()
 
     def _migrate(self) -> None:
-        for table, column, ctype in _LATE_COLUMNS:
-            cols = {r["name"] for r in self._conn.execute(f"PRAGMA table_info({table})")}
-            if column not in cols:
-                self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ctype}")
-        # activity table is created in the base schema for new DBs; ensure for old ones.
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS activity "
-            "(id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT, detail TEXT, ts REAL)"
-        )
-        self._conn.executescript(_LATE_TABLES)
+        # Wrap DDL in an explicit transaction so a crash mid-migration doesn't
+        # leave the schema half-migrated. sqlite3 doesn't auto-wrap DDL the way
+        # it does DML, so each ALTER would otherwise be its own auto-commit.
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            for table, column, ctype in _LATE_COLUMNS:
+                cols = {r["name"] for r in self._conn.execute(f"PRAGMA table_info({table})")}
+                if column not in cols:
+                    self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ctype}")
+            # activity table is created in the base schema for new DBs; ensure for old ones.
+            self._conn.execute(
+                "CREATE TABLE IF NOT EXISTS activity "
+                "(id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT, detail TEXT, ts REAL)"
+            )
+            self._conn.executescript(_LATE_TABLES)
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def __enter__(self) -> "Store":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
 
     # -- meta -------------------------------------------------------------------
     def set_meta(self, key: str, value: str) -> None:
@@ -328,4 +351,7 @@ class Store:
         return json.dumps(self.export_dict(), indent=2)
 
     def close(self) -> None:
-        self._conn.close()
+        with self._lock:
+            if not self._closed:
+                self._conn.close()
+                self._closed = True

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -138,6 +138,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
                 await toolctx.browser.close()
             except Exception:  # noqa: BLE001
                 pass
+        engagement.close()
     print()  # trailing newline
     return 0
 

--- a/riftor/safety/permissions.py
+++ b/riftor/safety/permissions.py
@@ -27,13 +27,25 @@ from textual.widgets import Button, Static
 
 
 def _default_deny() -> list[dict]:
-    """Sensible destructive-command guards, on by default for the bash tool."""
+    """Sensible destructive-command guards, on by default for the bash tool.
+
+    These patterns are defense-in-depth, NOT a sandbox. Shell obfuscation
+    (``$x``, ``base64 | sh``, ``$IFS``, quoting tricks) will always bypass
+    regex — the real guard is ``requires_permission`` prompting the operator
+    before *any* bash call runs. These patterns just catch the obvious cases
+    so a fat-fingered ``rm -rf /`` is blocked before the prompt even appears.
+    """
     return [
-        {"tool": "bash", "pattern": r"\brm\s+-[a-z]*r[a-z]*f|\brm\s+-[a-z]*f[a-z]*r"},
-        {"tool": "bash", "pattern": r"\bdd\s+.*of=/dev/"},
-        {"tool": "bash", "pattern": r"\bmkfs(\.\w+)?\b"},
+        # rm -rf in any flag arrangement: -rf, -fr, -r -f, -f -r, --recursive --force
+        {"tool": "bash", "pattern": r"\brm\s+(?:-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r|-r\b[^\n]*-f\b|-f\b[^\n]*-r\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b)"},
+        # rm -r on root-ish absolute paths even without -f (destroys everything)
+        {"tool": "bash", "pattern": r"\brm\s+[^\n]*-r\w*\b[^\n]*\s/(?:\S|$)"},
+        # find with -delete or -exec rm (alternative destructive tools)
+        {"tool": "bash", "pattern": r"\bfind\s+[^\n]*-(?:delete|exec\s+rm)\b"},
+        {"tool": "bash", "pattern": r"\bdd\s+[^\n]*of=/dev/"},
+        {"tool": "bash", "pattern": r"\b(?:mkfs|mke2fs)(?:\.\w+)?\b"},
         {"tool": "bash", "pattern": r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&"},  # fork bomb
-        {"tool": "bash", "pattern": r">\s*/dev/sd[a-z]"},
+        {"tool": "bash", "pattern": r">\s*/dev/(?:sd|nvme|vd)[a-z]"},
     ]
 
 

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -417,6 +417,12 @@ class RiftorApp(App):
                 await mgr.close()
             except Exception:  # noqa: BLE001
                 pass
+        # Close the SQLite engagement DB so WAL checkpoints run and the FD is
+        # released. Without this, the connection leaks on every app exit.
+        try:
+            self.engagement.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     def _toolchain_heads_up(self) -> None:
         """One-line note if recon tools are missing — surfaced up front, not mid-task."""
@@ -1717,11 +1723,15 @@ class RiftorApp(App):
         now = time.monotonic()
         self._rate_times = [t for t in self._rate_times if now - t < 60.0]
         if len(self._rate_times) >= limit:
+            # Sleep until the *oldest* request in the window expires, then evict
+            # it so we never exceed `limit` calls in any 60s sliding window.
             wait = 60.0 - (now - self._rate_times[0])
             if wait > 0:
                 self._note(f"rate limit ({limit}/min) — waiting {wait:.0f}s")
                 await asyncio.sleep(wait)
-        self._rate_times.append(time.monotonic())
+            now = time.monotonic()
+            self._rate_times = [t for t in self._rate_times if now - t < 60.0]
+        self._rate_times.append(now)
 
     # ---- agent loop ------------------------------------------------------------
     @work(exclusive=True)

--- a/tests/test_antiloop.py
+++ b/tests/test_antiloop.py
@@ -7,9 +7,25 @@ from riftor.agent import antiloop
 
 
 def test_signature_normalizes_whitespace():
+    # Whitespace-only differences still produce the same hash (issue #118).
     a = antiloop.call_signature("bash", {"cmd": "ls   -la"})
     b = antiloop.call_signature("bash", {"cmd": "ls -la"})
-    assert a == b == "bash:ls -la"
+    assert a == b
+
+
+def test_signature_distinct_beyond_truncation():
+    # The old code truncated at 200 chars, so calls differing only past that
+    # point collapsed to the same key and falsely tripped the loop breaker.
+    long_cmd_a = "rm -rf /tmp/" + "a" * 200 + "TAIL_A"
+    long_cmd_b = "rm -rf /tmp/" + "a" * 200 + "TAIL_B"
+    a = antiloop.call_signature("bash", {"cmd": long_cmd_a})
+    b = antiloop.call_signature("bash", {"cmd": long_cmd_b})
+    assert a != b, "calls with different tails must hash differently"
+
+
+def test_display_signature_is_human_readable():
+    sig = antiloop.display_signature("bash", {"cmd": "ls   -la"})
+    assert sig == "bash:ls -la"
 
 
 def test_first_calls_run_without_warning():

--- a/tests/test_cvss.py
+++ b/tests/test_cvss.py
@@ -1,0 +1,65 @@
+"""CVSS v3.1 base score calculation and vector validation.
+
+Verifies the pure-python implementation against official FIRST.org test vectors
+and confirms that invalid metric values are rejected (not silently mis-scored).
+"""
+
+from __future__ import annotations
+
+import math
+
+from riftor.engagement.cvss import base_score, parse_vector, severity_from_score
+
+
+# Official CVSS v3.1 base-score test vectors (FIRST.org spec §A.2).
+OFFICIAL_VECTORS = [
+    ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8),
+    ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N", 9.1),
+    ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 10.0),
+    ("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 6.8),
+    ("CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", 7.2),
+    ("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N", 4.3),
+    ("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1),
+    ("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N", 3.7),
+    ("CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.8),
+    ("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", 4.3),
+]
+
+
+def test_official_vectors():
+    """Spot-check against FIRST.org published base scores."""
+    for vector, expected in OFFICIAL_VECTORS:
+        actual = base_score(vector)
+        assert actual is not None, f"got None for {vector}"
+        assert math.isclose(actual, expected, abs_tol=0.05), (
+            f"{vector}: expected {expected}, got {actual}"
+        )
+
+
+def test_invalid_scope_value_rejected():
+    """S:X is not a valid CVSS metric value → must return None, not silently
+    treat it as scope-unchanged (issue #125)."""
+    assert parse_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:X/C:H/I:H/A:H") is None
+    assert base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:X/C:H/I:H/A:H") is None
+
+
+def test_invalid_attack_vector_rejected():
+    assert parse_vector("CVSS:3.1/AV:Q/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") is None
+    assert base_score("CVSS:3.1/AV:Q/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") is None
+
+
+def test_missing_metric_rejected():
+    assert parse_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H") is None
+
+
+def test_empty_vector_returns_none():
+    assert base_score("") is None
+    assert base_score("not-a-vector") is None
+
+
+def test_severity_bands():
+    assert severity_from_score(0.0) == "info"
+    assert severity_from_score(3.5) == "low"
+    assert severity_from_score(5.0) == "medium"
+    assert severity_from_score(8.0) == "high"
+    assert severity_from_score(9.8) == "critical"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -12,6 +12,49 @@ def test_default_deny_blocks_rm_rf():
     assert not perms.is_denied("bash", "ls -la")
 
 
+def test_default_deny_catches_separated_flags():
+    """rm with recursive+force in any flag arrangement must be caught (issue #109)."""
+    perms = Permissions()
+    variants = [
+        "rm -rf /",
+        "rm -fr /",
+        "rm -r -f /",
+        "rm -f -r /",
+        "rm --recursive --force /tmp/x",
+        "rm --force --recursive /tmp/x",
+    ]
+    for v in variants:
+        assert perms.is_denied("bash", v), f"separated-flag rm not caught: {v!r}"
+
+
+def test_default_deny_catches_rm_r_on_absolute_paths():
+    """rm -r on an absolute path is destructive even without -f (issue #109)."""
+    perms = Permissions()
+    for v in ["rm -r /", "rm -r /etc", "rm -r /home", "rm -r /tmp/x"]:
+        assert perms.is_denied("bash", v), f"rm -r on abs path not caught: {v!r}"
+    # relative paths and non-recursive rm must NOT be flagged
+    assert not perms.is_denied("bash", "rm -r relative-dir")
+    assert not perms.is_denied("bash", "rm single-file.txt")
+    assert not perms.is_denied("bash", "grep -r pattern /")  # grep -r, not rm -r
+
+
+def test_default_deny_catches_alternative_destructive_tools():
+    """find -delete, find -exec rm, mke2fs, nvme/vda writes (issue #109)."""
+    perms = Permissions()
+    destructive = [
+        "find / -delete",
+        "find / -exec rm {} \\;",
+        "mke2fs /dev/sda1",
+        "dd if=/dev/zero of=/dev/nvme0n1",
+        "dd if=/dev/zero of=/dev/vda",
+        "cat /dev/urandom > /dev/sda",
+    ]
+    for v in destructive:
+        assert perms.is_denied("bash", v), f"destructive cmd not caught: {v!r}"
+    # find without -delete/-exec rm must NOT be flagged
+    assert not perms.is_denied("bash", "find . -name '*.py'")
+
+
 def test_default_deny_catches_fork_bomb_variants():
     """The fork-bomb guard must match the readable spaced form, not just the
     compact one — shells accept whitespace between every token."""


### PR DESCRIPTION
## Summary

A batch of correctness / hardening fixes surfaced by a code review. Each is a small, self-contained fix on its own commit. **Stability first** — full CI is green (407 tests, smoke, lint, pyright 0 errors).

## Fixes

| Issue | Commit | Fix |
|---|---|---|
| #110, #111, #126 | `8fc4316` | SQLite: close the engagement connection on exit, WAL mode + `busy_timeout`, atomic migration (`BEGIN IMMEDIATE`), `RLock`, context-manager protocol |
| #113 | `209a1cd` | `_acompletion` no longer retries on `asyncio.CancelledError` — hitting Esc during backoff stops immediately instead of ~30s of zombie model calls |
| #118 | `707845b` | Antiloop hashes the full call signature instead of truncating at 200 chars (fixed false-positive circuit-breaker trips on long-argument scans) |
| #121 | `8fc4316` | Rate-gate off-by-one that let `limit+1` calls through per window |
| #122 | `44e0ec0` | Token estimate biased to over-count (`chars/3`) so the context-window warning fires early |
| #125 | `a6cd121` | CVSS `parse_vector` rejects invalid metric values (e.g. `S:X`) instead of silently mis-scoring |
| #109 | `d68ac4d` | Widened destructive-command deny-list: separated/long flags, recursive rm on absolute paths, `find -delete`/`-exec rm`, more block-device patterns |

## Testing

- **407 tests pass** (was 396 — added 11: CVSS validation, antiloop truncation, deny-list bypass classes)
- `dev/smoke.py`: all checks OK
- `ruff`: clean · `pyright`: 0 errors (10 pre-existing warnings, untouched)

## Notes

- The deny-list change is explicitly documented as **defense-in-depth, not a sandbox** — shell obfuscation (`$x`, `base64 | sh`) will always bypass regex; the real guard remains the `requires_permission` operator prompt.
- These are orthogonal to `docs/IMPROVEMENT_PLAN.md` (which covers feature-level work). This PR is pure bug/hardening.

Closes #109, #110, #111, #113, #118, #121, #122, #125, #126
