### PR TITLE
docs: refresh CLAUDE.md for v3.2.0 architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Product snapshot
+
+- **Version:** 3.2.0 (PyPI + GitHub Release)
+- **Website:** https://riftor.dev (source: https://github.com/Estudely/riftor-website — separate repo)
+- **Roadmap:** `todo.md` (Phase 8 launch is done; housekeeping items remain)
+- **Config reference:** `docs/configuration.md` (canonical; site "Docs" links here)
+
 ## Development commands
 
 All commands use `uv` (Astral's Python package manager). Install dev dependencies once: `uv sync --extra dev`.
@@ -18,6 +25,8 @@ All commands use `uv` (Astral's Python package manager). Install dev dependencie
 | Build | `uv build` |
 | Pre-commit hooks | `make install-hooks` or `uv run pre-commit install` |
 
+Optional extras: `uv sync --extra browser` (Playwright for `browser_*` tools), `--extra browser-ui` (inline screenshots on Python 3.12+), `--extra dev`.
+
 CI runs lint, type check, unit tests, and smoke on Python 3.11 + 3.12. All tests run **offline** — no API key or model needed.
 
 - **Offline by design.** The provider checks `RIFTOR_DEMO_RESPONSE` first and, if set, yields that canned text instead of calling litellm (`agent/provider.py`) — this is how the suite and smoke test avoid the network. `tests/conftest.py` supplies the shared fixtures `tmp_workdir`, `engagement`, and `toolctx`. `pytest` runs in `asyncio_mode = "auto"` (no `@pytest.mark.asyncio` needed).
@@ -25,7 +34,7 @@ CI runs lint, type check, unit tests, and smoke on Python 3.11 + 3.12. All tests
 
 ## Architecture
 
-riftor is a Python 3.11+ TUI pentest assistant: a Textual full-screen app backed by litellm, organized around the **RIFT** methodology (Recon → Intrusion → Foothold → Takeover).
+riftor is a Python 3.11+ TUI pentest assistant: a Textual full-screen app backed by litellm, organized around the **RIFT** methodology (Recon → Intrusion → Foothold → Takeover). Current release ships **34** agent tools, **350+** bundled methodology skills, Baaj/Chakla subagents, optional browser automation, plugins, memory/lessons/hypotheses, and hard scope + permission gates.
 
 ### Entry and dispatch (`riftor/__main__.py`)
 
@@ -35,7 +44,7 @@ CLI arg parsing → loads config → dispatches:
 - `--prompt`/`-p` (a.k.a. `--headless`): runs `headless.py` (one-shot, non-interactive; also reads stdin)
 - default: launches `tui/app.py` (the full Textual app)
 
-Other flags apply to either path: `--version`, `--model`, `--api-key`, `--workdir`, `--scope-file`, and `--i-know-what-i-am-doing-give-me-full-access` (stored as `yolo`; see below).
+Other flags: `--version`, `--model`, `--api-key`, `--workdir`, `--scope-file`, `--chakla-model`, `--browser-headed`, and `--i-know-what-i-am-doing-give-me-full-access` (stored as `yolo`; see below).
 
 ### Agent loop (shared by TUI and headless)
 
@@ -44,29 +53,49 @@ The core loop lives in both `tui/app.py` and `headless.py`. The skeleton is the 
 1. User input → added to `Context` (conversation history)
 2. `Context.repair()` runs first — it ensures every assistant `tool_call` has a following tool result, inserting a synthetic `[interrupted: …]` result for any orphaned id (this is what keeps a cancelled/crashed turn replayable)
 3. `Provider.stream_turn(messages, tools)` streams `("text", delta)` chunks as the model talks, then yields a final `("done", Turn)`. **Tool calls are buffered during streaming and only appear on the final `Turn`** — they are reassembled by `index` from the chunk fragments, not streamed live.
-4. For each tool call: scope-sensitive tools are checked against the engagement scope; dangerous tools (`requires_permission`) go through the `Permissions` engine
+4. For each tool call: **anti-loop** (`agent/antiloop.py`) can warn/stop on repeated identical calls; scope-sensitive tools are checked against the engagement scope; dangerous tools (`requires_permission`) go through the `Permissions` engine
 5. Tool results → context; loop continues up to `max_steps` (default **16**, `config.py`) or until a turn has no tool calls
 
 ### Sub-packages
 
-- **`riftor/agent/`** — LLM abstraction. `provider.py` wraps litellm (streaming, tool calling, retry/backoff with deterministic jitter, `classify_error()` mapping exceptions to a typed `ProviderError`). **litellm is lazily imported** on first model call (~2.4s — an estimate in a comment, not a measured constant) to keep startup fast. `context.py` builds the system prompt from `agent/prompts/system.md` (loaded via `importlib.resources`) and appends `LORE_PREAMBLE` when `lore=True`; it also handles `compact()` (clip old tool results to ~400 chars, keep the last ~8 messages) and the `repair()` above. `session.py` persists sessions as JSON via tmp-file + `Path.replace()`; the `complete` flag marks mid-turn checkpoints so a crashed run can be detected and resumed.
+- **`riftor/agent/`** — LLM abstraction. `provider.py` wraps litellm (streaming, tool calling, retry/backoff with deterministic jitter, `classify_error()` mapping exceptions to a typed `ProviderError`). **litellm is lazily imported** on first model call (~2.4s — an estimate in a comment, not a measured constant) to keep startup fast. `context.py` builds the system prompt from `agent/prompts/system.md` (loaded via `importlib.resources`) and appends `LORE_PREAMBLE` when `lore=True` (and genz persona when `genz=True`); it also handles `compact()` (clip old tool results to ~400 chars, keep the last ~8 messages) and the `repair()` above. `session.py` persists sessions as JSON via tmp-file + `Path.replace()`; the `complete` flag marks mid-turn checkpoints so a crashed run can be detected and resumed. `subagent.py` is the Chakla worker loop (isolated Context, `lore=False`, headless-style gating, shared engagement DB under a lock). `antiloop.py` classifies repeated tool-call signatures.
 - **`riftor/providers.py`** — provider registry feeding config and the model picker. Holds the `PROVIDERS` table and `PROVIDER_DEFAULTS` (curated model lists), resolves a provider from a model id (`provider_key_for_model`), and `fetch_models()` queries the live model list but **degrades to the curated defaults on any network/auth failure**. Edit this when touching model selection or credential resolution.
-- **`riftor/tui/`** — Textual app. `app.py` is the agent loop + all slash commands (in `_COMMANDS`/handler dict) + scope enforcement + permission modals + per-step session checkpointing, context-window monitoring (prompts `/compact` near the limit), and an optional `rate_limit_per_min` gate. `theme.py` defines **7 themes** (`rift` default, `dusk`, `void`, `fracture`, `singularity`, plus the light `dawn`/`paper`) via a `_PALETTES` dict → Textual CSS variables. `widgets.py` holds the `StatusBar` (renders the `[R·I·F·T]` stage, scope/findings/token/cost/context gauges, model, yolo flag), `Banner`, and `CommandDropdown` (slash-command autocomplete: prefix match then `difflib` fuzzy fallback). `config_screen.py` is the runtime settings modal (model/provider/temperature/max_tokens/theme/lore) with live theme preview and provider model discovery.
-- **`riftor/tools/`** — Agent-callable tool system. **All tools must be registered in the `ALL_TOOLS` list in `tools/__init__.py`** — its order is safe→mutating and is also the order shown to the model, and it **interleaves core and engagement tools** (read-only engagement tools like `ScopeListTool`/`ListHostsTool` come before mutating core tools like `WriteTool`/`BashTool`). Each tool extends `Tool` (ABC in `base.py`) and returns a `ToolResult`. A tool declares its policy via class flags: `requires_permission`, `danger`, `scope_sensitive` — these apply to engagement tools too (e.g. `AddScopeTool` requires permission), not just bash/write/edit. Tools are UI-agnostic — they return data; the app renders it. `core.py` has bash/read/write/edit/grep/glob/webfetch; `engagement.py` has the RIFT-specific tools (set-stage, scope, record service/finding, edit/delete finding, import-scan, generate-report).
-- **`riftor/engagement/`** — RIFT methodology engine. `scope.py` does IP/CIDR/domain/wildcard matching (`Target.parse`/`Target.matches`). `state.py` is the SQLite-backed persistence layer (tables: `meta`, `scope`, `hosts`, `services`, `findings`, `activity`; findings gained `cvss`/`tags`/`notes` via an in-place column migration). `cvss.py` is pure-Python CVSS v3.1 base scoring (only `math`). `report.py` renders md/html/json/SARIF (`both` = md+html, `all` = all four). `parsers.py` turns raw recon output (nmap normal/greppable, httpx, nuclei — bracketed or JSONL) into a `ParsedScan` of services+findings; the `ImportScanTool` feeds it into state with skip/merge/allow-all dedup. `doctor.py` reports which external recon tools (nmap, httpx, nuclei, ffuf, gobuster, nikto, sqlmap, subfinder, dig, whatweb, curl, rg) are on `PATH`.
+- **`riftor/tui/`** — Textual app. `app.py` is the agent loop + all slash commands (in `_COMMANDS`/handler dict) + scope enforcement + permission modals + per-step session checkpointing, context-window monitoring (prompts `/compact` near the limit), optional `rate_limit_per_min` gate, Chakla "flock" progress UI, `!` shell shortcut + CWD header. `theme.py` defines **7 themes** (`rift` default, `dusk`, `void`, `fracture`, `singularity`, plus the light `dawn`/`paper`) via a `_PALETTES` dict → Textual CSS variables. `widgets.py` holds the `StatusBar` (renders the `[R·I·F·T]` stage, scope/findings/token/cost/context gauges, model, yolo / worker-cost segments), `Banner`, and `CommandDropdown` (slash-command autocomplete: prefix match then `difflib` fuzzy fallback). `config_screen.py` is the runtime settings modal (model/provider/temperature/max_tokens/theme/lore + WORKERS/Chakla section) with live theme preview and provider model discovery. `screenshot_gallery.py` backs `/screenshots`.
+- **`riftor/tools/`** — Agent-callable tool system. **All tools must be registered in the `ALL_TOOLS` list in `tools/__init__.py`** — its order is safe→mutating and is also the order shown to the model, and it **interleaves core and engagement tools** (read-only engagement tools like `ScopeListTool`/`ListHostsTool`/`WordlistTool` come before mutating core tools like `WriteTool`/`BashTool`). Each tool extends `Tool` (ABC in `base.py`) and returns a `ToolResult`. A tool declares its policy via class flags: `requires_permission`, `danger`, `scope_sensitive` — these apply to engagement tools too (e.g. `AddScopeTool` requires permission), not just bash/write/edit. Tools are UI-agnostic — they return data; the app renders it.
+  - `core.py` — bash / read / write / edit / grep / glob / webfetch (+ `run_shell` for the `!` shortcut)
+  - `engagement.py` — scope, stage, record/edit/delete finding & service, import_scan, generate_report, wordlist, load_skill, hypotheses, lessons, remember
+  - `browser.py` — `browser_*` tools (optional `riftor[browser]` / Playwright; degrade with an install hint when absent)
+  - `subagent.py` — `DispatchChaklaTool` (`dispatch_chakla`)
+  - Plugins append more tools at startup via `register_plugins()` (see `plugins.py`)
+- **`riftor/engagement/`** — RIFT methodology engine. `scope.py` does IP/CIDR/domain/wildcard matching (`Target.parse`/`Target.matches`). `state.py` is the SQLite-backed persistence layer (tables: `meta`, `scope`, `hosts`, `services`, `findings`, `activity`, `hypotheses`; findings have `cvss`/`tags`/`notes`/`confidence`/`verification_method` via in-place column migration). `cvss.py` is pure-Python CVSS v3.1 base scoring (only `math`). `report.py` renders md/html/json/SARIF (`both` = md+html, `all` = all four). `parsers.py` turns raw recon output (nmap normal/greppable, httpx, nuclei — bracketed or JSONL) into a `ParsedScan` of services+findings; the `ImportScanTool` feeds it into state with skip/merge/allow-all dedup. `doctor.py` reports which external recon tools (nmap, httpx, nuclei, ffuf, gobuster, nikto, sqlmap, subfinder, dig, whatweb, curl, rg) are on `PATH`. Also: `lessons.py` (cross-session lessons), `memory.py` (per-engagement notes), `templates.py` (engagement playbooks), `wordlists.py` (local wordlist discovery).
+- **`riftor/skills/`** — Bundled methodology skill markdown (350+). Loaded by the `load_skill` tool / `/skills` command; not operator-editable in-tree (operator skills can also live under XDG config — see `docs/configuration.md`).
+- **`riftor/plugins.py`** — Operator plugins: drop a `.py` (or package) exporting `TOOLS: list[Tool]` into `~/.config/riftor/plugins/`. Discovered at TUI/headless startup; bad plugins warn + skip (never fatal). Config: `plugins_enabled` / `plugins_allow` / `plugins_deny`.
+- **`riftor/terminology.py`** — Renameable Baaj/Chakla labels (`label_main` / `label_worker`).
 - **`riftor/safety/`** — Trust and safety. `permissions.py` resolves a call by precedence: **deny rules (incl. session-denied) → allow rules / session-grants → operator prompt**. Five default deny patterns guard `rm -rf`, `dd of=/dev/…`, `mkfs`, fork bombs, and writes to block devices (`> /dev/sda…`). Rules live in `~/.config/riftor/permissions.toml` (honoring `XDG_CONFIG_HOME`). `audit.py` provides JSONL audit logging with gzip rotation.
 
 ### Key design conventions
 
-- **Bad config never crashes.** Malformed config or permission files degrade silently to defaults on load — the app always starts (`Config.load()`, `Permissions.load()`, scope-file preloading, and `providers.fetch_models()`).
+- **Bad config never crashes.** Malformed config or permission files degrade silently to defaults on load — the app always starts (`Config.load()`, `Permissions.load()`, scope-file preloading, plugin load, and `providers.fetch_models()`).
 - **Tools are independent of the UI.** `Tool.execute()` returns a `ToolResult`; both the TUI and headless mode call the same execute methods and just render results differently.
-- **TUI vs headless gating differ — this is the main place the two loops diverge.** In the **TUI**, an out-of-scope or dangerous call raises an *interactive operator prompt* (once / session / always-allow / deny), so the operator can override per call; `scope dry-run` warns without blocking. In **headless** mode there is no operator: dangerous tools auto-deny unless an explicit allow rule exists in `permissions.toml`, and out-of-scope scope-sensitive calls are **always hard-blocked with no override**. Only the TUI does per-step session checkpointing, context-window monitoring, and rate-limiting.
+- **TUI vs headless gating differ — this is the main place the two loops diverge.** In the **TUI**, an out-of-scope or dangerous call raises an *interactive operator prompt* (once / session / always-allow / deny), so the operator can override per call; `scope dry-run` warns without blocking. In **headless** mode there is no operator: dangerous tools auto-deny unless an explicit allow rule exists in `permissions.toml`, and out-of-scope scope-sensitive calls are **always hard-blocked with no override**. Chakla workers use the same headless-style gating. Only the TUI does per-step session checkpointing, context-window monitoring, rate-limiting, and the live flock panel.
 - **YOLO mode bypasses every guardrail.** `--i-know-what-i-am-doing-give-me-full-access` sets `yolo=True`, which short-circuits the permission engine, scope enforcement, and the step limit (gated by `if not self.yolo` / `if not yolo` throughout `app.py` and `headless.py`). Preserve those guards when editing the loop — a regression here silently disarms all safety.
-- **Engagement state is per-workdir.** Each working directory gets its own `.riftor/` with an `engagement.db` (SQLite), `sessions/`, and `reports/`. Sessions auto-save and resume.
+- **Engagement state is per-workdir.** Each working directory gets its own `.riftor/` with an `engagement.db` (SQLite), `sessions/`, `reports/`, and optionally `browser-profile/`. Sessions auto-save and resume.
 - **Context windows vary by provider.** The status bar shows a context-window gauge using per-provider estimates (`app.py`): Anthropic 200k, OpenAI/OpenRouter/Groq 128k, Gemini 1M, Ollama 8k, default 128k.
+- **Telemetry is intentionally not shipped.** Do not add analytics/phone-home. The only `telemetry` reference is `litellm.telemetry = False`. Historical design note (dropped): `docs/superpowers/specs/2026-06-10-telemetry-design.md` (gitignored under `docs/superpowers/`).
 - **`uv.lock` is committed** for reproducible installs. Dependencies are pinned.
+
+### Releases
+
+`pyproject.toml` is the version source of truth. Flow (see `CONTRIBUTING.md`):
+1. `uv version X.Y.Z` (bumps `pyproject.toml` + `uv.lock`)
+2. PR → merge to `main`
+3. `git tag vX.Y.Z && git push origin vX.Y.Z` on the merged commit
+4. `.github/workflows/release.yml` runs CI, publishes to PyPI (trusted publishing), creates the GitHub Release
+
+Do **not** tag before the bump is on `main`.
 
 ### Ancillary
 
 - `completions/` ships bash (`riftor.bash`) and zsh (`_riftor`) completions — **update them when you add or rename a CLI flag.**
-- `docs/` holds `configuration.md` and the `riftor.1` man page; `todo.md` is the roadmap.
+- `docs/` holds `configuration.md`, the `riftor.1` man page, and release notes (e.g. `RELEASE_NOTES_v3.2.0.md`); `todo.md` is the roadmap.
+- Website is **not** built from this repo — edit https://github.com/Estudely/riftor-website for https://riftor.dev.


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` to match the v3.2.0 codebase and launch state
- Document subagents, skills, browser tools, plugins, anti-loop, and related engagement modules
- Note telemetry is intentionally not shipped; website lives in a separate repo
- Add the release tagging flow for maintainers

## Test plan
- [ ] Skim `CLAUDE.md` against current package layout
- [ ] No code/behavior changes


Made with [Cursor](https://cursor.com)