### PR TITLE
chore: release v3.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Product snapshot
 
-- **Version:** 3.5.0 (PyPI + GitHub Release)
+- **Version:** 3.6.0 (PyPI + GitHub Release)
 - **Website:** https://riftor.dev (source: https://github.com/Estudely/riftor-website — separate repo)
 - **Roadmap:** `todo.md` (Phase 8 launch done; housekeeping + post-launch feature MVPs shipped in v3.3.0)
 - **Config reference:** `docs/configuration.md` (canonical; site "Docs" links here)
@@ -100,5 +100,5 @@ Do **not** tag before the bump is on `main`.
 ### Ancillary
 
 - `completions/` ships bash (`riftor.bash`) and zsh (`_riftor`) completions — **update them when you add or rename a CLI flag.**
-- `docs/` holds `configuration.md`, the `riftor.1` man page, and release notes (e.g. `RELEASE_NOTES_v3.5.0.md`); `todo.md` is the roadmap.
+- `docs/` holds `configuration.md`, the `riftor.1` man page, and release notes (e.g. `RELEASE_NOTES_v3.6.0.md`); `todo.md` is the roadmap.
 - Website is **not** built from this repo — edit https://github.com/Estudely/riftor-website for https://riftor.dev.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![CI](https://github.com/Estudely/riftor/actions/workflows/ci.yml/badge.svg)](https://github.com/Estudely/riftor/actions/workflows/ci.yml)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue)](https://github.com/Estudely/riftor/blob/main/LICENSE)
 
-**🌐 Website:** https://riftor.dev · **Latest:** [v3.5.0](https://github.com/Estudely/riftor/releases/tag/v3.5.0)
+**🌐 Website:** https://riftor.dev · **Latest:** [v3.6.0](https://github.com/Estudely/riftor/releases/tag/v3.6.0)
 
 ![riftor demo](https://raw.githubusercontent.com/Estudely/riftor/main/demo.gif)
 
-### Featured — v3.5.0
+### Featured — v3.6.0
 An open-source offensive-security AI agent for your terminal. Set scope, task
 the agent, approve the dangerous bits, and walk out with CVSS-scored findings
 and md/html/json/SARIF reports. **350+** methodology skills, Baaj/Chakla

--- a/docs/RELEASE_NOTES_v3.6.0.md
+++ b/docs/RELEASE_NOTES_v3.6.0.md
@@ -1,0 +1,29 @@
+# riftor v3.6.0 — session & rollback QoL
+
+Find the rift. Open it. Cross through.
+
+## Highlights
+- **Session prune + prefix IDs** — `/sessions rm <id|old [days]>`; `/resume`
+  accepts a unique prefix or suffix
+- **`/rollback` UX** — numbered `[1]` user turns on replay; `/rollback last [k]`;
+  message-index off-by-one vs `dump()` fixed
+- **Context overflow → compact offer** — when the provider hits the window limit,
+  a modal offers `/compact` then nudges `/retry`
+- **`make demo-headless`** — offline one-liner via `RIFTOR_DEMO_RESPONSE` (skips
+  the API-key gate when demo env is set)
+- **Headless permissions cookbook** — minimal CI allowlist snippet in
+  `docs/configuration.md`
+
+## Install
+```bash
+pip install -U riftor
+# optional extras:
+pip install -U 'riftor[browser]'
+pip install -U 'riftor[mcp]'
+```
+
+## Links
+- Site: https://riftor.dev
+- Docs: https://github.com/Estudely/riftor/blob/main/docs/configuration.md
+- Repo: https://github.com/Estudely/riftor
+- Prior: [v3.5.0](https://github.com/Estudely/riftor/releases/tag/v3.5.0) (slash registries, headless exit 4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "3.5.0"
+version = "3.6.0"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/todo.md
+++ b/todo.md
@@ -260,7 +260,7 @@ custom provider using `custom_route`.
 - uv 0.11.14, Python 3.12.3 at /usr/bin/python3
 - **Cloud-first**: default model `anthropic/claude-sonnet-4-6`; key in local
   config (`~/.config/riftor/config.toml`, perms 600, outside the repo)
-- Latest release: **v3.5.0** (PyPI + GitHub Release; 350+ bundled skills).
+- Latest release: **v3.6.0** (PyPI + GitHub Release; 350+ bundled skills).
   Website: https://riftor.dev (source: Estudely/riftor-website).
 - Local Ollama is a supported fallback, not the identity
 - Reference reads: NousResearch/hermes-agent (Python analog), earendil-works/pi (minimal core)

--- a/uv.lock
+++ b/uv.lock
@@ -2083,7 +2083,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary
- Bump version to **3.6.0**
- Curated notes in `docs/RELEASE_NOTES_v3.6.0.md`
- README Featured + CLAUDE/todo version pointers

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v3.6.0` and push tag → release workflow publishes
- [ ] Verify PyPI 3.6.0


Made with [Cursor](https://cursor.com)