### PR TITLE
Fix first-run onboarding wizard

### DIFF
--- a/riftor/tui/onboarding.py
+++ b/riftor/tui/onboarding.py
@@ -2,17 +2,30 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
+from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static
 
-from riftor.providers import PROVIDERS, PROVIDER_DEFAULTS, apply_prefix, provider_key_for_model
+from riftor.providers import (
+    PROVIDERS,
+    PROVIDER_DEFAULTS,
+    FetchResult,
+    apply_prefix,
+    fetch_models,
+    provider_key_for_model,
+)
 
 if TYPE_CHECKING:
     from riftor.config import Config
+
+
+def _model_options(provider_key: str) -> list[tuple[str, str]]:
+    return [(m, m) for m in PROVIDER_DEFAULTS.get(provider_key, [])]
 
 
 class OnboardingScreen(ModalScreen[dict | None]):
@@ -25,35 +38,76 @@ class OnboardingScreen(ModalScreen[dict | None]):
         self.config = config
         self._step = 0
         self._provider = provider_key_for_model(config.model)
+        self._full_models: list[tuple[str, str]] = _model_options(self._provider)
 
     def compose(self) -> ComposeResult:
+        meta = PROVIDERS[self._provider]
+        env_key = meta.env
+        prefilled = ""
+        if env_key and os.environ.get(env_key):
+            prefilled = os.environ[env_key]
+        elif self.config.api_key:
+            prefilled = self.config.api_key
+
+        model_opts = self._full_models
+        model_val = model_opts[0][1] if model_opts else Select.NULL
+
         with Vertical(id="onboard-box"):
             yield Static("Welcome to riftor", id="onboard-title")
             yield Static("", id="onboard-subtitle")
-            with Vertical(id="onboard-step-0"):
-                yield Label("Choose your LLM provider")
-                yield Select(
-                    [(m.label, k) for k, m in PROVIDERS.items()],
-                    value=self._provider,
-                    allow_blank=False,
-                    id="ob-provider",
-                )
-                yield Label("API key (or set env var)")
-                yield Input(password=True, placeholder="sk-…", id="ob-key")
-            with Vertical(id="onboard-step-1", classes="hidden"):
-                yield Label("Model")
-                opts = [(m, m) for m in PROVIDER_DEFAULTS.get(self._provider, [])]
-                yield Select(opts, value=opts[0][1] if opts else Select.NULL, id="ob-model")
-            with Vertical(id="onboard-step-2", classes="hidden"):
-                yield Label("Scope targets (one per line, optional)")
-                yield Input(placeholder="example.com  10.0.0.0/24", id="ob-scope")
+            with Vertical(id="onboard-body"):
+                with Vertical(id="onboard-step-0", classes="onboard-step"):
+                    yield Label("Choose your LLM provider")
+                    yield Select(
+                        [(m.label, k) for k, m in PROVIDERS.items()],
+                        value=self._provider,
+                        allow_blank=False,
+                        id="ob-provider",
+                    )
+                    yield Label("API key (or set env var)")
+                    yield Input(
+                        password=True,
+                        placeholder=f"or export {env_key or 'PROVIDER_API_KEY'}",
+                        value=prefilled,
+                        id="ob-key",
+                    )
+                with Vertical(id="onboard-step-1", classes="onboard-step hidden"):
+                    yield Label("Model")
+                    yield Select(
+                        model_opts,
+                        value=model_val,
+                        allow_blank=True,
+                        id="ob-model",
+                    )
+                    yield Label("Custom model id (optional override)")
+                    yield Input(placeholder="e.g. deepseek-chat", id="ob-model-custom")
+                    with Horizontal(classes="onboard-fetch-row"):
+                        yield Button("Fetch live models", id="ob-fetch", variant="default")
+                        yield Static("", id="ob-fetch-status")
+                with Vertical(id="onboard-step-2", classes="onboard-step hidden"):
+                    yield Label("Scope targets (comma or newline separated, optional)")
+                    yield Input(placeholder="example.com  10.0.0.0/24", id="ob-scope")
             with Horizontal(id="onboard-buttons"):
                 yield Button("Back", id="ob-back", variant="default")
-                yield Button("Next", id="ob-next", variant="primary")
-                yield Button("Skip", id="ob-skip", variant="default")
+                yield Button("Next", id="ob-next", variant="default")
+                yield Button("Skip setup", id="ob-skip", variant="default")
 
     def on_mount(self) -> None:
         self._show_step(0)
+        self._refresh_model_options(self._provider)
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "ob-provider" and isinstance(event.value, str):
+            self._provider = event.value
+            self._refresh_model_options(event.value)
+
+    def _refresh_model_options(self, provider_key: str) -> None:
+        self._full_models = _model_options(provider_key) or [("(type below)", "")]
+        sel = self.query_one("#ob-model", Select)
+        sel.set_options(self._full_models)
+        if self._full_models:
+            sel.value = self._full_models[0][1]
+        self.query_one("#ob-fetch-status", Static).update("")
 
     def _show_step(self, step: int) -> None:
         self._step = step
@@ -62,7 +116,6 @@ class OnboardingScreen(ModalScreen[dict | None]):
             "Step 2 of 3 — Model",
             "Step 3 of 3 — Scope (optional)",
         ]
-        self.query_one("#onboard-title", Static).update("Welcome to riftor")
         self.query_one("#onboard-subtitle", Static).update(titles[step])
         for i in range(3):
             panel = self.query_one(f"#onboard-step-{i}", Vertical)
@@ -70,10 +123,38 @@ class OnboardingScreen(ModalScreen[dict | None]):
                 panel.remove_class("hidden")
             else:
                 panel.add_class("hidden")
-        back = self.query_one("#ob-back", Button)
-        back.disabled = step == 0
-        nxt = self.query_one("#ob-next", Button)
-        nxt.label = "Finish" if step == 2 else "Next"
+        self.query_one("#ob-back", Button).disabled = step == 0
+        self.query_one("#ob-next", Button).label = "Finish" if step == 2 else "Next"
+
+    def _resolved_key(self) -> str | None:
+        typed = self.query_one("#ob-key", Input).value.strip()
+        if typed:
+            return typed
+        meta = PROVIDERS.get(self._provider)
+        if meta and meta.env:
+            return os.environ.get(meta.env)
+        return None
+
+    @work(thread=True, exclusive=True, group="onboard-fetch")
+    def _fetch_models_worker(self, provider: str, key: str | None) -> None:
+        meta = PROVIDERS.get(provider)
+        base = meta.default_base if meta else None
+        result = fetch_models(provider, base, key)
+        self.app.call_from_thread(self._apply_fetch_result, result)
+
+    def _apply_fetch_result(self, result: FetchResult) -> None:
+        if not self.is_running:
+            return
+        status = self.query_one("#ob-fetch-status", Static)
+        if result.models:
+            self._full_models = [(m, m) for m in result.models]
+            sel = self.query_one("#ob-model", Select)
+            sel.set_options(self._full_models)
+            sel.value = self._full_models[0][1]
+        if result.error:
+            status.update(f"fetch failed — using defaults ({result.error[:40]})")
+        else:
+            status.update(f"{result.source}: {len(result.models)} models")
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -87,25 +168,29 @@ class OnboardingScreen(ModalScreen[dict | None]):
         if bid == "ob-skip":
             self.dismiss({"onboarded": True})
             return
+        if bid == "ob-fetch":
+            prov_sel = self.query_one("#ob-provider", Select).value
+            provider = prov_sel if isinstance(prov_sel, str) else self._provider
+            self.query_one("#ob-fetch-status", Static).update("fetching…")
+            self._fetch_models_worker(provider, self._resolved_key())
+            return
         if bid == "ob-next":
             if self._step < 2:
                 if self._step == 0:
                     prov = self.query_one("#ob-provider", Select).value
                     if isinstance(prov, str):
                         self._provider = prov
-                    # Rebuild model options for step 1
-                    opts = [(m, m) for m in PROVIDER_DEFAULTS.get(self._provider, [])]
-                    sel = self.query_one("#ob-model", Select)
-                    sel.set_options(opts or [("(custom)", "")])
+                        self._refresh_model_options(prov)
                 self._show_step(self._step + 1)
                 return
-            # Finish
             prov = self.query_one("#ob-provider", Select).value
             if not isinstance(prov, str):
                 prov = self._provider
+            custom = self.query_one("#ob-model-custom", Input).value.strip()
             model_sel = self.query_one("#ob-model", Select).value
-            model = apply_prefix(prov, str(model_sel)) if model_sel else self.config.model
-            key = self.query_one("#ob-key", Input).value.strip() or None
+            chosen = custom or (str(model_sel) if model_sel else "")
+            model = apply_prefix(prov, chosen) if chosen else self.config.model
+            key = self._resolved_key()
             scope = self.query_one("#ob-scope", Input).value.strip()
             self.dismiss({
                 "onboarded": True,

--- a/riftor/tui/themes/rift.tcss
+++ b/riftor/tui/themes/rift.tcss
@@ -488,3 +488,97 @@ ScreenshotGalleryScreen {
     border: none;
     margin: 0 0 0 2;
 }
+
+/* — onboarding modal — */
+#onboard-box {
+    layout: vertical;
+    width: 72;
+    max-width: 92%;
+    height: auto;
+    max-height: 100%;
+    padding: 0;
+    background: $panel;
+    border: round $violet;
+}
+#onboard-title {
+    width: 1fr;
+    height: 3;
+    padding: 1 2 0 2;
+    background: $surface;
+    border-bottom: solid $border;
+    color: $foreground;
+    text-style: bold;
+}
+#onboard-subtitle {
+    width: 1fr;
+    height: 1;
+    padding: 0 2;
+    color: $muted;
+    background: $surface;
+    border-bottom: solid $border;
+}
+#onboard-body {
+    height: auto;
+    padding: 1 2;
+    overflow-y: auto;
+}
+.onboard-step {
+    height: auto;
+}
+.onboard-step.hidden {
+    display: none;
+}
+.onboard-step > Label {
+    width: 1fr;
+    color: $muted;
+    margin: 0 0 0 0;
+}
+.onboard-step > Select,
+.onboard-step > Input {
+    width: 1fr;
+    height: 3;
+    margin-bottom: 1;
+}
+.onboard-fetch-row {
+    height: 3;
+    align: left middle;
+    margin-bottom: 1;
+}
+.onboard-fetch-row Button {
+    height: 1;
+    min-height: 1;
+    min-width: 16;
+    border: none;
+    background: $surface;
+    color: $cyan;
+    margin-right: 2;
+}
+#ob-fetch-status {
+    width: 1fr;
+    color: $muted;
+    height: 1;
+}
+#onboard-buttons {
+    height: 3;
+    align: right middle;
+    background: $surface;
+    border-top: solid $border;
+    padding: 0 2;
+}
+#onboard-buttons Button {
+    height: 1;
+    min-height: 1;
+    min-width: 10;
+    border: none;
+    margin: 0 0 0 2;
+}
+#onboard-buttons #ob-next {
+    background: $violet;
+    color: $background;
+    text-style: bold;
+}
+#onboard-buttons #ob-back,
+#onboard-buttons #ob-skip {
+    background: $surface;
+    color: $muted;
+}

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -16,6 +16,11 @@ from riftor.tui.app import RiftorApp
 from riftor.tui.onboarding import OnboardingScreen, _model_options
 
 
+def _press(screen: OnboardingScreen, button_id: str) -> None:
+    btn = screen.query_one(button_id, Button)
+    screen.on_button_pressed(Button.Pressed(btn))
+
+
 def _patch_paths(tmp: Path) -> None:
     cfgmod.CONFIG_DIR = tmp
     cfgmod.CONFIG_PATH = tmp / "config.toml"
@@ -89,7 +94,7 @@ async def test_app_launches_onboarding_and_completes_deepseek_flow():
         cfg = Config(onboarded=False)
         app = RiftorApp(cfg, workdir=workdir)
         async with app.run_test(size=(100, 30)) as pilot:
-            await pilot.pause(0.35)  # on_mount timer → OnboardingScreen
+            await pilot.pause(0.5)  # on_mount timer → OnboardingScreen
             assert isinstance(app.screen, OnboardingScreen)
             screen = app.screen
 
@@ -97,8 +102,8 @@ async def test_app_launches_onboarding_and_completes_deepseek_flow():
             prov.value = "deepseek"
             screen.on_select_changed(Mock(select=prov, value="deepseek"))
             screen.query_one("#ob-key", Input).value = "sk-test"
-            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
-            await pilot.pause()
+            _press(screen, "#ob-next")
+            await pilot.pause(0.1)
 
             assert screen.query_one("#onboard-step-0").has_class("hidden")
             assert not screen.query_one("#onboard-step-1").has_class("hidden")
@@ -106,12 +111,12 @@ async def test_app_launches_onboarding_and_completes_deepseek_flow():
             values = [v for _, v in model_sel._options if v != Select.NULL]  # noqa: SLF001
             assert values == PROVIDER_DEFAULTS["deepseek"]
             model_sel.value = "deepseek-v4-pro"
-            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
-            await pilot.pause()
+            _press(screen, "#ob-next")
+            await pilot.pause(0.1)
 
             screen.query_one("#ob-scope", Input).value = "example.com"
-            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
-            await pilot.pause(0.2)
+            _press(screen, "#ob-next")
+            await pilot.pause(0.5)  # async worker applies dismiss result
 
             assert cfg.onboarded is True
             assert cfg.model == "deepseek/deepseek-v4-pro"

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,120 @@
+"""Onboarding wizard: step visibility, provider→model refresh, finish payload."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Button, Input, Select
+
+import riftor.config as cfgmod
+from riftor.config import Config
+from riftor.providers import PROVIDER_DEFAULTS, apply_prefix
+from riftor.tui.app import RiftorApp
+from riftor.tui.onboarding import OnboardingScreen, _model_options
+
+
+def _patch_paths(tmp: Path) -> None:
+    cfgmod.CONFIG_DIR = tmp
+    cfgmod.CONFIG_PATH = tmp / "config.toml"
+    cfgmod.PERMISSIONS_PATH = tmp / "permissions.toml"
+    cfgmod.KEYBINDINGS_PATH = tmp / "kb.toml"
+
+
+@pytest.mark.asyncio
+async def test_onboarding_shows_one_step_at_a_time():
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        screen = OnboardingScreen(Config())
+        from textual.app import App
+
+        class _Host(App):
+            pass
+
+        app = _Host()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await app.push_screen(screen)
+            await pilot.pause()
+            assert not screen.query_one("#onboard-step-0").has_class("hidden")
+            assert screen.query_one("#onboard-step-1").has_class("hidden")
+            assert screen.query_one("#onboard-step-2").has_class("hidden")
+            screen._show_step(1)
+            assert screen.query_one("#onboard-step-0").has_class("hidden")
+            assert not screen.query_one("#onboard-step-1").has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_provider_change_refreshes_model_list():
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        screen = OnboardingScreen(Config(model="openrouter/auto"))
+        from textual.app import App
+
+        class _Host(App):
+            pass
+
+        app = _Host()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await app.push_screen(screen)
+            await pilot.pause()
+            event = Mock()
+            event.select = screen.query_one("#ob-provider", Select)
+            event.value = "deepseek"
+            screen.on_select_changed(event)
+            model_sel = screen.query_one("#ob-model", Select)
+            values = [v for _, v in model_sel._options if v != Select.NULL]  # noqa: SLF001
+            assert values == PROVIDER_DEFAULTS["deepseek"]
+
+
+def test_model_options_for_deepseek():
+    assert _model_options("deepseek") == [
+        ("deepseek-v4-pro", "deepseek-v4-pro"),
+        ("deepseek-v4-flash", "deepseek-v4-flash"),
+    ]
+
+
+def test_apply_prefix_deepseek():
+    assert apply_prefix("deepseek", "deepseek-v4-pro") == "deepseek/deepseek-v4-pro"
+
+
+@pytest.mark.asyncio
+async def test_app_launches_onboarding_and_completes_deepseek_flow():
+    """End-to-end: fresh app → onboarding modal → provider/model/scope → saved config."""
+    with tempfile.TemporaryDirectory() as d:
+        _patch_paths(Path(d))
+        workdir = Path(d) / "proj"
+        workdir.mkdir()
+        cfg = Config(onboarded=False)
+        app = RiftorApp(cfg, workdir=workdir)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause(0.35)  # on_mount timer → OnboardingScreen
+            assert isinstance(app.screen, OnboardingScreen)
+            screen = app.screen
+
+            prov = screen.query_one("#ob-provider", Select)
+            prov.value = "deepseek"
+            screen.on_select_changed(Mock(select=prov, value="deepseek"))
+            screen.query_one("#ob-key", Input).value = "sk-test"
+            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
+            await pilot.pause()
+
+            assert screen.query_one("#onboard-step-0").has_class("hidden")
+            assert not screen.query_one("#onboard-step-1").has_class("hidden")
+            model_sel = screen.query_one("#ob-model", Select)
+            values = [v for _, v in model_sel._options if v != Select.NULL]  # noqa: SLF001
+            assert values == PROVIDER_DEFAULTS["deepseek"]
+            model_sel.value = "deepseek-v4-pro"
+            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
+            await pilot.pause()
+
+            screen.query_one("#ob-scope", Input).value = "example.com"
+            screen.on_button_pressed(Mock(button=screen.query_one("#ob-next", Button)))
+            await pilot.pause(0.2)
+
+            assert cfg.onboarded is True
+            assert cfg.model == "deepseek/deepseek-v4-pro"
+            assert cfg.providers["deepseek"].api_key == "sk-test"
+            assert "example.com" in [t for t, _ in app.engagement.store.list_scope()]
+


### PR DESCRIPTION
## Summary
- Fix onboarding steps all rendering at once by adding `.onboard-step.hidden` CSS (was missing; only config modal had hide rules).
- Refresh model dropdown immediately when provider changes; add **Fetch live models** and custom model id field (parity with `/config`).
- Style onboarding footer buttons to match the config modal (flat height-1, not default chunky blocks).
- Add unit + app-level e2e test: fresh `RiftorApp` → DeepSeek provider → model → scope → saved config.

## Test plan
- [x] `uv run python -m pytest tests/test_onboarding.py -v` (5 tests, incl. e2e through `RiftorApp`)
- [x] `uv run ruff check riftor/tui/onboarding.py tests/test_onboarding.py`
- [ ] Manual: delete `onboarded` from config, launch TUI, pick DeepSeek, confirm only step 1 visible, Next → DeepSeek models, Fetch works with key


Made with [Cursor](https://cursor.com)