### PR TITLE
fix(headless): checkpoint the session so crashed runs are resumable

### DIFF
--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Callable
 
 from riftor import tools
+from riftor.agent import session as sessions
 from riftor.agent.context import Context
 from riftor.agent.provider import Provider, ProviderError, ToolCall
 from riftor.config import Config
@@ -104,9 +105,20 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
 
     context.add_user(prompt)
     max_steps = 10**9 if yolo else cfg.max_steps
+    # Persist the session so a crashed headless run (OOM, SIGTERM, network drop)
+    # leaves a resumable checkpoint, matching the TUI's behavior (issue #120).
+    sid = sessions.new_id()
+
+    def _checkpoint(complete: bool) -> None:
+        try:
+            sessions.save(workdir, sid, context.dump(), cfg.model, complete=complete)
+        except Exception:  # noqa: BLE001 — never let checkpointing break the run
+            pass
+
     try:
         for _ in range(max_steps):
             context.repair()
+            _checkpoint(complete=False)  # per-step checkpoint before the model call
             text_parts: list[str] = []
             turn = None
             try:
@@ -124,6 +136,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
                         turn = payload  # type: ignore[assignment]  # ("done", Turn)
             except ProviderError as exc:
                 print(f"\nriftor: provider error [{exc.kind}] — {exc}", file=sys.stderr)
+                _checkpoint(complete=False)  # leave a resumable checkpoint on error
                 return 1
             if turn is None:
                 break
@@ -132,6 +145,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
                 break
             for call in turn.tool_calls:
                 await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
+        _checkpoint(complete=True)  # ran to completion → mark the session done
     finally:
         if toolctx.browser is not None and toolctx.browser.launched:
             try:

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -133,3 +133,42 @@ def test_headless_registers_plugins(monkeypatch, tmp_path):
         tools_pkg.ALL_TOOLS[:] = snap_list
         tools_pkg._BY_NAME.clear()
         tools_pkg._BY_NAME.update(snap_map)
+
+
+# --- session checkpointing (#120) ---------------------------------------------
+
+def test_headless_run_checkpoints_session(monkeypatch, tmp_workdir):
+    """A completed headless run must persist a resumable session marked complete
+    (issue #120). Uses the offline demo mock so no model is called."""
+    from riftor.agent import session as sessions
+    from riftor.headless import _run
+
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "recon complete, no cap")
+    cfg = Config(model="anthropic/claude-sonnet-4-6", api_key="sk-demo")
+
+    import asyncio
+    rc = asyncio.run(_run(cfg, tmp_workdir, "enumerate the target", None))
+    assert rc == 0
+
+    rows = sessions.list_sessions(tmp_workdir)
+    assert len(rows) == 1
+    assert rows[0]["complete"] is True
+    loaded = sessions.load(tmp_workdir, rows[0]["id"])
+    assert loaded is not None
+    # the user prompt and the assistant answer are both persisted
+    assert any(m.get("role") == "user" and "enumerate" in m.get("content", "")
+               for m in loaded["messages"])
+    assert any(m.get("role") == "assistant" for m in loaded["messages"])
+
+
+def test_headless_no_incomplete_left_after_success(monkeypatch, tmp_workdir):
+    """After a clean run there must be no incomplete (crash) checkpoint lingering."""
+    from riftor.agent import session as sessions
+    from riftor.headless import _run
+
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "done")
+    cfg = Config(model="anthropic/claude-sonnet-4-6", api_key="sk-demo")
+
+    import asyncio
+    asyncio.run(_run(cfg, tmp_workdir, "scan", None))
+    assert sessions.find_incomplete(tmp_workdir) == []


### PR DESCRIPTION
## Summary
Headless mode (`--headless`/`--prompt`) never persisted its conversation, so a crash (OOM, SIGTERM, network drop) was unrecoverable and invisible to `find_incomplete()` — defeating the documented CI/scripting use case (#120).

It now mirrors the TUI's crash-safe behavior:
- mints a session id and checkpoints with `complete=False` before each model call
- leaves a resumable checkpoint on provider error
- marks `complete=True` when the loop finishes cleanly

Checkpointing is best-effort (wrapped in try/except) so it can never break the run itself.

## Testing
- 427 tests pass (was 425 — added 2 end-to-end headless tests via the offline demo mock: completed run persists a complete session; no incomplete checkpoint left after success)
- ruff clean · pyright 0 errors · smoke OK

Closes #120