### PR TITLE
Release v4.1.1: Codex HTTP 400 diagnostics

### DIFF
--- a/docs/RELEASE_NOTES_v4.1.1.md
+++ b/docs/RELEASE_NOTES_v4.1.1.md
@@ -1,0 +1,10 @@
+# riftor v4.1.1 — Codex HTTP 400 diagnostics
+
+## Fixes
+- **Codex / ChatGPT subscription errors** — HTTP 400 responses from
+  `chatgpt.com/backend-api/codex/responses` now surface the backend `detail`
+  (instead of a bare `HTTP Error 400: Bad Request`).
+- **Mid-stream failure classification** — litellm `MidStreamFallbackError` /
+  `APIConnectionError` wrappers that carry an HTTP 400 classify as
+  `validation` (not retryable `network`), so the TUI shows
+  `rift collapsed [validation] — …` rather than a raw traceback dump.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riftor"
-version = "4.1.0"
+version = "4.1.1"
 description = "An open-source offensive-security AI agent that lives in your terminal."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/riftor/agent/codex_provider.py
+++ b/riftor/agent/codex_provider.py
@@ -715,14 +715,52 @@ def _stream_responses(
     The SINGLE inference network seam — tests monkeypatch *this* to feed canned
     SSE lines. Uses stdlib ``urllib`` and streams the response line-by-line so
     the SSE parser sees frames as they arrive.
+
+    HTTP errors are re-raised as ``RuntimeError`` carrying the Codex JSON
+    ``detail`` (or truncated body) so operators see *why* the backend rejected
+    the request instead of a bare ``HTTP Error 400: Bad Request``.
     """
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         RESPONSES_URL, data=data, headers=headers, method="POST"
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed https endpoint
-        for raw in resp:
-            yield raw.decode("utf-8", errors="replace")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed https endpoint
+            for raw in resp:
+                yield raw.decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(_format_http_error(exc)) from exc
+
+
+def _format_http_error(exc: urllib.error.HTTPError) -> str:
+    """Build an operator-facing message from a Codex/urllib HTTPError."""
+    body = ""
+    try:
+        raw = exc.read()
+        if isinstance(raw, bytes):
+            body = raw.decode("utf-8", errors="replace")
+        elif raw is not None:
+            body = str(raw)
+    except Exception:  # noqa: BLE001 — body is best-effort
+        body = ""
+    body = body.strip()
+    detail = body
+    if body:
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            if isinstance(parsed.get("detail"), str):
+                detail = parsed["detail"]
+            else:
+                err = parsed.get("error")
+                if isinstance(err, dict) and isinstance(err.get("message"), str):
+                    detail = err["message"]
+                elif isinstance(err, str):
+                    detail = err
+    detail = (detail or exc.reason or "Bad Request")[:400]
+    return f"HTTP {exc.code}: {detail}"
 
 
 # litellm registry-matches the bare model name and will hijack any id it knows

--- a/riftor/agent/provider.py
+++ b/riftor/agent/provider.py
@@ -131,20 +131,45 @@ class ProviderError(Exception):
 
 
 def _status_code(exc: Exception) -> int | None:
-    """Best-effort HTTP status from a litellm/httpx exception.
+    """Best-effort HTTP status from a litellm/httpx/urllib exception.
 
     litellm's typed exceptions carry ``status_code``; httpx nests it under
-    ``.response.status_code``. Using the real code avoids the substring-matching
-    false positives (issue #117) where a message mentioning a port or byte count
-    like "5000" was misread as a 500 server error.
+    ``.response.status_code``; ``urllib.error.HTTPError`` uses ``.code``.
+    Using the real code avoids the substring-matching false positives
+    (issue #117) where a message mentioning a port or byte count like "5000"
+    was misread as a 500 server error.
+
+    Also walks ``__cause__`` / ``__context__`` one level so a litellm wrapper
+    (e.g. MidStreamFallbackError) that preserves the urllib HTTPError still
+    yields its status.
     """
-    for attr in ("status_code", "code"):
-        val = getattr(exc, attr, None)
-        if isinstance(val, int):
-            return val
-    resp = getattr(exc, "response", None)
-    code = getattr(resp, "status_code", None)
-    return code if isinstance(code, int) else None
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        for attr in ("status_code", "code"):
+            val = getattr(cur, attr, None)
+            if isinstance(val, int):
+                return val
+        resp = getattr(cur, "response", None)
+        code = getattr(resp, "status_code", None)
+        if isinstance(code, int):
+            return code
+        nxt = cur.__cause__ or cur.__context__
+        cur = nxt if isinstance(nxt, BaseException) else None
+    return None
+
+
+def _http_status_in_message(text: str) -> int | None:
+    """Parse an explicit ``HTTP Error NNN`` / ``HTTP NNN`` token from ``text``.
+
+    Used when litellm stringifies an urllib HTTPError into an APIConnectionError
+    message and drops the typed status attribute.
+    """
+    match = re.search(r"\bHTTP(?:\s+Error)?\s+(\d{3})\b", text, flags=re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return None
 
 
 def classify_error(exc: Exception) -> ProviderError:
@@ -158,6 +183,8 @@ def classify_error(exc: Exception) -> ProviderError:
     text = str(exc)
     low = text.lower()
     status = _status_code(exc)
+    if status is None:
+        status = _http_status_in_message(text)
 
     # A standalone HTTP status token in the message, only as a fallback when the
     # exception carries no real status_code attribute.
@@ -185,6 +212,12 @@ def classify_error(exc: Exception) -> ProviderError:
                              retryable=True)
     if "timeout" in name or "timed out" in low:
         return ProviderError("timeout", "request timed out. " + text[:160], retryable=True)
+    # Prefer an explicit HTTP status (incl. from "HTTP Error 400: …" messages)
+    # over the "connection" substring in litellm's APIConnectionError type name.
+    if status == 400 or "badrequest" in name or "invalid" in low \
+            or (status is None and _msg_has_status("400")):
+        return ProviderError("validation", "request rejected by the provider. " + text[:200],
+                             retryable=False)
     if (status is not None and 500 <= status <= 599) or "overloaded" in low \
             or (status is None and _msg_has_status("500", "502", "503", "504", "529")):
         return ProviderError("server", "provider server error — retrying. " + text[:160], retryable=True)
@@ -197,10 +230,6 @@ def classify_error(exc: Exception) -> ProviderError:
             "context window exceeded — clear/compact the conversation (/clear or /compact). " + text[:160],
             retryable=False,
         )
-    if status == 400 or "badrequest" in name or "invalid" in low \
-            or (status is None and _msg_has_status("400")):
-        return ProviderError("validation", "request rejected by the provider. " + text[:200],
-                             retryable=False)
     return ProviderError("unknown", text[:240] or name, retryable=False)
 
 
@@ -293,13 +322,18 @@ class Provider:
             yield demo
             return
         response = await self._acompletion(**self._kwargs(messages))
-        async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
-            try:
-                content = chunk.choices[0].delta.content
-            except (IndexError, AttributeError):
-                content = None
-            if content:
-                yield content
+        try:
+            async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
+                try:
+                    content = chunk.choices[0].delta.content
+                except (IndexError, AttributeError):
+                    content = None
+                if content:
+                    yield content
+        except ProviderError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — classify mid-stream provider failures
+            raise classify_error(exc) from exc
 
     async def stream_turn(
         self, messages: list[dict], tools: list[dict] | None = None
@@ -330,78 +364,83 @@ class Provider:
         _seq = 0
         usage = Usage()
 
-        async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
-            seen = _extract_usage(chunk)
-            if seen is not None:
-                usage = seen
-            try:
-                delta = chunk.choices[0].delta
-            except (IndexError, AttributeError):
-                continue
+        try:
+            async for chunk in response:  # type: ignore[union-attr]  # litellm stream is async-iterable
+                seen = _extract_usage(chunk)
+                if seen is not None:
+                    usage = seen
+                try:
+                    delta = chunk.choices[0].delta
+                except (IndexError, AttributeError):
+                    continue
 
-            content = getattr(delta, "content", None)
-            if content:
-                text_parts.append(content)
-                yield ("text", content)
+                content = getattr(delta, "content", None)
+                if content:
+                    text_parts.append(content)
+                    yield ("text", content)
 
-            reasoning = getattr(delta, "reasoning_content", None)
-            if reasoning:
-                # Display-only: surface the model's thinking to the UI but never
-                # accumulate it into the assistant message (keeps history clean,
-                # avoids provider replay issues with thinking blocks).
-                yield ("thinking", reasoning)
+                reasoning = getattr(delta, "reasoning_content", None)
+                if reasoning:
+                    # Display-only: surface the model's thinking to the UI but never
+                    # accumulate it into the assistant message (keeps history clean,
+                    # avoids provider replay issues with thinking blocks).
+                    yield ("thinking", reasoning)
 
-            for tc in getattr(delta, "tool_calls", None) or []:
-                tc_id = getattr(tc, "id", None)
-                fn = getattr(tc, "function", None)
-                fn_name = getattr(fn, "name", None) if fn is not None else None
-                # Spec-conformant streams (OpenAI/litellm) tag every fragment with a
-                # stable ``index`` so fragments of one call reassemble correctly.
-                # Some providers omit it; defaulting all of them to 0 (the old bug)
-                # collapsed distinct calls onto one slot. When ``index`` is absent we
-                # resolve the slot by the strongest signal available — id, then a
-                # fresh-name fragment, then a same-name continuation — and only fall
-                # back to "most recent" as a last resort (issue #116).
-                raw_idx = getattr(tc, "index", None)
-                if raw_idx is not None:
-                    key: object = ("idx", raw_idx)
-                elif tc_id is not None:
-                    # Match an existing slot with this id (continuation), else new.
-                    key = next(
-                        (k for k, s in acc.items() if s.get("id") == tc_id), None
-                    )  # type: ignore[assignment]
-                    if key is None:
+                for tc in getattr(delta, "tool_calls", None) or []:
+                    tc_id = getattr(tc, "id", None)
+                    fn = getattr(tc, "function", None)
+                    fn_name = getattr(fn, "name", None) if fn is not None else None
+                    # Spec-conformant streams (OpenAI/litellm) tag every fragment with a
+                    # stable ``index`` so fragments of one call reassemble correctly.
+                    # Some providers omit it; defaulting all of them to 0 (the old bug)
+                    # collapsed distinct calls onto one slot. When ``index`` is absent we
+                    # resolve the slot by the strongest signal available — id, then a
+                    # fresh-name fragment, then a same-name continuation — and only fall
+                    # back to "most recent" as a last resort (issue #116).
+                    raw_idx = getattr(tc, "index", None)
+                    if raw_idx is not None:
+                        key: object = ("idx", raw_idx)
+                    elif tc_id is not None:
+                        # Match an existing slot with this id (continuation), else new.
+                        key = next(
+                            (k for k, s in acc.items() if s.get("id") == tc_id), None
+                        )  # type: ignore[assignment]
+                        if key is None:
+                            key = ("seq", _seq)
+                            _seq += 1
+                    elif fn_name is not None:
+                        # No id/index but a name present → this fragment starts (or is)
+                        # a distinct call. Reuse a same-named slot only if it's still
+                        # waiting for its arguments; otherwise start a fresh slot so two
+                        # same-named calls don't merge.
+                        key = next(
+                            (k for k, s in acc.items()
+                             if s.get("name") == fn_name and not s.get("args")),
+                            None,
+                        )  # type: ignore[assignment]
+                        if key is None:
+                            key = ("seq", _seq)
+                            _seq += 1
+                    elif acc:
+                        # Pure continuation fragment (no id, no index, no name): the only
+                        # safe assumption is it continues the most recently touched call.
+                        key = next(reversed(acc))
+                    else:
                         key = ("seq", _seq)
                         _seq += 1
-                elif fn_name is not None:
-                    # No id/index but a name present → this fragment starts (or is)
-                    # a distinct call. Reuse a same-named slot only if it's still
-                    # waiting for its arguments; otherwise start a fresh slot so two
-                    # same-named calls don't merge.
-                    key = next(
-                        (k for k, s in acc.items()
-                         if s.get("name") == fn_name and not s.get("args")),
-                        None,
-                    )  # type: ignore[assignment]
-                    if key is None:
-                        key = ("seq", _seq)
-                        _seq += 1
-                elif acc:
-                    # Pure continuation fragment (no id, no index, no name): the only
-                    # safe assumption is it continues the most recently touched call.
-                    key = next(reversed(acc))
-                else:
-                    key = ("seq", _seq)
-                    _seq += 1
-                slot = acc.setdefault(key, {"id": None, "name": None, "args": ""})
-                if tc_id:
-                    slot["id"] = tc_id
-                if fn is not None:
-                    if fn_name:
-                        slot["name"] = fn_name
-                    fn_args = getattr(fn, "arguments", None)
-                    if fn_args:
-                        slot["args"] += fn_args
+                    slot = acc.setdefault(key, {"id": None, "name": None, "args": ""})
+                    if tc_id:
+                        slot["id"] = tc_id
+                    if fn is not None:
+                        if fn_name:
+                            slot["name"] = fn_name
+                        fn_args = getattr(fn, "arguments", None)
+                        if fn_args:
+                            slot["args"] += fn_args
+        except ProviderError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — classify mid-stream provider failures
+            raise classify_error(exc) from exc
 
         tool_calls: list[ToolCall] = []
         raw_tool_calls: list[dict] = []

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -189,6 +189,34 @@ def test_refresh_http_error_becomes_auth_error(tmp_path, monkeypatch):
     assert "codex login" in str(ei.value)
 
 
+def test_stream_responses_surfaces_http_400_detail(monkeypatch):
+    """Codex returns {"detail": "..."} on 400 — include it so operators see why."""
+    import io
+
+    detail = '{"detail":"Unsupported parameter: metadata"}'
+
+    def fake_urlopen(req, timeout=120.0):
+        raise urllib.error.HTTPError(
+            "https://chatgpt.com/backend-api/codex/responses",
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(detail.encode()),
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(RuntimeError) as ei:
+        list(
+            codex_provider._stream_responses(
+                {"model": "gpt-5.5", "input": [], "store": False, "stream": True},
+                {"Authorization": "Bearer x"},
+            )
+        )
+    msg = str(ei.value)
+    assert "400" in msg
+    assert "Unsupported parameter: metadata" in msg
+
+
 def test_refresh_non_json_becomes_auth_error(tmp_path, monkeypatch):
     _write_auth(tmp_path, {"access_token": "old-at", "refresh_token": "old-rt"})
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -406,6 +406,68 @@ def test_classify_missing_module_not_retryable_network():
     assert err.retryable is False
 
 
+def test_classify_api_connection_wrapping_http_400_is_validation_not_network():
+    """litellm wraps urllib HTTP 400 as APIConnectionError / MidStreamFallbackError.
+
+    The word 'connection' in the type name must not beat an explicit HTTP 400 —
+    otherwise Codex payload rejections look like flaky network and get retried.
+    """
+    msg = (
+        "litellm.MidStreamFallbackError: litellm.APIConnectionError: "
+        "HTTP Error 400: Bad Request"
+    )
+    err = prov.classify_error(Exception(msg))
+    assert err.kind == "validation"
+    assert err.retryable is False
+    assert "400" in str(err) or "rejected" in str(err).lower()
+
+
+def test_classify_uses_http_error_code_attribute():
+    import io
+    import urllib.error
+
+    body = io.BytesIO(b'{"detail":"Unsupported parameter: metadata"}')
+    exc = urllib.error.HTTPError(
+        "https://chatgpt.com/backend-api/codex/responses",
+        400,
+        "Bad Request",
+        hdrs=None,
+        fp=body,
+    )
+    err = prov.classify_error(exc)
+    assert err.kind == "validation"
+    assert err.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_classifies_mid_stream_errors(monkeypatch):
+    """Errors raised while iterating the stream (after acompletion returns)
+    must become ProviderError — not a raw MidStreamFallbackError dump.
+    """
+    monkeypatch.delenv("RIFTOR_DEMO_RESPONSE", raising=False)
+
+    class _BoomStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise Exception(
+                "litellm.MidStreamFallbackError: litellm.APIConnectionError: "
+                "HTTP Error 400: Bad Request"
+            )
+
+    async def fake_acompletion(self, **kwargs):
+        return _BoomStream()
+
+    monkeypatch.setattr(prov.Provider, "_acompletion", fake_acompletion)
+    p = Provider_for_test()
+    with pytest.raises(prov.ProviderError) as ei:
+        async for _ in p.stream_turn([{"role": "user", "content": "go"}]):
+            pass
+    assert ei.value.kind == "validation"
+    assert ei.value.retryable is False
+
+
 # --- cost estimation (#114) ---------------------------------------------------
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -2083,7 +2083,7 @@ wheels = [
 
 [[package]]
 name = "riftor"
-version = "4.1.0"
+version = "4.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Codex / ChatGPT subscription HTTP 400s dumping a raw `MidStreamFallbackError` into the TUI, and releases as **v4.1.1**.

## Changes

- Surface Codex `{"detail":...}` from urllib HTTPError in `_stream_responses`
- Classify mid-stream errors; prefer explicit HTTP 400 over `APIConnectionError`'s `"connection"` substring
- Version bump to 4.1.1 + release notes

## Verification

CI green on the fix; version-bump commit will re-run CI before merge. Tag `v4.1.1` on main after merge to fire the release workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd71c67-b91a-48af-b0dd-f244ef6ae801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd71c67-b91a-48af-b0dd-f244ef6ae801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

