### PR TITLE
fix(provider): derive USD cost from token counts when the provider omits it

### DIFF
--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -389,6 +389,13 @@ class Provider:
         if raw_tool_calls:
             assistant_message["tool_calls"] = raw_tool_calls
 
+        # litellm's streamed usage rarely carries `.cost` (it's only populated
+        # when a cost success_callback is configured, which we don't). Derive the
+        # cost from the token counts so /cost and the status bar aren't stuck at
+        # $0.0000 (issue #114). Best-effort: unknown models just leave cost at 0.
+        if usage.cost == 0.0 and (usage.prompt_tokens or usage.completion_tokens):
+            usage.cost = self._estimate_cost(usage)
+
         yield (
             "done",
             Turn(
@@ -398,3 +405,25 @@ class Provider:
                 usage=usage,
             ),
         )
+
+    def _estimate_cost(self, usage: Usage) -> float:
+        """Compute USD cost from token counts via litellm's pricing table.
+
+        Returns 0.0 for models litellm doesn't have pricing for (rather than
+        raising) — the gauge simply stays at 0 in that case.
+        """
+        try:
+            litellm = _get_litellm()
+            model = self.config.model
+            if model.startswith("codex/"):
+                from riftor.agent.codex_provider import to_litellm_model
+
+                model = to_litellm_model(model)
+            cost = litellm.completion_cost(
+                model=model,
+                prompt_tokens=usage.prompt_tokens,
+                completion_tokens=usage.completion_tokens,
+            )
+            return float(cost or 0.0)
+        except Exception:  # noqa: BLE001 — pricing is best-effort, never fatal
+            return 0.0

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -358,3 +358,90 @@ def test_classify_message_fallback_when_no_status():
     """With no status_code attribute, fall back to a word-boundary match."""
     err = prov.classify_error(Exception("HTTP 502 Bad Gateway"))
     assert err.kind == "server"
+
+
+# --- cost estimation (#114) ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cost_estimated_from_tokens_when_provider_omits_it(monkeypatch):
+    """litellm's streamed usage has no .cost; the Turn must still carry a cost
+    derived from the token counts (issue #114)."""
+    class _Usage:
+        prompt_tokens = 1000
+        completion_tokens = 500
+        cost = None  # provider did not supply cost
+
+    class _Delta:
+        content = "hi"
+        reasoning_content = None
+        tool_calls = None
+
+    class _Choice:
+        def __init__(self):
+            self.delta = _Delta()
+
+    class _Chunk:
+        def __init__(self, usage=None):
+            self.choices = [_Choice()]
+            self.usage = usage
+
+    async def _fake_stream():
+        yield _Chunk()
+        yield _Chunk(usage=_Usage())
+
+    async def _fake_acompletion(self, **kwargs):
+        return _fake_stream()
+
+    # Stub _estimate_cost so the test doesn't depend on litellm's pricing table.
+    monkeypatch.setattr(prov.Provider, "_acompletion", _fake_acompletion)
+    monkeypatch.setattr(prov.Provider, "_estimate_cost", lambda self, usage: 0.0123)
+
+    p = Provider_for_test()
+    turn = None
+    async for event, payload in p.stream_turn([{"role": "user", "content": "go"}]):
+        if event == "done":
+            turn = payload
+    assert turn is not None
+    assert turn.usage.prompt_tokens == 1000
+    assert turn.usage.completion_tokens == 500
+    assert turn.usage.cost == 0.0123
+
+
+@pytest.mark.asyncio
+async def test_cost_not_estimated_when_no_tokens(monkeypatch):
+    """No token usage → don't call the pricing table (keeps offline tests offline)."""
+    called = {"n": 0}
+
+    class _Delta:
+        content = "hi"
+        reasoning_content = None
+        tool_calls = None
+
+    class _Chunk:
+        def __init__(self):
+            self.choices = [type("Ch", (), {"delta": _Delta()})()]
+            self.usage = None  # no usage at all
+
+    async def _fake_stream():
+        yield _Chunk()
+
+    async def _fake_acompletion(self, **kwargs):
+        return _fake_stream()
+
+    def _spy(self, usage):
+        called["n"] += 1
+        return 0.0
+
+    monkeypatch.setattr(prov.Provider, "_acompletion", _fake_acompletion)
+    monkeypatch.setattr(prov.Provider, "_estimate_cost", _spy)
+    p = Provider_for_test()
+    async for event, payload in p.stream_turn([{"role": "user", "content": "go"}]):
+        pass
+    assert called["n"] == 0
+
+
+def test_provider_supplied_cost_is_kept(monkeypatch):
+    """When litellm DOES supply a cost, we keep it (don't override)."""
+    u = prov._extract_usage(type("C", (), {"usage": type("U", (), {
+        "prompt_tokens": 10, "completion_tokens": 5, "cost": 0.5})()})())
+    assert u is not None and u.cost == 0.5


### PR DESCRIPTION
## Summary
litellm's streamed usage object only carries `.cost` when a cost `success_callback` is configured (which riftor doesn't), so `/cost` and the status bar were permanently stuck at **$0.0000** (#114).

After assembling a turn, if the usage has tokens but no cost, we now compute it via `litellm.completion_cost()` from the token counts + the model's pricing table.

Best-effort by design:
- models litellm has no pricing for leave cost at 0.0 (no exception)
- estimation is skipped entirely when there are no tokens, so offline/mock paths don't touch the pricing table
- a provider-supplied cost is preserved (never overridden)

## Testing
- 430 tests pass (was 427 — added 3: cost derived when omitted, no estimation without tokens, provider cost preserved)
- ruff clean · pyright 0 errors · smoke OK · suite still ~29s (no hang)

Closes #114