### PR TITLE
fix(provider): thread-safe lazy litellm init with a reentrant lock

### DIFF
--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import os
 import re
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, AsyncIterator
 
@@ -23,25 +24,38 @@ if TYPE_CHECKING:
 # needed on the first model call, so we import + configure it lazily — keeping app
 # startup fast. The cost then hides behind the network round-trip of that call.
 _litellm = None
+# Reentrant: _init_litellm -> _register_codex_provider -> codex_provider imports
+# call _get_litellm() again on the SAME thread during registration. A plain Lock
+# would self-deadlock here (issue #123); an RLock lets the same thread re-enter.
+_litellm_lock = threading.RLock()
 
 
 def _get_litellm():
     global _litellm
-    if _litellm is None:
-        _litellm = _init_litellm()
-    return _litellm
+    if _litellm is not None:
+        return _litellm
+    with _litellm_lock:
+        # Double-checked: another thread may have finished while we waited.
+        if _litellm is None:
+            _litellm = _init_litellm()
+        return _litellm
 
 
 def _init_litellm():
-    """Import and configure litellm once. Guarded by the caller's None-check so
-    a concurrent first-call race at worst imports litellm twice (harmless — the
-    codex registration has its own dedup guard)."""
+    """Import and configure litellm once, then register the codex handler.
+
+    ``_litellm`` is published to the module global *before* codex registration
+    because that registration re-enters ``_get_litellm()`` on the same thread
+    (codex_provider.py) — it must see the configured module, not recurse.
+    """
+    global _litellm
     os.environ.setdefault("LITELLM_LOG", "ERROR")
     import litellm
 
     litellm.telemetry = False
     litellm.drop_params = True
     litellm.suppress_debug_info = True
+    _litellm = litellm  # publish before the reentrant codex registration
     _register_codex_provider(litellm)
     return litellm
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -445,3 +445,37 @@ def test_provider_supplied_cost_is_kept(monkeypatch):
     u = prov._extract_usage(type("C", (), {"usage": type("U", (), {
         "prompt_tokens": 10, "completion_tokens": 5, "cost": 0.5})()})())
     assert u is not None and u.cost == 0.5
+
+
+# --- thread-safe lazy litellm init (#123) -------------------------------------
+
+def test_get_litellm_concurrent_first_calls_return_same_instance():
+    """Many threads racing on the first _get_litellm() must all get the one
+    configured instance without deadlocking (issue #123). The codex registration
+    re-enters _get_litellm() on the same thread, so the lock must be reentrant."""
+    import threading
+
+    saved = prov._litellm
+    try:
+        prov._litellm = None  # force a fresh init under contention
+        results: list = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()  # release all threads at once to maximize contention
+            results.append(prov._get_litellm())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)  # if the RLock regresses to a deadlock, this trips
+
+        assert all(not t.is_alive() for t in threads), "a thread deadlocked"
+        assert len(results) == 8
+        assert all(r is results[0] for r in results), "threads saw different instances"
+        # codex handler still registered exactly once
+        entries = list(getattr(results[0], "custom_provider_map", None) or [])
+        assert sum(1 for e in entries if e.get("provider") == "codex") == 1
+    finally:
+        prov._litellm = saved


### PR DESCRIPTION
## Summary
Guards the lazy `_get_litellm()` initializer with a module-level **RLock** + double-checked locking so concurrent first-calls (e.g. main model + a chakla worker) can't double-import or partially-configure litellm (#123).

### Why reentrant (this is the crux)
`_init_litellm` → `_register_codex_provider` → `codex_provider` **re-enters `_get_litellm()` on the same thread** during registration. A plain `threading.Lock` self-deadlocks there (an earlier attempt at this fix did exactly that and hung the test suite). An `RLock` lets the same thread re-acquire. We also publish `_litellm` to the module global **before** codex registration so the reentrant call returns the configured module instead of recursing into a second init.

## Testing
- 431 tests pass (was 430 — added a contention test: 8 threads race the first init behind a barrier, must all get the same instance, codex handler registered exactly once, 30s join timeout catches a deadlock regression)
- ruff clean · pyright 0 errors · smoke OK · suite ~29s (no hang)

Closes #123