### PR TITLE
Fix provider error classification for missing dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ reports/
 # internal AI planning/spec docs — kept locally, not shipped or tracked
 docs/superpowers/
 .env
+
+# local UI-capture scratch outputs
+dev/ui_capture.py
+dev/ui-captures/

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -164,6 +164,14 @@ def classify_error(exc: Exception) -> ProviderError:
     def _msg_has_status(*codes: str) -> bool:
         return any(re.search(rf"\b{c}\b", text) for c in codes)
 
+    # litellm 1.92+ surfaces missing proxy deps as APIConnectionError whose message
+    # contains "connection" — check import failures before the network heuristics.
+    if isinstance(exc, (ImportError, ModuleNotFoundError)) or "no module named" in low:
+        return ProviderError(
+            "config",
+            "missing Python dependency for the LLM layer — reinstall/upgrade riftor. " + text[:160],
+            retryable=False,
+        )
     if status == 401 or status == 403 or "authentication" in name or "auth" in low \
             or "api key" in low or (status is None and _msg_has_status("401", "403")):
         return ProviderError(

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -399,6 +399,13 @@ def test_classify_message_fallback_when_no_status():
     assert err.kind == "server"
 
 
+def test_classify_missing_module_not_retryable_network():
+    """litellm 1.92 APIConnectionError embeds 'connection' but means missing deps."""
+    err = prov.classify_error(Exception("APIConnectionError: No module named 'fastapi'"))
+    assert err.kind == "config"
+    assert err.retryable is False
+
+
 # --- cost estimation (#114) ---------------------------------------------------
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- classify `No module named ...` provider failures as `config` errors before network heuristics
- add regression coverage for `APIConnectionError: No module named 'fastapi'`
- ignore local `dev/ui_capture.py` and `dev/ui-captures/` scratch artifacts so workspace status stays clean

## Test plan
- [x] `uv run pytest tests/test_provider.py -q`

Made with [Cursor](https://cursor.com)