### PR TITLE
Bump version to 4.0.2 and alphabetize slash commands.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "4.0.1"
+version = "4.0.2"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/tui/app.py
+++ b/riftor/tui/app.py
@@ -153,14 +153,14 @@ class PromptInput(Input):
 
 # Commands offered for fuzzy "did you mean" suggestions.
 _COMMANDS = [
-    "/help", "/clear", "/model", "/scope", "/findings", "/finding",
-    "/edit-finding", "/delete-finding", "/hosts", "/services", "/report",
-    "/sessions", "/resume", "/new", "/branch", "/rollback", "/theme", "/config", "/tools", "/skills",
-    "/permissions", "/cost", "/retry", "/continue",
-    "/compact", "/copy", "/show", "/timeline", "/audit", "/export", "/conversation",
-    "/doctor", "/review", "/hypotheses", "/lesson", "/lessons", "/memory", "/template",
-    "/methodology", "/workers",
-    "/browser", "/screenshots", "/graph", "/merge", "/clearlog", "/exit", "/quit",
+    "/audit", "/branch", "/browser", "/clear", "/clearlog", "/compact",
+    "/config", "/continue", "/conversation", "/copy", "/cost", "/delete-finding",
+    "/doctor", "/edit-finding", "/exit", "/export", "/finding", "/findings",
+    "/graph", "/help", "/hosts", "/hypotheses", "/lesson", "/lessons",
+    "/memory", "/merge", "/methodology", "/model", "/new", "/permissions",
+    "/quit", "/report", "/resume", "/retry", "/review", "/rollback",
+    "/scope", "/screenshots", "/services", "/sessions", "/show", "/skills",
+    "/template", "/theme", "/timeline", "/tools", "/workers",
 ]
 
 HELP = """\

--- a/tests/test_commands_registry.py
+++ b/tests/test_commands_registry.py
@@ -27,7 +27,7 @@ def test_handler_keys_subset_of_commands():
         workdir = Path(d)
         _patch_paths(workdir)
         app = RiftorApp(Config(onboarded=True), workdir=workdir)
-        handler_keys = set(app._command_handlers("").keys()) | {"/exit", "/quit"}
+        handler_keys = set(RiftorApp._command_handlers(app, "").keys()) | {"/exit", "/quit"}
         missing = handler_keys - set(_COMMANDS)
         assert not missing, f"handlers missing from _COMMANDS: {sorted(missing)}"
 
@@ -41,3 +41,8 @@ def test_help_lists_hypotheses_and_lessons_separately_from_memory():
     memory_line = next(line for line in HELP.splitlines() if "`/memory" in line)
     assert "hypothes" not in memory_line.lower()
     assert "lesson" not in memory_line.lower()
+
+
+def test_commands_are_alphabetized():
+    """Slash-command suggestions should stay alphabetized for operators."""
+    assert _COMMANDS == sorted(_COMMANDS)

--- a/uv.lock
+++ b/uv.lock
@@ -2085,7 +2085,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "4.0.1"
+version = "4.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
## Summary
- bump the package version from `4.0.1` to `4.0.2`
- alphabetize slash-command suggestions and add a regression test for ordering
- refresh the local virtualenv so `uv run pytest` uses a valid `pytest` entrypoint in this checkout

## Test plan
- [x] `uv run pytest tests/test_commands_registry.py -q`
- [x] `uv run riftor --version`

Made with [Cursor](https://cursor.com)