### PR TITLE
fix(agent): stop forcing /continue during recon (#104)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `show_thinking` | bool | `true` | Show the model's reasoning as a dim block above each answer (and on stderr in `--headless`). |
 | `show_tool_output` | bool | `true` | Render tool-result blocks in the chat. When off, the `⛏` call line still shows and hidden output stays reachable via `/show <id>`. |
 | `reasoning_effort` | string | `medium` | Thinking budget requested from the model: `none` `low` `medium` `high`. `none` (or `show_thinking = false`) sends no reasoning request. |
-| `max_steps` | int | `16` | Tool-call steps per task before pausing (extend live with `/continue`). Also caps each Chakla worker's step budget. |
+| `max_steps` | int | `16` | Tool-call steps per task before pausing. `/continue [N]` raises the live session budget (and the barren-round ceiling) so recon isn't cut short every few rounds; the config file is unchanged until you Save in `/config`. Also caps each Chakla worker's step budget. |
 | `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |
 | `result_preview_lines` | int | `25` | Lines of a tool result shown before `…/show <id>`. |
 | `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |

--- a/riftor/agent/circuit.py
+++ b/riftor/agent/circuit.py
@@ -1,0 +1,61 @@
+"""Barren-round / progress circuit breaker for the agent loop.
+
+Pure helpers so the rule can be unit-tested without driving Textual.
+The loop in ``tui/app.py`` owns the side effects (stopping, operator notes).
+
+Issue #104: the breaker used to watch *findings only*, so recon that records
+hosts/services looked "stuck" and forced ``/continue`` every few rounds.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from riftor.engagement import Engagement
+
+#: Consecutive tool-using rounds with no new hosts/services/findings before stop.
+BARREN_LIMIT = 8
+
+#: When the operator explicitly ``/continue``s, raise the barren ceiling so the
+#: same recon stretch is not immediately cut short again.
+_CONTINUE_BARREN_BONUS = 16
+
+
+def progress_score(engagement: Engagement | None) -> int:
+    """Monotonic engagement progress: hosts + services + findings.
+
+    Recon that only discovers infrastructure still counts as progress.
+    """
+    if engagement is None:
+        return 0
+    store = engagement.store
+    return (
+        len(store.list_hosts())
+        + len(store.list_services())
+        + engagement.findings_count()
+    )
+
+
+def barren_limit(*, extra_steps: int = 0) -> int:
+    """Barren-round ceiling for this agent run.
+
+    A positive ``extra_steps`` means the operator asked to continue — give the
+    run more room before the barren breaker fires again.
+    """
+    if extra_steps > 0:
+        return BARREN_LIMIT + _CONTINUE_BARREN_BONUS
+    return BARREN_LIMIT
+
+
+def should_stop_barren(barren_rounds: int, *, limit: int | None = None) -> bool:
+    """True when ``barren_rounds`` has reached the stop threshold."""
+    ceiling = BARREN_LIMIT if limit is None else limit
+    return barren_rounds >= ceiling
+
+
+def note_for_barren_stop() -> str:
+    return (
+        "⚠ circuit breaker: no new hosts/services/findings for several rounds — "
+        "stopping. /continue to resume or change approach."
+    )

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -27,7 +27,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Collapsible, Input, Markdown, RichLog, Static
 
 from riftor import tools
-from riftor.agent import antiloop
+from riftor.agent import antiloop, circuit
 from riftor.agent import session as sessions
 from riftor.agent.context import Context
 from riftor.agent.provider import Provider, ProviderError, ToolCall, Turn, Usage
@@ -165,7 +165,7 @@ HELP = """\
 
 _Conversation_
 - `/help` — show this help · `/clear` — clear conversation (`Ctrl+L`)
-- `/retry` — re-run the last turn · `/continue [N]` — extend the step budget
+- `/retry` — re-run the last turn · `/continue [N]` — raise the session step budget (+ barren ceiling)
 - `/compact` — shrink old tool output to free context
 - `/cost` — token + cost for this session
 - `/conversation` — export the full conversation as markdown
@@ -1556,7 +1556,14 @@ class RiftorApp(App):
         extra = 16
         if arg.strip().isdigit():
             extra = int(arg.strip())
-        self._note(f"continuing — extending the step budget by {extra}")
+        # Persist the bump so later turns (and the next /continue) start from a
+        # higher baseline — otherwise every task still dies at the old max_steps
+        # and the operator has to /continue again and again (issue #104).
+        self.max_steps += extra
+        self.config.max_steps = self.max_steps
+        self._note(
+            f"continuing — step budget now {self.max_steps} (+{extra} this run)"
+        )
         self._agent("Continue from where you left off.", extra_steps=extra)
 
     def _compact_cmd(self) -> None:
@@ -1747,10 +1754,13 @@ class RiftorApp(App):
         self._spinner = PulseSpinner(label, classes="spinner")
         await self._mount(self._spinner)
         self._spinner.start()
-        budget = 10**9 if self.yolo else self.max_steps + extra_steps
+        # /continue already bumped self.max_steps; don't double-count extra_steps
+        # into the budget (extra_steps still raises the barren ceiling below).
+        budget = 10**9 if self.yolo else self.max_steps
         _recent_cmds: list[str] = []
         _barren_rounds = 0
-        _findings_before = self.engagement.findings_count() if self.engagement else 0
+        _progress_before = circuit.progress_score(self.engagement)
+        _barren_ceiling = circuit.barren_limit(extra_steps=extra_steps)
         try:
             for step in range(budget):
                 self._save_session(complete=False)  # crash-safe checkpoint
@@ -1805,18 +1815,15 @@ class RiftorApp(App):
                     await self._run_tool(call)
                 if anti_loop_stop:
                     break
-                # all tools ran normally; check barren rounds
-                current_findings = self.engagement.findings_count() if self.engagement else 0
-                if current_findings > _findings_before:
+                # Progress = hosts + services + findings (recon counts too — #104).
+                current_progress = circuit.progress_score(self.engagement)
+                if current_progress > _progress_before:
                     _barren_rounds = 0
-                    _findings_before = current_findings
+                    _progress_before = current_progress
                 else:
                     _barren_rounds += 1
-                if _barren_rounds >= 8:
-                    self._note(
-                        "⚠ circuit breaker: 8 rounds with no new findings — "
-                        "stopping. /continue to resume or change approach."
-                    )
+                if circuit.should_stop_barren(_barren_rounds, limit=_barren_ceiling):
+                    self._note(circuit.note_for_barren_stop())
                     break
             else:
                 self._note(

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1,0 +1,63 @@
+"""Barren-round / progress circuit breaker (issue #104).
+
+The agent must treat hosts and services as progress during recon — not only
+findings — otherwise /continue is needed every few rounds of enumeration.
+"""
+
+from __future__ import annotations
+
+from riftor.agent import circuit
+from riftor.engagement import Engagement
+
+
+def test_progress_counts_hosts_and_services_not_just_findings(tmp_path):
+    eng = Engagement(tmp_path)
+    assert circuit.progress_score(eng) == 0
+
+    eng.store.add_host("10.0.0.1")
+    assert circuit.progress_score(eng) == 1
+
+    eng.add_service(host="10.0.0.1", port=80, proto="tcp", service="http")
+    assert circuit.progress_score(eng) == 2
+
+    eng.add_finding(title="xss", severity="high", host="10.0.0.1")
+    assert circuit.progress_score(eng) == 3
+    eng.close()
+
+
+def test_progress_score_none_engagement_is_zero():
+    assert circuit.progress_score(None) == 0
+
+
+def test_barren_resets_when_hosts_grow_without_findings():
+    """Recon that only records hosts must not trip the barren breaker."""
+    barren = 0
+    prev = 0
+    # Simulate 7 rounds of host discovery (no findings).
+    for n_hosts in range(1, 8):
+        score = n_hosts  # stand-in for progress_score
+        if score > prev:
+            barren = 0
+            prev = score
+        else:
+            barren += 1
+        assert not circuit.should_stop_barren(barren)
+
+
+def test_barren_stops_only_after_limit_with_no_progress():
+    barren = 0
+    for _ in range(circuit.BARREN_LIMIT - 1):
+        barren += 1
+        assert not circuit.should_stop_barren(barren)
+    barren += 1
+    assert circuit.should_stop_barren(barren)
+
+
+def test_continue_disables_barren_for_that_run():
+    """Explicit /continue means the operator wants more work — don't re-trip
+    the barren breaker on the same run (issue #104)."""
+    assert circuit.barren_limit(extra_steps=0) == circuit.BARREN_LIMIT
+    assert circuit.barren_limit(extra_steps=16) > circuit.BARREN_LIMIT
+    assert not circuit.should_stop_barren(
+        circuit.BARREN_LIMIT, limit=circuit.barren_limit(extra_steps=16)
+    )


### PR DESCRIPTION
## Summary
Fixes #104 — operators had to `/continue` repeatedly during recon.

**Root cause:** the barren-round circuit breaker only watched *findings*. Host/service discovery looked "stuck", so the loop stopped every 8 tool rounds. `/continue` also did not persist the step budget, so the next task hit the same wall.

**Fix:**
- Progress = hosts + services + findings (`riftor/agent/circuit.py`)
- `/continue` raises the session `max_steps` (and the barren ceiling for that run)
- Unit tests for the progress / barren rules

## Test plan
- [x] `pytest tests/test_circuit.py tests/test_antiloop.py`
- [x] ruff + pyright clean on touched files
- [ ] CI green
- [ ] Manual: long recon that only records hosts/services should not stop at 8 barren rounds; `/continue` should raise the live step budget


Made with [Cursor](https://cursor.com)