### PR TITLE
QoL: slash registries, resume /retry, headless step-limit exit

### DIFF
--- a/completions/_riftor
+++ b/completions/_riftor
@@ -8,7 +8,7 @@ _riftor() {
     '--version[print version and exit]' \
     '--config[print the config file path and exit]' \
     '--model[override the model for this run]:model:(anthropic/claude-sonnet-4-6 openai/gpt-4o openrouter/auto ollama_chat/llama3.1)' \
-    '--chakla-model[override the Chakla (worker) model for this run]:model:(anthropic/claude-haiku-4-5-20251001 anthropic/claude-sonnet-4-6 openai/gpt-4o)' \
+    '--chakla-model[override the Chakla (worker) model for this run; empty default reuses main]:model:(anthropic/claude-sonnet-4-6 anthropic/claude-haiku-4-5-20251001 openai/gpt-4o)' \
     '--api-key[override the API key for this run]:key:' \
     '--workdir[engagement working directory]:dir:_files -/' \
     '--scope-file[load scope targets from a file]:file:_files' \

--- a/completions/riftor.bash
+++ b/completions/riftor.bash
@@ -13,6 +13,7 @@ _riftor() {
             return 0
             ;;
         --model|--chakla-model)
+            # chakla_model defaults to "" (reuse main); Haiku is a common cheap override
             COMPREPLY=( $(compgen -W "anthropic/claude-sonnet-4-6 anthropic/claude-haiku-4-5-20251001 openai/gpt-4o openrouter/auto ollama_chat/llama3.1" -- "$cur") )
             return 0
             ;;

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -410,6 +410,51 @@ async def main() -> None:
         assert "operator likes quiet scans" in sp
         assert "WEB APPLICATION" in sp
 
+        # Slash-command registry drift guard: every dispatch key ⊆ _COMMANDS
+        from riftor.tui.app import _COMMANDS
+        handler_keys = set(app._command_handlers("").keys()) | {"/exit", "/quit"}
+        missing = handler_keys - set(_COMMANDS)
+        assert not missing, f"handlers missing from _COMMANDS: {sorted(missing)}"
+
+        # Post-v3.3 session/engagement commands: don't crash and do useful work
+        inp.value = "seed for branch"
+        await pilot.press("enter")
+        await pilot.pause()
+        app.action_cancel()
+        before_sid = app.session_id
+        assert len(app.context.dump()) >= 1, "expected seeded message in history"
+        inp.value = "/branch smoke-fork"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.session_id != before_sid, "branch should mint a new session id"
+        # dump() is the persisted history (no synthetic system msg); 0 clears it
+        inp.value = "/rollback 0"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert len(app.context.dump()) == 0
+
+        app.engagement.add_service(host="10.0.0.5", port=443, service="https")
+        inp.value = "/graph"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert (Path(workdir) / ".riftor" / "reports" / "graph.mmd").exists(), \
+            "/graph should write .riftor/reports/graph.mmd"
+
+        inp.value = "/hypotheses"
+        await pilot.press("enter")
+        await pilot.pause()
+        inp.value = "/lesson WHEN smoke → assert lightly"
+        await pilot.press("enter")
+        await pilot.pause()
+        inp.value = "/lessons"
+        await pilot.press("enter")
+        await pilot.pause()
+        # /copy with stored output should not crash
+        app._last_output = "smoke-copy-payload"
+        inp.value = "/copy"
+        await pilot.press("enter")
+        await pilot.pause()
+
     print("SMOKE OK")
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,23 +19,25 @@ falls back to detected defaults (it won't overwrite your file) and launches.
 | `max_tokens` | int | `2048` | Max tokens per model response. |
 | `theme` | string | `rift` | Dark: `rift` `dusk` `void` `fracture` `singularity` · Light: `dawn` `paper`. Changing it in `/config` previews live. |
 | `lore` | bool | `true` | The subtle rift persona; off = strictly professional voice. |
+| `genz` | bool | `false` | Gen Z / Chakla Baaj persona overlay (also toggled with `/genz`). |
 | `show_thinking` | bool | `true` | Show the model's reasoning as a dim block above each answer (and on stderr in `--headless`). |
 | `show_tool_output` | bool | `true` | Render tool-result blocks in the chat. When off, the `⛏` call line still shows and hidden output stays reachable via `/show <id>`. |
 | `reasoning_effort` | string | `medium` | Thinking budget requested from the model: `none` `low` `medium` `high`. `none` (or `show_thinking = false`) sends no reasoning request. |
-| `max_steps` | int | `16` | Tool-call steps per task before pausing. `/continue [N]` raises the live session budget (and the barren-round ceiling) so recon isn't cut short every few rounds; the config file is unchanged until you Save in `/config`. Also caps each Chakla worker's step budget. |
+| `max_steps` | int | `16` | Tool-call steps per task before pausing. `/continue [N]` raises the live session budget (and the barren-round ceiling) so recon isn't cut short every few rounds; the config file is unchanged until you Save in `/config`. Also caps each Chakla worker's step budget. In `--headless` / `--prompt`, exceeding this exits with code `4`. |
 | `max_result_chars` | int | `30000` | Cap on tool output fed back to the model. |
 | `result_preview_lines` | int | `25` | Lines of a tool result shown before `…/show <id>`. |
 | `rate_limit_per_min` | int | `0` | Cap model calls per minute (`0` = unlimited). |
 | `browser_headless` | bool | `true` | Run the Playwright browser headless (good for servers/SSH). Set `false` to launch it visibly. |
 | `browser_persistent_profile` | bool | `false` | Reuse a profile at `.riftor/browser-profile/` (persists cookies/sessions). Default is incognito — a fresh context per launch. |
 | `wordlists_dir` | string | — | Extra directory the `wordlist` tool searches, in addition to the known SecLists/system locations. |
+| `skills_dir` | string | — | Extra directory of operator skill markdown (in addition to the bundled skills and `~/.config/riftor/skills/`). |
 | `plugins_enabled` | bool | `true` | Master switch for operator plugins. `false` disables all plugin loading. |
 | `plugins_allow` | list | `[]` | If non-empty, only these plugin module names are loaded. |
 | `plugins_deny` | list | `[]` | Plugin module names to skip. Deny wins over allow. |
 | `mcp_enabled` | bool | `true` | Master switch for MCP client connections (`riftor[mcp]`). |
 | `hackerone_username` | string | — | Optional HackerOne API username for `/scope bounty hackerone:<handle>` (prefer env `HACKERONE_USERNAME`). |
 | `hackerone_token` | string | — | Optional HackerOne API token (prefer env `HACKERONE_TOKEN`). |
-| `chakla_model` | string | `anthropic/claude-haiku-4-5-20251001` | The cheap worker model used by dispatched Chakla subagents. |
+| `chakla_model` | string | `""` (reuse main) | Chakla worker model. Empty string means reuse the main `model`. Override with a cheap id (e.g. Haiku) when you want workers on a different model. |
 | `chakla_max_workers` | int | `5` | Max number of Chakla workers per dispatch batch. |
 | `chakla_timeout_s` | int | `300` | Per-worker wall-clock timeout in seconds. |
 | `label_main` | string | `Baaj` | Display name for the orchestrator agent. |
@@ -95,9 +97,10 @@ Key properties of the worker fleet:
 - **Concurrency is bounded.** `chakla_max_workers` caps parallel workers;
   each worker's step budget is `max_steps` (shared with the main agent);
   `chakla_timeout_s` sets the wall-clock ceiling. Tune these to stay within rate limits.
-- **Worker model defaults to Haiku.** `chakla_model` defaults to
-  `anthropic/claude-haiku-4-5-20251001` — a cheap, fast model well-suited to
-  bounded recon tasks. Override it with `--chakla-model` at the CLI or by editing
+- **Worker model defaults to the main model.** `chakla_model` defaults to an
+  empty string, which means workers reuse `model`. Set it to a cheaper id
+  (e.g. `anthropic/claude-haiku-4-5-20251001`) when you want workers on a
+  different model. Override with `--chakla-model` at the CLI or by editing
   the config file.
 
 ### Live worker visibility
@@ -120,6 +123,19 @@ invocation and are not persisted to config.toml):
 | `--chakla-model MODEL` | `chakla_model` | Override the Chakla worker model. |
 | `--api-key KEY` | `api_key` | Override the API key. |
 | `--browser-headed` | `browser_headless` | Run the browser visibly for this run only (does not persist). |
+
+### Headless exit codes
+
+`--prompt` / `--headless` exit codes (for CI scripting):
+
+| Code | Meaning |
+|---|---|
+| `0` | Finished normally (model stopped without more tool calls). |
+| `1` | Provider error. |
+| `2` | No prompt given. |
+| `3` | Missing API credentials for the selected model. |
+| `4` | Stopped after `max_steps` (truncated run — raise the budget or use YOLO). |
+| `130` | Interrupted (`KeyboardInterrupt`). |
 
 ## Browser
 

--- a/docs/riftor.1
+++ b/docs/riftor.1
@@ -47,6 +47,26 @@ Type \fB/help\fR inside riftor for the full list, including \fB/scope\fR,
 \fB/retry\fR, \fB/continue\fR, \fB/compact\fR, \fB/timeline\fR, \fB/browser\fR and \fB/export\fR.
 \fB/browser\fR shows browser status; \fB/browser headed\fR / \fB/browser headless\fR
 switch the mode (persisted) and \fB/browser close\fR tears it down.
+.SH EXIT STATUS
+Headless (\fB\-\-prompt\fR / \fB\-\-headless\fR) exit codes:
+.TP
+.B 0
+Finished normally.
+.TP
+.B 1
+Provider error.
+.TP
+.B 2
+No prompt given.
+.TP
+.B 3
+Missing API credentials.
+.TP
+.B 4
+Stopped after \fBmax_steps\fR (truncated run).
+.TP
+.B 130
+Interrupted.
 .SH FILES
 .TP
 .I ~/.config/riftor/config.toml
@@ -64,7 +84,7 @@ Selected keys from \fB~/.config/riftor/config.toml\fR (\fB[riftor]\fR table):
 Main-agent litellm model id (default: \fIanthropic/claude-sonnet-4-6\fR).
 .TP
 .B chakla_model
-Chakla worker model id (default: \fIanthropic/claude-haiku-4-5-20251001\fR).
+Chakla worker model id. Empty (default) reuses the main \fBmodel\fR.
 .TP
 .B chakla_max_workers
 Maximum number of Chakla workers per dispatch batch (default: \fI5\fR).

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -4,6 +4,14 @@ Useful for scripting and CI. The agent streams to stdout. For safety, dangerous
 tools (bash/write/edit) only run if an explicit allow rule exists in
 ``permissions.toml`` — otherwise they are auto-denied (no interactive operator to
 approve). Out-of-scope, scope-sensitive calls are always blocked.
+
+Exit codes:
+  0   finished normally (model stopped without more tool calls)
+  1   provider error
+  2   no prompt given
+  3   missing API credentials
+  4   stopped after ``max_steps`` (truncated; raise the budget or use YOLO)
+  130 interrupted (KeyboardInterrupt)
 """
 
 from __future__ import annotations
@@ -123,6 +131,7 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
         except Exception:  # noqa: BLE001 — never let checkpointing break the run
             pass
 
+    truncated = False
     try:
         for _ in range(max_steps):
             context.repair()
@@ -153,7 +162,10 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
                 break
             for call in turn.tool_calls:
                 await _run_tool_headless(call, engagement, permissions, audit, toolctx, context, yolo=yolo)
-        _checkpoint(complete=True)  # ran to completion → mark the session done
+        else:
+            # for-else: loop exhausted without a clean break → step budget hit
+            truncated = True
+        _checkpoint(complete=not truncated)
     finally:
         if toolctx.browser is not None and toolctx.browser.launched:
             try:
@@ -162,6 +174,13 @@ async def _run(cfg: Config, workdir: Path, prompt: str, scope_file: str | None, 
                 pass
         engagement.close()
     print()  # trailing newline
+    if truncated:
+        print(
+            f"riftor: stopped after {max_steps} steps (max_steps); "
+            "raise max_steps in config or pass --i-know-what-i-am-doing-give-me-full-access",
+            file=sys.stderr,
+        )
+        return 4
     return 0
 
 

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -155,9 +155,9 @@ _COMMANDS = [
     "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
     "/sessions", "/resume", "/new", "/branch", "/rollback", "/theme", "/config", "/tools", "/skills",
     "/permissions", "/lore", "/genz", "/cost", "/retry", "/continue",
-    "/compact", "/timeline", "/audit", "/export", "/conversation",
-    "/doctor", "/review", "/memory", "/template", "/browser",
-    "/screenshots", "/graph", "/merge", "/exit",
+    "/compact", "/copy", "/show", "/timeline", "/audit", "/export", "/conversation",
+    "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/memory", "/template",
+    "/browser", "/screenshots", "/graph", "/merge", "/clearlog", "/exit", "/quit",
 ]
 
 HELP = """\
@@ -167,6 +167,8 @@ _Conversation_
 - `/help` — show this help · `/clear` — clear conversation (`Ctrl+L`)
 - `/retry` — re-run the last turn · `/continue [N]` — raise the session step budget (+ barren ceiling)
 - `/compact` — shrink old tool output to free context
+- `/copy` — copy the last agent/tool output to the clipboard
+- `/show <id>` — reveal a truncated tool result by id
 - `/cost` — token + cost for this session
 - `/conversation` — export the full conversation as markdown
 
@@ -182,7 +184,9 @@ _Engagement_
 - `/graph` — render a kill-chain attack graph (Mermaid) from engagement data
 - `/timeline` — engagement activity log · `/export` — archive the whole engagement
 - `/merge <path>` — merge another engagement.db (collaborative hand-off)
-- `/memory [add <tag> <text>|rm <id>|clear]` — engagement notes, hypotheses, and durable lessons
+- `/memory [add <tag> <text>|rm <id>|clear]` — durable engagement notes
+- `/hypotheses` — list open/confirmed/refuted attack hypotheses
+- `/lesson <text>` — save a durable cross-session lesson · `/lessons` — list them
 - `/template [webapp|api|network|ad]` — apply an engagement playbook · `/template off`
 
 _Skills_
@@ -195,14 +199,14 @@ _Settings & sessions_
 - `/model [name]` — show or switch the model · `/theme [name]` (rift/dusk/void/fracture/singularity/dawn/paper)
 - `/config` — settings panel · `/permissions` — review allow/deny rules
 - `/lore` — toggle the rift persona · `/genz` — toggle Gen Z / Chakla Baaj mode 🦅
-- `/audit` — recent tool-call audit log
+- `/audit` — recent tool-call audit log · `/clearlog` — clear the shell output pane
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed
 - `/browser [headed|headless|close]` — browser mode / teardown · `/screenshots` — view captures
 - `/review` — self-critique findings for false positives before reporting
 - `/sessions` · `/resume <id>` · `/new` — manage saved sessions
 - `/branch [label]` — fork the current session (message history only)
 - `/rollback <n>` — keep only the first *n* messages (truncate history)
-- `/tools` — list available agent tools · `/exit` — quit (`Ctrl+C`)
+- `/tools` — list available agent tools · `/exit` · `/quit` — quit (`Ctrl+C`)
 
 Type anything else to task the agent. `↑/↓` recall input · `PgUp/PgDn` scroll ·
 `Esc` cancels a running response. Drag to select text, `Ctrl+Y` copies it.
@@ -228,13 +232,21 @@ _PALETTE_COMMANDS = [
     ("/audit", "Audit log", "Recent tool-call audit entries"),
     ("/cost", "Cost", "Token + cost for this session"),
     ("/compact", "Compact context", "Shrink old tool output"),
+    ("/copy", "Copy last output", "Copy last agent/tool output to clipboard"),
+    ("/show", "Show tool result", "Reveal a truncated tool result by id"),
     ("/retry", "Retry", "Re-run the last turn"),
+    ("/hypotheses", "Hypotheses", "List attack hypotheses"),
+    ("/lessons", "Lessons", "List durable cross-session lessons"),
+    ("/lesson", "Add lesson", "Save a durable lesson"),
+    ("/clearlog", "Clear shell log", "Clear the shell output pane"),
     ("/config", "Config", "Open the settings panel"),
     ("/new", "New session", "Start a fresh conversation"),
     ("/clear", "Clear", "Clear the conversation"),
     ("/screenshots", "Screenshots", "Browse, view, and delete screenshots"),
     ("/memory", "Memory", "Durable notes for this engagement"),
     ("/template", "Template", "Apply an engagement playbook"),
+    ("/branch", "Branch session", "Fork the current session history"),
+    ("/rollback", "Rollback", "Truncate session to the first n messages"),
 ]
 
 
@@ -751,12 +763,9 @@ class RiftorApp(App):
             chat.scroll_end()
             self._autoscroll = True
 
-    def _command(self, text: str) -> None:
-        parts = text.split(maxsplit=1)
-        cmd = parts[0].lower()
-        arg = parts[1].strip() if len(parts) > 1 else ""
-
-        handlers = {
+    def _command_handlers(self, arg: str) -> dict:
+        """Slash-command dispatch table. Keys must stay ⊆ ``_COMMANDS``."""
+        return {
             "/help": lambda: self._markdown(HELP),
             "/tools": self._tools_cmd,
             "/skills": lambda: self._skills_cmd(arg),
@@ -804,11 +813,17 @@ class RiftorApp(App):
             "/template": lambda: self._template_cmd(arg),
             "/clearlog": self._clearlog_cmd,
         }
+
+    def _command(self, text: str) -> None:
+        parts = text.split(maxsplit=1)
+        cmd = parts[0].lower()
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
         if cmd in ("/exit", "/quit"):
             self._save_session()
             self.exit()
             return
-        handler = handlers.get(cmd)
+        handler = self._command_handlers(arg).get(cmd)
         if handler is not None:
             handler()
             return
@@ -1748,7 +1763,11 @@ class RiftorApp(App):
         self._clear_flock()
         self.chat.remove_children()
         self._replay_transcript(self.context.messages)
-        self._note(f"resumed session {sid} ({len(data.get('messages', []))} messages)")
+        n = len(data.get("messages", []))
+        note = f"resumed session {sid} ({n} messages)"
+        if not data.get("complete", True):
+            note += "  ⚠ previous run ended mid-task — /retry to resume or /continue"
+        self._note(note)
 
     def _branch_cmd(self, arg: str) -> None:
         label = arg.strip() or None

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -1,0 +1,43 @@
+"""Slash-command registry must stay in sync with live dispatch handlers.
+
+Autocomplete and "did you mean" read ``_COMMANDS``; if a handler exists but the
+name is missing there, operators get a false "unknown command" suggestion miss.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import riftor.config as cfgmod
+from riftor.config import Config
+from riftor.tui.app import _COMMANDS, HELP, RiftorApp
+
+
+def _patch_paths(tmp: Path) -> None:
+    cfgmod.CONFIG_DIR = tmp
+    cfgmod.CONFIG_PATH = tmp / "config.toml"
+    cfgmod.PERMISSIONS_PATH = tmp / "permissions.toml"
+    cfgmod.KEYBINDINGS_PATH = tmp / "kb.toml"
+
+
+def test_handler_keys_subset_of_commands():
+    """Every dispatch key (plus /exit /quit) must appear in ``_COMMANDS``."""
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        app = RiftorApp(Config(), workdir=workdir)
+        handler_keys = set(app._command_handlers("").keys()) | {"/exit", "/quit"}
+        missing = handler_keys - set(_COMMANDS)
+        assert not missing, f"handlers missing from _COMMANDS: {sorted(missing)}"
+
+
+def test_help_lists_hypotheses_and_lessons_separately_from_memory():
+    """HELP must not claim hypotheses/lessons live under /memory."""
+    assert "/hypotheses" in HELP
+    assert "/lesson" in HELP
+    assert "/lessons" in HELP
+    # /memory line should describe notes only — not hypotheses/lessons
+    memory_line = next(line for line in HELP.splitlines() if "`/memory" in line)
+    assert "hypothes" not in memory_line.lower()
+    assert "lesson" not in memory_line.lower()

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -172,3 +172,38 @@ def test_headless_no_incomplete_left_after_success(monkeypatch, tmp_workdir):
     import asyncio
     asyncio.run(_run(cfg, tmp_workdir, "scan", None))
     assert sessions.find_incomplete(tmp_workdir) == []
+
+
+def test_headless_step_limit_returns_nonzero(monkeypatch, tmp_workdir, capsys):
+    """Hitting max_steps must exit nonzero with a stderr note (CI-distinguishable)."""
+    import asyncio
+
+    from riftor.agent.provider import Provider, ToolCall, Turn
+    from riftor.headless import _run
+
+    async def _always_tool(*_a, **_k):
+        call = ToolCall(id="c1", name="scope_list", arguments={}, raw_arguments="{}")
+        turn = Turn(
+            text="",
+            tool_calls=[call],
+            assistant_message={
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "scope_list", "arguments": "{}"},
+                    }
+                ],
+            },
+        )
+        yield ("done", turn)
+
+    monkeypatch.setattr(Provider, "stream_turn", _always_tool)
+    cfg = Config(model="anthropic/claude-sonnet-4-6", api_key="sk-demo", max_steps=2)
+
+    rc = asyncio.run(_run(cfg, tmp_workdir, "keep going forever", None))
+    assert rc == 4
+    err = capsys.readouterr().err
+    assert "max_steps" in err.lower() or "step" in err.lower()

--- a/tests/test_resume_retry_hint.py
+++ b/tests/test_resume_retry_hint.py
@@ -1,0 +1,71 @@
+"""Incomplete-session resume must always nudge the operator toward /retry."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import riftor.config as cfgmod
+from riftor.agent import session as sessions
+from riftor.config import Config
+from riftor.tui.app import RiftorApp
+
+
+def _patch_paths(tmp: Path) -> None:
+    cfgmod.CONFIG_DIR = tmp
+    cfgmod.CONFIG_PATH = tmp / "config.toml"
+    cfgmod.PERMISSIONS_PATH = tmp / "permissions.toml"
+    cfgmod.KEYBINDINGS_PATH = tmp / "kb.toml"
+
+
+@pytest.mark.asyncio
+async def test_resume_cmd_incomplete_hints_retry():
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        app = RiftorApp(Config(), workdir=workdir)
+        async with app.run_test():
+            # Save after mount so _offer_recovery does not fire on this sid.
+            msgs = [
+                {"role": "user", "content": "scan it"},
+                {"role": "assistant", "content": "working…"},
+            ]
+            sessions.save(workdir, "crash-sid", msgs, "m", complete=False)
+            notes: list[str] = []
+            real_note = app._note
+
+            def _capture(text: str) -> None:
+                notes.append(text)
+                real_note(text)
+
+            app._note = _capture  # type: ignore[method-assign]
+            app._resume_cmd("crash-sid")
+            assert any("resumed session crash-sid" in n for n in notes)
+            assert any("/retry" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_resume_cmd_complete_omits_retry_hint():
+    with tempfile.TemporaryDirectory() as d:
+        workdir = Path(d)
+        _patch_paths(workdir)
+        app = RiftorApp(Config(), workdir=workdir)
+        async with app.run_test():
+            msgs = [
+                {"role": "user", "content": "done"},
+                {"role": "assistant", "content": "ok"},
+            ]
+            sessions.save(workdir, "ok-sid", msgs, "m", complete=True)
+            notes: list[str] = []
+            real_note = app._note
+
+            def _capture(text: str) -> None:
+                notes.append(text)
+                real_note(text)
+
+            app._note = _capture  # type: ignore[method-assign]
+            app._resume_cmd("ok-sid")
+            assert any("resumed session ok-sid" in n for n in notes)
+            assert not any("/retry" in n for n in notes)


### PR DESCRIPTION
## Summary
- Sync `_COMMANDS`, `HELP`, and `_PALETTE_COMMANDS` with live slash handlers (`/copy`, `/show`, `/hypotheses`, `/lesson(s)`, `/clearlog`, `/quit`); fix `/memory` HELP so it no longer claims hypotheses/lessons live there; add a registry drift guard (handlers ⊆ `_COMMANDS`).
- Incomplete-session resume via `/resume` (and thus crash-recovery modal) now always nudges `/retry`, matching auto-resume.
- Align `docs/configuration.md`, man page, and shell completions with `config.py`: `chakla_model` defaults to `""` (reuse main); document `genz` and `skills_dir`.
- Headless runs that hit `max_steps` return exit code `4` with a stderr note (documented for CI); previously they exited `0` silently.
- Extend `dev/smoke.py` for `/branch`, `/rollback`, `/graph`, `/hypotheses`/`/lesson(s)`, and `/copy`.

## Test plan
- [x] `uv run python -m pytest tests/test_commands_registry.py tests/test_resume_retry_hint.py tests/test_headless.py -q`
- [x] `uv run python dev/smoke.py`
- [x] `uv run ruff check` + `uv run python -m pyright` on touched modules
- [ ] Manual: incomplete `/resume <id>` shows `/retry` hint; typo of `/hypotheses` suggests correctly; headless with tiny `max_steps` exits `4`


Made with [Cursor](https://cursor.com)