### PR TITLE
fix(session): atomic per-writer save + repair() dedup across full history

### DIFF
--- a/riftor/agent/context.py
+++ b/riftor/agent/context.py
@@ -161,17 +161,30 @@ class Context:
         return changed
 
     def repair(self) -> int:
-        """Ensure every assistant tool_call has a following tool result.
+        """Ensure every assistant tool_call has a tool result somewhere.
 
         If a turn was interrupted (cancel, new message mid-run, error), an
         assistant ``tool_use`` can be left without its ``tool_result``, which
         Anthropic rejects. We insert a synthetic result for each missing id,
         immediately after that assistant message's existing tool results.
+
+        A tool_call_id is only "missing" if NO tool result for it exists
+        anywhere in the history — not just in the consecutive block after the
+        assistant message. A resumed session can interleave the real result
+        further down; synthesizing a second one there would create a duplicate
+        tool_call_id, which the provider rejects with a 400 (issue #115).
         Returns the number of synthetic results inserted.
         """
+        messages = self._messages
+        # First pass: every tool_call_id that already has a result ANYWHERE.
+        all_provided: set[str] = set()
+        for m in messages:
+            if m.get("role") == "tool":
+                tid = m.get("tool_call_id")
+                if tid:
+                    all_provided.add(tid)
         repaired: list[dict] = []
         inserted = 0
-        messages = self._messages
         i = 0
         while i < len(messages):
             msg = messages[i]
@@ -179,13 +192,14 @@ class Context:
             if msg.get("role") == "assistant" and msg.get("tool_calls"):
                 expected = [tc.get("id") for tc in msg["tool_calls"] if tc.get("id")]
                 j = i + 1
-                provided: set[str] = set()
+                # Keep the consecutive tool-result block attached to this turn.
                 while j < len(messages) and messages[j].get("role") == "tool":
                     repaired.append(messages[j])
-                    provided.add(messages[j].get("tool_call_id"))
                     j += 1
                 for tid in expected:
-                    if tid not in provided:
+                    # Only synthesize when the id has NO result anywhere in the
+                    # whole history — never when it's provided out of position.
+                    if tid not in all_provided:
                         repaired.append(
                             {
                                 "role": "tool",
@@ -193,6 +207,7 @@ class Context:
                                 "content": "[interrupted: no tool result was recorded]",
                             }
                         )
+                        all_provided.add(tid)  # don't double-insert for repeats
                         inserted += 1
                 i = j
                 continue

--- a/riftor/agent/session.py
+++ b/riftor/agent/session.py
@@ -8,7 +8,10 @@ the agent keeps its memory across runs.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
+import uuid
 from pathlib import Path
 
 
@@ -28,7 +31,10 @@ def _title(messages: list[dict]) -> str:
 
 
 def new_id() -> str:
-    return time.strftime("%Y%m%d-%H%M%S")
+    # Second-resolution timestamp + a short random suffix so two sessions started
+    # in the same clock second (e.g. /new then immediately tasking, or two
+    # windows) don't collide onto the same file (issue #112).
+    return time.strftime("%Y%m%d-%H%M%S") + "-" + uuid.uuid4().hex[:4]
 
 
 def save(
@@ -57,10 +63,21 @@ def save(
         "title": _title(messages),
         "messages": messages,
     }
-    # atomic write: tmp + replace, so a crash never leaves a half-written file
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    tmp.replace(path)
+    # atomic write: unique tmp + replace, so a crash never leaves a half-written
+    # file AND two processes writing the same session don't clobber each other's
+    # tmp file (issue #112). mkstemp gives a per-writer name in the same dir so
+    # the final os.replace is atomic on the same filesystem.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f"{session_id}.", suffix=".json.tmp"
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        tmp.replace(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
     return path
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -51,3 +51,63 @@ def test_context_mutable_genz():
     assert GENZ_PREAMBLE in ctx.system_prompt
     ctx.genz = False
     assert GENZ_PREAMBLE not in ctx.system_prompt
+
+
+# --- repair() (#115) ----------------------------------------------------------
+
+def _tool_call_msg(*ids):
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {"id": i, "type": "function", "function": {"name": "bash", "arguments": "{}"}}
+            for i in ids
+        ],
+    }
+
+
+def _tool_result(tid, content="ok"):
+    return {"role": "tool", "tool_call_id": tid, "content": content}
+
+
+def test_repair_inserts_missing_result():
+    ctx = Context()
+    ctx.load([
+        {"role": "user", "content": "go"},
+        _tool_call_msg("a", "b"),
+        _tool_result("a"),  # b is missing
+    ])
+    inserted = ctx.repair()
+    assert inserted == 1
+    tool_ids = [m["tool_call_id"] for m in ctx.messages if m.get("role") == "tool"]
+    assert sorted(tool_ids) == ["a", "b"]
+
+
+def test_repair_no_op_when_all_present():
+    ctx = Context()
+    ctx.load([
+        {"role": "user", "content": "go"},
+        _tool_call_msg("a"),
+        _tool_result("a"),
+    ])
+    assert ctx.repair() == 0
+
+
+def test_repair_does_not_duplicate_out_of_position_result():
+    """If a real result for an id exists further down the history (e.g. a resumed
+    session interleaved it), repair must NOT synthesize a second one — that would
+    create a duplicate tool_call_id and the provider 400s (issue #115)."""
+    ctx = Context()
+    ctx.load([
+        {"role": "user", "content": "go"},
+        _tool_call_msg("a", "b"),
+        _tool_result("a"),
+        # b's real result is interleaved after a non-tool message
+        {"role": "assistant", "content": "thinking..."},
+        _tool_result("b", "real b result"),
+    ])
+    inserted = ctx.repair()
+    assert inserted == 0, "must not synthesize a duplicate for the out-of-position result"
+    b_results = [m for m in ctx.messages if m.get("tool_call_id") == "b"]
+    assert len(b_results) == 1
+    assert b_results[0]["content"] == "real b result"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -24,3 +24,31 @@ def test_atomic_write_leaves_no_tmp(tmp_workdir):
     session.save(tmp_workdir, "sid", [{"role": "user", "content": "x"}], "m")
     leftovers = list((tmp_workdir / ".riftor" / "sessions").glob("*.tmp"))
     assert not leftovers
+
+
+def test_new_id_is_unique_within_same_second():
+    """Two ids minted back-to-back must differ so same-second sessions don't
+    collide onto one file (issue #112)."""
+    ids = {session.new_id() for _ in range(50)}
+    assert len(ids) == 50
+
+
+def test_tmp_files_not_listed_as_sessions(tmp_workdir):
+    """The unique .json.tmp files must not be picked up by list_sessions."""
+    session.save(tmp_workdir, "20260101-000000-abcd", [{"role": "user", "content": "x"}], "m")
+    rows = session.list_sessions(tmp_workdir)
+    assert len(rows) == 1
+    assert rows[0]["id"] == "20260101-000000-abcd"
+
+
+def test_concurrent_saves_same_id_dont_corrupt(tmp_workdir):
+    """Interleaved saves to the same session id must always leave a valid,
+    fully-parseable file (unique tmp names prevent cross-writer clobbering)."""
+    import json
+    for i in range(20):
+        session.save(tmp_workdir, "sid", [{"role": "user", "content": f"msg {i}"}], "m")
+    path = tmp_workdir / ".riftor" / "sessions" / "sid.json"
+    data = json.loads(path.read_text(encoding="utf-8"))  # must parse cleanly
+    assert data["messages"][0]["content"] == "msg 19"
+    # no tmp leftovers
+    assert not list((tmp_workdir / ".riftor" / "sessions").glob("*.tmp"))


### PR DESCRIPTION
## Summary
Two data-integrity fixes in the session/context layer.

### Session save (#112)
- `new_id()` gets a short random suffix so two sessions started in the same clock second don't collide onto one file.
- `save()` writes via `tempfile.mkstemp` (unique per-writer temp name) instead of a fixed `<id>.json.tmp`, so two processes on the same workdir (TUI + headless, two terminals) can't clobber each other's temp mid-replace. Cleans up the temp on failure.

### repair() (#115)
A `tool_call_id` is now considered *missing* only if **no** tool result for it exists anywhere in the history — not just in the consecutive block after the assistant message. A resumed/interleaved session could otherwise get a **synthetic duplicate** result for an id whose real result sits further down → duplicate `tool_call_id` → non-retryable provider **400**.

## Testing
- 425 tests pass (was 419 — added 6: same-second id uniqueness, concurrent same-id saves, tmp-file exclusion, repair insert/no-op/no-duplicate)
- ruff clean · pyright 0 errors · smoke OK (REPAIR OK)

Closes #112, #115