### PR TITLE
feat: QoL 6–10 — sessions prune/prefix, rollback UX, compact offer, demo-headless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # riftor — common dev tasks. Requires uv (https://docs.astral.sh/uv/).
-.PHONY: help dev run lint typecheck test smoke check build clean install-hooks
+.PHONY: help dev run lint typecheck test smoke check build clean install-hooks demo-headless
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -22,6 +22,9 @@ test: ## Run the pytest suite
 
 smoke: ## Run the headless TUI smoke suite
 	uv run python dev/smoke.py
+
+demo-headless: ## Offline --prompt smoke (no API key; uses RIFTOR_DEMO_RESPONSE)
+	RIFTOR_DEMO_RESPONSE='demo ok' uv run riftor --prompt 'say hi'
 
 check: lint typecheck test smoke ## Run every CI gate locally
 

--- a/dev/smoke.py
+++ b/dev/smoke.py
@@ -427,7 +427,17 @@ async def main() -> None:
         await pilot.press("enter")
         await pilot.pause()
         assert app.session_id != before_sid, "branch should mint a new session id"
-        # dump() is the persisted history (no synthetic system msg); 0 clears it
+        # dump() is the persisted history (no synthetic system msg). Seed another
+        # user turn, then /rollback last drops that turn (not raw message count).
+        inp.value = "second turn for rollback"
+        await pilot.press("enter")
+        await pilot.pause()
+        app.action_cancel()
+        assert len(app.context.dump()) >= 2
+        inp.value = "/rollback last"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert len(app.context.dump()) == 1, "rollback last should drop the last user turn"
         inp.value = "/rollback 0"
         await pilot.press("enter")
         await pilot.pause()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,6 +382,41 @@ Manage rules live with `/permissions allow <tool> [pattern]` and
 an approval prompt. In headless mode (`--prompt`), approval-gated tools only run
 if a standing `allow` rule exists.
 
+### Headless / CI allowlist
+
+`--prompt` / `--headless` has no operator to click Approve. Dangerous tools
+(`bash`, `write`, `edit`, `add_scope`, …) are **auto-denied** unless
+`~/.config/riftor/permissions.toml` already allows them. Out-of-scope
+scope-sensitive calls are always hard-blocked (no override).
+
+Minimal snippet for scripted recon (adjust patterns to your engagement):
+
+```toml
+# ~/.config/riftor/permissions.toml
+[permissions]
+allow = [
+  { tool = "bash", pattern = '^(nmap|httpx|dig|curl)\\b' },
+  { tool = "read" },
+  { tool = "grep" },
+  { tool = "glob" },
+  { tool = "webfetch" },
+  # optional — only if the agent should widen scope unattended:
+  # { tool = "add_scope" },
+]
+deny = [
+  { tool = "bash", pattern = 'rm\\s+-rf|mkfs|dd\\s+.*of=/dev/' },
+]
+```
+
+Then:
+
+```bash
+riftor --prompt "enumerate in-scope hosts with nmap" --workdir ./eng
+# or:  make demo-headless   # offline canned reply, no API key
+```
+
+Denial text in the tool result points at this file when an allow rule is missing.
+
 The agent can **request** adding in-scope targets itself via the `add_scope` tool
 (e.g. a subdomain it discovered on an in-scope host). Like other privileged tools
 it is **approval-gated**: you confirm it in the prompt, and in headless mode it is

--- a/riftor/agent/session.py
+++ b/riftor/agent/session.py
@@ -187,3 +187,82 @@ def truncate(
         branch_label=data.get("branch_label"),
     )
     return load(workdir, session_id)
+
+
+def resolve_id(workdir: Path, query: str) -> str:
+    """Resolve a session id by exact match, unique prefix, or unique suffix.
+
+    Raises ``ValueError`` when nothing matches or the query is ambiguous.
+    """
+    q = query.strip()
+    if not q:
+        raise ValueError("empty session id")
+    ids = [s["id"] for s in list_sessions(workdir)]
+    if q in ids:
+        return q
+    prefix_hits = [i for i in ids if i.startswith(q)]
+    if len(prefix_hits) == 1:
+        return prefix_hits[0]
+    if len(prefix_hits) > 1:
+        preview = ", ".join(f"`{i}`" for i in prefix_hits[:5])
+        more = f" (+{len(prefix_hits) - 5} more)" if len(prefix_hits) > 5 else ""
+        raise ValueError(f"ambiguous session id '{q}': {preview}{more}")
+    suffix_hits = [i for i in ids if i.endswith(q)]
+    if len(suffix_hits) == 1:
+        return suffix_hits[0]
+    if len(suffix_hits) > 1:
+        preview = ", ".join(f"`{i}`" for i in suffix_hits[:5])
+        more = f" (+{len(suffix_hits) - 5} more)" if len(suffix_hits) > 5 else ""
+        raise ValueError(f"ambiguous session id '{q}': {preview}{more}")
+    raise ValueError(f"no such session: {q}")
+
+
+def delete(workdir: Path, session_id: str) -> bool:
+    """Delete a session file. Returns True if a file was removed."""
+    path = sessions_dir(workdir) / f"{session_id}.json"
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def prune_old(
+    workdir: Path,
+    *,
+    max_age_days: float = 7.0,
+    keep_ids: set[str] | None = None,
+) -> list[str]:
+    """Delete sessions whose ``updated`` stamp is older than ``max_age_days``.
+
+    ``keep_ids`` are never deleted (e.g. the live session). Returns deleted ids
+    newest-first among those removed.
+    """
+    keep = keep_ids or set()
+    cutoff = time.time() - (max_age_days * 86400.0)
+    removed: list[str] = []
+    for row in list_sessions(workdir):
+        sid = row["id"]
+        if sid in keep:
+            continue
+        if float(row.get("updated") or 0) >= cutoff:
+            continue
+        if delete(workdir, sid):
+            removed.append(sid)
+    return removed
+
+
+def index_before_last_user_turns(messages: list[dict], k: int) -> int:
+    """Return the truncate index that drops the last ``k`` user turns.
+
+    A "user turn" is a message with ``role == "user"``. Truncating at the
+    returned index keeps everything before that turn (and drops the turn plus
+    any following assistant/tool messages). ``k <= 0`` keeps the full list.
+    """
+    if k <= 0:
+        return len(messages)
+    user_idxs = [i for i, m in enumerate(messages) if m.get("role") == "user"]
+    if not user_idxs:
+        return 0
+    if k >= len(user_idxs):
+        return 0
+    return user_idxs[-k]

--- a/riftor/headless.py
+++ b/riftor/headless.py
@@ -17,6 +17,7 @@ Exit codes:
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from pathlib import Path
 from typing import Callable
@@ -76,7 +77,7 @@ def run_headless(
         if not prompt:
             print("riftor --headless: no prompt (use --prompt or pipe stdin)", file=sys.stderr)
             return 2
-    if not cfg.has_credentials():
+    if not cfg.has_credentials() and not os.environ.get("RIFTOR_DEMO_RESPONSE"):
         env = cfg.provider_env() or "ANTHROPIC_API_KEY"
         print(f"riftor: no API key for {cfg.model}; set {env}", file=sys.stderr)
         return 3
@@ -220,7 +221,8 @@ async def _run_tool_headless(
         context.add_tool_result(
             call.id,
             "[denied: headless] This tool needs approval and no allow rule exists. "
-            "Add one to permissions.toml to enable it in headless mode.",
+            "Add one to ~/.config/riftor/permissions.toml "
+            "(see docs/configuration.md — Headless / CI allowlist).",
         )
         audit.record(tool.name, preview, allowed=False)
         return

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -203,9 +203,10 @@ _Settings & sessions_
 - `/doctor` — check which external recon tools (nmap/httpx/…) are installed
 - `/browser [headed|headless|close]` — browser mode / teardown · `/screenshots` — view captures
 - `/review` — self-critique findings for false positives before reporting
-- `/sessions` · `/resume <id>` · `/new` — manage saved sessions
+- `/sessions` · `/sessions rm <id|old [days]>` · `/resume <id>` · `/new` — manage saved sessions
+  (id may be a unique prefix/suffix of `YYYYMMDD-HHMMSS-xxxx`)
 - `/branch [label]` — fork the current session (message history only)
-- `/rollback <n>` — keep only the first *n* messages (truncate history)
+- `/rollback <n>` — keep only the first *n* messages · `/rollback last [k]` — drop the last *k* user turns (default 1)
 - `/tools` — list available agent tools · `/exit` · `/quit` — quit (`Ctrl+C`)
 
 Type anything else to task the agent. `↑/↓` recall input · `PgUp/PgDn` scroll ·
@@ -246,7 +247,7 @@ _PALETTE_COMMANDS = [
     ("/memory", "Memory", "Durable notes for this engagement"),
     ("/template", "Template", "Apply an engagement playbook"),
     ("/branch", "Branch session", "Fork the current session history"),
-    ("/rollback", "Rollback", "Truncate session to the first n messages"),
+    ("/rollback", "Rollback", "Truncate history (/rollback n | last [k])"),
 ]
 
 
@@ -269,6 +270,13 @@ class RiftorCommands(CommandProvider):
 
 class _RecoveryModal(ModalScreen[bool]):
     """Offered when an incomplete (crashed) session is found on startup."""
+
+    DEFAULT_CSS = """
+    _RecoveryModal {
+        align: center middle;
+        background: $background 75%;
+    }
+    """
 
     BINDINGS = [
         ("escape", "dismiss(False)", "Start fresh"),
@@ -302,6 +310,46 @@ class _RecoveryModal(ModalScreen[bool]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.dismiss(event.button.id == "resume")
+
+
+class _CompactOfferModal(ModalScreen[bool]):
+    """One-shot offer to /compact after a context-window ProviderError."""
+
+    DEFAULT_CSS = """
+    _CompactOfferModal {
+        align: center middle;
+        background: $background 75%;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "dismiss(False)", "Skip"),
+        ("c", "dismiss(True)", "Compact"),
+        ("y", "dismiss(True)", "Compact"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-box"):
+            yield Static(
+                Text("⚠  Context Window Exceeded", style="bold #fbbf24"),
+                id="confirm-title",
+            )
+            yield Static(
+                Text(
+                    "The model rejected the turn — conversation is too large.\n"
+                    "Run /compact now to shrink old tool output, then retry?"
+                ),
+                id="confirm-detail",
+            )
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Compact (c)", id="compact", variant="success")
+                yield Button("Skip (esc)", id="skip", variant="default")
+
+    def on_mount(self) -> None:
+        self.query_one("#compact", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "compact")
 
 
 class RiftorApp(App):
@@ -784,7 +832,7 @@ class RiftorApp(App):
             "/report": lambda: self._report_cmd(arg),
             "/graph": self._graph_cmd,
             "/merge": lambda: self._merge_cmd(arg),
-            "/sessions": self._sessions_cmd,
+            "/sessions": lambda: self._sessions_cmd(arg),
             "/resume": lambda: self._resume_cmd(arg),
             "/new": self._new_session,
             "/branch": lambda: self._branch_cmd(arg),
@@ -1731,7 +1779,11 @@ class RiftorApp(App):
         except Exception:  # noqa: BLE001 — persistence must never crash the app
             pass
 
-    def _sessions_cmd(self) -> None:
+    def _sessions_cmd(self, arg: str = "") -> None:
+        parts = arg.split(maxsplit=2)
+        if parts and parts[0].lower() in ("rm", "delete", "prune"):
+            self._sessions_rm_cmd(parts[1:])
+            return
         rows = sessions.list_sessions(self.workdir)
         if not rows:
             self._note("no saved sessions")
@@ -1745,12 +1797,58 @@ class RiftorApp(App):
             lines.append(
                 f"- {marker}`{s['id']}`{flag}{parent}{label} · {s['messages']} msgs · {s['title']}"
             )
-        self._markdown("**sessions**\n\n" + "\n".join(lines))
+        self._markdown(
+            "**sessions**\n\n"
+            + "\n".join(lines)
+            + "\n\n`/sessions rm <id|old [days]>` · `/resume <prefix>`"
+        )
+
+    def _sessions_rm_cmd(self, args: list[str]) -> None:
+        if not args:
+            self._note("usage: /sessions rm <id|old [days]> — see /sessions")
+            return
+        target = args[0].strip()
+        if target.lower() == "old":
+            days = 7.0
+            if len(args) > 1:
+                try:
+                    days = float(args[1])
+                except ValueError:
+                    self._note("usage: /sessions rm old [days] — days must be a number")
+                    return
+                if days <= 0:
+                    self._note("prune: days must be > 0")
+                    return
+            removed = sessions.prune_old(
+                self.workdir, max_age_days=days, keep_ids={self.session_id},
+            )
+            if not removed:
+                self._note(f"no sessions older than {days:g} day(s) to prune")
+                return
+            self._note(f"pruned {len(removed)} session(s) older than {days:g} day(s)")
+            return
+        try:
+            sid = sessions.resolve_id(self.workdir, target)
+        except ValueError as exc:
+            self._note(str(exc))
+            return
+        if sid == self.session_id:
+            self._note("cannot delete the active session — /new first, or pick another id")
+            return
+        if sessions.delete(self.workdir, sid):
+            self._note(f"deleted session {sid}")
+        else:
+            self._note(f"no such session: {sid}")
 
     def _resume_cmd(self, arg: str) -> None:
         sid = arg.strip()
         if not sid:
-            self._note("usage: /resume <id> — see /sessions")
+            self._note("usage: /resume <id> — unique prefix/suffix ok; see /sessions")
+            return
+        try:
+            sid = sessions.resolve_id(self.workdir, sid)
+        except ValueError as exc:
+            self._note(str(exc))
             return
         data = sessions.load(self.workdir, sid)
         if not data:
@@ -1785,18 +1883,43 @@ class RiftorApp(App):
         self._resume_cmd(new_id)
 
     def _rollback_cmd(self, arg: str) -> None:
-        if not arg.strip():
-            self._note("usage: /rollback <n> — keep first n messages")
+        raw = arg.strip()
+        if not raw:
+            self._note(
+                "usage: /rollback <n> — keep first n messages · "
+                "/rollback last [k] — drop last k user turns (default 1)"
+            )
             return
-        try:
-            n = int(arg.strip())
-        except ValueError:
-            self._note("usage: /rollback <n> — n must be a non-negative integer")
-            return
-        if n < 0:
-            self._note("rollback: n must be >= 0")
-            return
-        msg_count = len(self.context.messages)
+        persisted = self.context.dump()
+        parts = raw.split()
+        if parts[0].lower() == "last":
+            k = 1
+            if len(parts) > 1:
+                try:
+                    k = int(parts[1])
+                except ValueError:
+                    self._note("usage: /rollback last [k] — k must be a positive integer")
+                    return
+            if k < 1:
+                self._note("rollback last: k must be >= 1")
+                return
+            n = sessions.index_before_last_user_turns(persisted, k)
+            label = f"last {k} user turn(s)"
+        else:
+            try:
+                n = int(raw)
+            except ValueError:
+                self._note(
+                    "usage: /rollback <n> | /rollback last [k] — n/k must be integers"
+                )
+                return
+            if n < 0:
+                self._note("rollback: n must be >= 0")
+                return
+            label = f"{n} messages"
+        # Validate against persisted history (dump), not context.messages which
+        # prepends the synthetic system prompt.
+        msg_count = len(persisted)
         if n > msg_count:
             self._note(f"rollback: only {msg_count} messages in session (requested {n})")
             return
@@ -1811,7 +1934,8 @@ class RiftorApp(App):
         self._clear_flock()
         self.chat.remove_children()
         self._replay_transcript(self.context.messages)
-        self._note(f"rolled back to {n} messages")
+        kept = len(data.get("messages", []))
+        self._note(f"rolled back to {kept} messages ({label})")
 
     def _reset_browser_for_session(self) -> None:
         """Close and forget the session's browser on a session switch (/new, /resume)
@@ -1852,14 +1976,25 @@ class RiftorApp(App):
         self._note(f"new session {self.session_id}")
 
     def _replay_transcript(self, messages: list[dict]) -> None:
-        """Re-render a saved conversation (compact) so the screen reflects history."""
+        """Re-render a saved conversation (compact) so the screen reflects history.
+
+        User turns are numbered ``[1]``, ``[2]``, … so ``/rollback last`` is
+        easier to aim without counting raw message indices.
+        """
         p = self._pal()
+        user_turn = 0
         for msg in messages:
             role = msg.get("role")
+            if role == "system":
+                continue
             if role == "user":
                 content = msg.get("content")
                 if isinstance(content, str) and content.strip():
-                    self.chat.mount(Static(Text(content), classes="user"))
+                    user_turn += 1
+                    prefix = f"[{user_turn}] "
+                    self.chat.mount(
+                        Static(Text(prefix + content), classes="user")
+                    )
             elif role == "assistant":
                 content = msg.get("content")
                 if isinstance(content, str) and content.strip():
@@ -2008,6 +2143,8 @@ class RiftorApp(App):
                 )
         except ProviderError as exc:
             self._error(f"rift collapsed [{exc.kind}] — {exc}")
+            if exc.kind == "context":
+                await self._offer_compact_after_overflow()
         except Exception as exc:  # noqa: BLE001
             self._error(f"rift collapsed — {exc}")
         finally:
@@ -2016,6 +2153,18 @@ class RiftorApp(App):
             self.status.set_busy(False)
             self.chat.scroll_end(animate=False)
             self._save_session(complete=True)
+
+    async def _offer_compact_after_overflow(self) -> None:
+        """One-shot modal: compact old tool results after a context-window error."""
+        do_compact = await self.push_screen_wait(_CompactOfferModal())
+        if not do_compact:
+            self._note("skipped compact — /compact or /clear when ready, then /retry")
+            return
+        changed = self.context.compact()
+        self._refresh_usage()
+        self._note(
+            f"compacted {changed} old tool result(s) — /retry to continue"
+        )
 
     async def _assistant_turn(self) -> Turn:
         self.context.repair()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -24,6 +24,7 @@ def test_classify_server_retryable():
 def test_classify_context():
     err = classify_error(Exception("maximum context length is 200000 tokens"))
     assert err.kind == "context" and not err.retryable
+    assert "/compact" in str(err)
 
 
 def test_usage_add():

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -54,6 +54,7 @@ async def test_requires_permission_tool_auto_denied_without_allow_rule(gate):
     context = await _run(call, gate)
     msg = _last_tool_result(context)
     assert "denied: headless" in msg
+    assert "permissions.toml" in msg
     # and the file was NOT written
     assert not (toolctx.workdir / "x.txt").exists()
 
@@ -207,3 +208,20 @@ def test_headless_step_limit_returns_nonzero(monkeypatch, tmp_workdir, capsys):
     assert rc == 4
     err = capsys.readouterr().err
     assert "max_steps" in err.lower() or "step" in err.lower()
+
+
+def test_run_headless_demo_skips_api_key(monkeypatch, tmp_workdir, capsys):
+    """RIFTOR_DEMO_RESPONSE must allow --prompt without credentials (make demo-headless)."""
+    import os
+
+    from riftor.headless import run_headless
+
+    monkeypatch.setenv("RIFTOR_DEMO_RESPONSE", "hi from demo")
+    for key in list(os.environ):
+        if key.endswith("_API_KEY") or key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+    cfg = Config(model="anthropic/claude-sonnet-4-6")
+    assert not cfg.has_credentials()
+    rc = run_headless(cfg, tmp_workdir, prompt="say hi")
+    assert rc == 0
+    assert "hi from demo" in capsys.readouterr().out

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -89,3 +89,72 @@ def test_save_preserves_parent_id_across_updates(tmp_workdir):
     assert loaded is not None
     assert loaded["parent_id"] == "ancestor"
     assert len(loaded["messages"]) == 2
+
+
+def test_resolve_id_exact_and_unique_prefix(tmp_workdir):
+    session.save(tmp_workdir, "20260717-120000-abcd", [{"role": "user", "content": "a"}], "m")
+    session.save(tmp_workdir, "20260717-130000-ef01", [{"role": "user", "content": "b"}], "m")
+    assert session.resolve_id(tmp_workdir, "20260717-120000-abcd") == "20260717-120000-abcd"
+    assert session.resolve_id(tmp_workdir, "20260717-12") == "20260717-120000-abcd"
+    assert session.resolve_id(tmp_workdir, "ef01") == "20260717-130000-ef01"
+
+
+def test_resolve_id_ambiguous_prefix_raises(tmp_workdir):
+    session.save(tmp_workdir, "20260717-120000-aaaa", [{"role": "user", "content": "a"}], "m")
+    session.save(tmp_workdir, "20260717-120000-bbbb", [{"role": "user", "content": "b"}], "m")
+    try:
+        session.resolve_id(tmp_workdir, "20260717-12")
+        raise AssertionError("expected ValueError for ambiguous prefix")
+    except ValueError as exc:
+        assert "ambiguous" in str(exc).lower()
+
+
+def test_resolve_id_missing_raises(tmp_workdir):
+    try:
+        session.resolve_id(tmp_workdir, "nope")
+        raise AssertionError("expected ValueError for missing id")
+    except ValueError as exc:
+        assert "no such" in str(exc).lower() or "not found" in str(exc).lower()
+
+
+def test_delete_removes_session_file(tmp_workdir):
+    session.save(tmp_workdir, "20260717-120000-abcd", [{"role": "user", "content": "a"}], "m")
+    assert session.delete(tmp_workdir, "20260717-120000-abcd") is True
+    assert session.load(tmp_workdir, "20260717-120000-abcd") is None
+    assert session.delete(tmp_workdir, "20260717-120000-abcd") is False
+
+
+def test_prune_old_deletes_aged_sessions(tmp_workdir, monkeypatch):
+    import time
+
+    now = 1_700_000_000.0
+    monkeypatch.setattr(time, "time", lambda: now)
+    session.save(tmp_workdir, "fresh-aaaa", [{"role": "user", "content": "new"}], "m")
+    old_path = tmp_workdir / ".riftor" / "sessions" / "stale-bbbb.json"
+    session.save(tmp_workdir, "stale-bbbb", [{"role": "user", "content": "old"}], "m")
+    # Backdate the stale session's updated stamp
+    import json
+    data = json.loads(old_path.read_text(encoding="utf-8"))
+    data["updated"] = now - (10 * 86400)
+    old_path.write_text(json.dumps(data), encoding="utf-8")
+
+    removed = session.prune_old(tmp_workdir, max_age_days=7, keep_ids={"fresh-aaaa"})
+    assert removed == ["stale-bbbb"]
+    assert session.load(tmp_workdir, "stale-bbbb") is None
+    assert session.load(tmp_workdir, "fresh-aaaa") is not None
+
+
+def test_index_before_last_user_turns():
+    msgs = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "two"},
+        {"role": "assistant", "content": "a2"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "a3"},
+    ]
+    assert session.index_before_last_user_turns(msgs, 1) == 4
+    assert session.index_before_last_user_turns(msgs, 2) == 2
+    assert session.index_before_last_user_turns(msgs, 3) == 0
+    assert session.index_before_last_user_turns(msgs, 99) == 0
+    assert session.index_before_last_user_turns([], 1) == 0


### PR DESCRIPTION
## Summary
- **Sessions:** `/sessions rm <id|old [days]>` deletes by id or prunes aged sessions; `/resume` (and delete) accept unique id prefix/suffix.
- **Rollback:** numbered user turns on transcript replay; `/rollback last [k]` drops the last *k* user turns; `/rollback <n>` now validates against persisted `dump()` (fixes system-message off-by-one).
- **Context overflow:** context-window `ProviderError` offers a one-shot Compact modal, then prompts `/retry`.
- **Headless cookbook:** CI allowlist snippet in `docs/configuration.md`; denial text points at `permissions.toml`.
- **`make demo-headless`:** offline `--prompt` with `RIFTOR_DEMO_RESPONSE` (skips API-key gate when demo env is set). No version bump.

## Test plan
- [x] `uv run python -m pytest tests/test_session.py tests/test_headless.py tests/test_agent.py`
- [x] `uv run python -m pyright riftor/agent/session.py riftor/tui/app.py riftor/headless.py`
- [x] `uv run ruff check` on touched files
- [x] `uv run python dev/smoke.py` (includes `/rollback last`)
- [x] `make demo-headless` prints canned reply without API key
- [ ] Manual: `/sessions` → `/resume <suffix>` → `/sessions rm <prefix>`; trigger context error and confirm Compact modal


Made with [Cursor](https://cursor.com)