### PR TITLE
chore: release v3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "2.0.0"
+version = "3.0.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "2.0.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Bumps `pyproject.toml` + `uv.lock` to **3.0.0** (major version).

Per CONTRIBUTING.md release flow: land this bump on main first, then tag `v3.0.0` on the merged commit — the release workflow verifies tag==pyproject version, builds, publishes to PyPI (trusted publishing), and creates the GitHub Release.

### Since 2.0.0
- **Hardening batch (#127)** — SQLite connection lifecycle + WAL + atomic migration; cancel-safe provider retries; antiloop full-signature hashing; CVSS vector validation; widened destructive-command deny-list; rate-gate off-by-one; token-estimate bias. Closes #109–#111, #113, #118, #121–#122, #125–#126.
- **Docker base → python:3.14-slim (#96)**
- **Dependency + Actions bumps (#108, #101)**

### Verified locally on merged main
- 407 tests pass · smoke OK · ruff clean · pyright 0 errors
- `uv build` produces riftor-3.0.0 sdist + wheel