### PR TITLE
chore: release v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "3.0.0"
+version = "3.1.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Bumps to **3.1.0** (minor — bug/hardening fixes, no breaking changes).

Per the release flow: land this bump, then tag `v3.1.0` to publish.

### Since 3.0.0 — remaining code-review findings, all fixed
| Area | Issues |
|---|---|
| Report injection/schema | #119 (markdown fence), #124 (SARIF) |
| Provider correctness | #116 (reassembly), #117 (classify), #114 (cost), #123 (thread-safe init) |
| Session/context integrity | #112 (atomic save), #115 (repair dedup) |
| Headless | #120 (crash-resumable checkpointing) |

### Verified on merged main
- 431 tests pass (was 396 at 2.0.0) · ruff clean · pyright 0 errors · smoke OK
- `uv build` produces riftor-3.1.0 sdist + wheel